### PR TITLE
Implement extension management commands

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -35,6 +35,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionUpgradeDbCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     $commands[] = new \Civi\Cv\Command\UrlCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -31,6 +31,9 @@ class Application extends \Symfony\Component\Console\Application {
   public function createCommands($context = 'default') {
     $commands = array();
     $commands[] = new \Civi\Cv\Command\ApiCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     $commands[] = new \Civi\Cv\Command\UrlCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -31,6 +31,7 @@ class Application extends \Symfony\Component\Console\Application {
   public function createCommands($context = 'default') {
     $commands = array();
     $commands[] = new \Civi\Cv\Command\ApiCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionDownloadCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -44,6 +44,37 @@ class BaseCommand extends Command {
   }
 
   /**
+   * Execute an API call. If it fails, display a formatted error.
+   *
+   * Note: If there is an error, we still return it softly so that the
+   * command can exit gracefully.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param $entity
+   * @param $action
+   * @param $params
+   * @return mixed
+   */
+  protected function callApiSuccess(InputInterface $input, OutputInterface $output, $entity, $action, $params) {
+    $params['debug'] = 1;
+    if (!isset($params['version'])) {
+      $params['version'] = 3;
+    }
+    $result = \civicrm_api($entity, $action, $params);
+    if (!empty($result['is_error'])) {
+      $data = array(
+        'entity' => $entity,
+        'action' => $action,
+        'params' => $params,
+        'result' => $result,
+      );
+      $output->writeln("<error>Error: API Call Failed</error>: " . Encoder::encode($data, 'pretty'));
+    }
+    return $result;
+  }
+
+  /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param $result

--- a/src/Command/BaseExtensionCommand.php
+++ b/src/Command/BaseExtensionCommand.php
@@ -1,0 +1,63 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BaseExtensionCommand extends BaseCommand {
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return array
+   *   Array(0=>$keys, 1=>$errors).
+   */
+  protected function parseKeys(InputInterface $input, OutputInterface $output) {
+    $allKeys = \CRM_Extension_System::singleton()->getFullContainer()->getKeys();
+    $foundKeys = array();
+    $missingKeys = array();
+    $shortMap = NULL;
+
+    foreach ($input->getArgument('key-or-name') as $keyOrName) {
+      if (strpos($keyOrName, '.') !== FALSE) {
+        if (in_array($keyOrName, $allKeys)) {
+          $foundKeys[] = $keyOrName;
+        }
+        else {
+          $missingKeys[] = $keyOrName;
+        }
+      }
+      else {
+        if ($shortMap === NULL) {
+          $shortMap = $this->getShortMap();
+        }
+        if ($shortMap[$keyOrName]) {
+          $foundKeys = array_merge($foundKeys, $shortMap[$keyOrName]);
+        }
+        else {
+          $missingKeys[] = $keyOrName;
+        }
+      }
+    }
+
+    return array($foundKeys, $missingKeys);
+  }
+
+  /**
+   * @return array
+   *   Array(string $shortName => string $longName).
+   */
+  protected function getShortMap() {
+    $map = array();
+    $mapper = \CRM_Extension_System::singleton()->getMapper();
+    $container = \CRM_Extension_System::singleton()->getFullContainer();
+
+    foreach ($container->getKeys() as $key) {
+      $info = $mapper->keyToInfo($key);
+      if ($info->file) {
+        $map[$info->file][] = $key;
+      }
+    }
+    return $map;
+  }
+
+}

--- a/src/Command/ExtensionDisableCommand.php
+++ b/src/Command/ExtensionDisableCommand.php
@@ -1,0 +1,68 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionDisableCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:disable')
+      ->setAliases(array('dis'))
+      ->setDescription('Disable an extension')
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->setHelp('Disable an extension
+
+Examples:
+  cv ext:disable org.example.foobar
+  cv dis foobar
+
+Note:
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.disable`.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
+
+    // Uninstall what's recognized or what looks like an ext key.
+    $disableKeys = array_merge($foundKeys, preg_grep('/\./', $missingKeys));
+    $missingKeys = preg_grep('/\./', $missingKeys, PREG_GREP_INVERT);
+
+    foreach ($missingKeys as $key) {
+      $output->writeln("<comment>Ignoring unrecognized extension \"$key\"</comment>");
+    }
+    foreach ($disableKeys as $key) {
+      $output->writeln("<info>Disabling extension \"$key\"</info>");
+    }
+
+    $result = $this->callApiSuccess($input, $output, 'Extension', 'disable', array(
+      'keys' => $disableKeys,
+    ));
+    if (!empty($result['is_error'])) {
+      return 1;
+    }
+  }
+
+}

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -1,0 +1,171 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionDownloadCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:download')
+      ->setAliases(array('dl'))
+      ->setDescription('Download an extension')
+      ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the remote list of extensions')
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Optionally append a URL.')
+      ->setHelp('Download an extension
+
+Examples:
+  cv ext:download org.example.foobar
+  cv dl foobar
+  cv dl "org.example.foobar@http://example.org/files/foobar.zip"
+
+Note:
+  Short names ("foobar") do not work when passing an explicit URL.
+
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.install`.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    if ($input->getOption('refresh')) {
+      $output->writeln("<info>Refreshing extensions</info>");
+      $result = $this->callApiSuccess($input, $output, 'Extension', 'refresh', array(
+        'local' => FALSE,
+        'remote' => TRUE,
+      ));
+      if (!empty($result['is_error'])) {
+        return 1;
+      }
+    }
+
+    list ($downloads, $errors) = $this->parseDownloads($input);
+    if (!empty($errors)) {
+      foreach ($errors as $error) {
+        $output->writeln("<error>$error</error>");
+      }
+      return 1;
+    }
+
+    foreach ($downloads as $key => $url) {
+      $output->writeln("<info>Downloading extension \"$key\" ($url)</info>");
+      $result = $this->callApiSuccess($input, $output, 'Extension', 'download', array(
+        'key' => $key,
+        'url' => $url,
+      ));
+      if (!empty($result['is_error'])) {
+        return 1;
+      }
+    }
+  }
+
+  /**
+   * Get a list of all available extensions.
+   *
+   * @return array
+   *   ($key => CRM_Extension_Info)
+   */
+  protected function getRemoteInfos() {
+    static $cache = NULL;
+    if ($cache === NULL) {
+      $cache = \CRM_Extension_System::singleton()
+        ->getBrowser()->getExtensions();
+    }
+    return $cache;
+  }
+
+  /**
+   * @return array
+   *   Array(string $shortName => string $longName).
+   */
+  protected function getRemoteShortMap() {
+    static $cache = NULL;
+    if ($cache === NULL) {
+      $cache = array();
+      foreach ($this->getRemoteInfos() as $key => $info) {
+        if ($info->file) {
+          $cache[$info->file][] = $key;
+        }
+      }
+    }
+    return $cache;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return array
+   *   Array(array $downloads, array $errors).
+   */
+  protected function parseDownloads(InputInterface $input) {
+    $downloads = array(); // Array(string $key => null|string $url)
+    $errors = array(); // Array(string $message).
+
+    $remoteInfos = NULL;
+    $shortMap = NULL;
+
+    if (!$input->getArgument('key-or-name')) {
+      $errors[] = 'Error: Please specify at least one extension to download';
+    }
+
+    foreach ($input->getArgument('key-or-name') as $keyOrName) {
+      $url = NULL;
+      if (strpos($keyOrName, '@') !== FALSE) {
+        list ($keyOrName, $url) = explode('@', $keyOrName, 2);
+      }
+
+      if (strpos($keyOrName, '.') === FALSE) {
+        if ($shortMap === NULL) {
+          $shortMap = $this->getRemoteShortMap();
+        }
+        if (isset($shortMap[$keyOrName])) {
+          if (count($shortMap[$keyOrName]) === 1) {
+            $keyOrName = $shortMap[$keyOrName][0];
+          }
+          else {
+            $otherNames = implode(', ', $shortMap[$keyOrName]);
+            $errors[] = "Ambiguous extension \"$keyOrName\". ($otherNames)";
+            continue;
+          }
+        }
+      }
+
+      if (empty($url)) {
+        if ($remoteInfos === NULL) {
+          $remoteInfos = $this->getRemoteInfos();
+        }
+
+        if (!empty($remoteInfos[$keyOrName]->downloadUrl)) {
+          $url = $remoteInfos[$keyOrName]->downloadUrl;
+        }
+        else {
+          $errors[] = "Error: Unrecognized extension \"$keyOrName\"";
+          continue;
+        }
+      }
+
+      $downloads[$keyOrName] = $url;
+    }
+    return array($downloads, $errors);
+  }
+
+}

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -23,10 +23,10 @@ class ExtensionDownloadCommand extends BaseExtensionCommand {
     $this
       ->setName('ext:download')
       ->setAliases(array('dl'))
-      ->setDescription('Download an extension')
+      ->setDescription('Download and enable an extension')
       ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the remote list of extensions')
       ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Optionally append a URL.')
-      ->setHelp('Download an extension
+      ->setHelp('Download and enable an extension
 
 Examples:
   cv ext:download org.example.foobar

--- a/src/Command/ExtensionEnableCommand.php
+++ b/src/Command/ExtensionEnableCommand.php
@@ -1,0 +1,81 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionEnableCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:enable')
+      ->setAliases(array('en'))
+      ->setDescription('Enable an extension')
+      ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the local list of extensions')
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->setHelp('Enable an extension
+
+Examples:
+  cv ext:enable org.example.foobar
+  cv en foobar
+
+Note:
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+  
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.install`.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    if ($input->getOption('refresh')) {
+      $output->writeln("<info>Refreshing extensions</info>");
+      $result = $this->callApiSuccess($input, $output, 'Extension', 'refresh', array(
+        'local' => TRUE,
+        'remote' => FALSE,
+      ));
+      if (!empty($result['is_error'])) {
+        return 1;
+      }
+
+    }
+
+    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
+
+    if ($missingKeys) {
+      foreach ($missingKeys as $key) {
+        $output->writeln("<error>Error: Unrecognized extension \"$key\"</error>");
+      }
+      return 1;
+    }
+
+    foreach ($foundKeys as $key) {
+      $output->writeln("<info>Enabling extension \"$key\"</info>");
+    }
+
+    $result = $this->callApiSuccess($input, $output, 'Extension', 'install', array(
+      'keys' => $foundKeys,
+    ));
+    if (!empty($result['is_error'])) {
+      return 1;
+    }
+  }
+
+}

--- a/src/Command/ExtensionUninstallCommand.php
+++ b/src/Command/ExtensionUninstallCommand.php
@@ -1,0 +1,75 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionUninstallCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:uninstall')
+      ->setAliases(array())
+      ->setDescription('Uninstall an extension and purge its data')
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->setHelp('Uninstall an extension and purge its data.
+
+Examples:
+  cv ext:uninstall org.example.foobar
+  cv ext:uninstall foobar
+
+Note:
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.uninstall`.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
+
+    // Uninstall what's recognized or what looks like an ext key.
+    $uninstallKeys = array_merge($foundKeys, preg_grep('/\./', $missingKeys));
+    $missingKeys = preg_grep('/\./', $missingKeys, PREG_GREP_INVERT);
+
+    foreach ($missingKeys as $key) {
+      $output->writeln("<comment>Ignoring unrecognized extension \"$key\"</comment>");
+    }
+    foreach ($uninstallKeys as $key) {
+      $output->writeln("<info>Uninstalling extension \"$key\"</info>");
+    }
+
+    $result = $this->callApiSuccess($input, $output, 'Extension', 'disable', array(
+      'keys' => $uninstallKeys,
+    ));
+    if (!empty($result['is_error'])) {
+      return 1;
+    }
+
+    $result = $this->callApiSuccess($input, $output, 'Extension', 'uninstall', array(
+      'keys' => $uninstallKeys,
+    ));
+    if (!empty($result['is_error'])) {
+      return 1;
+    }
+  }
+
+}

--- a/src/Command/ExtensionUpgradeDbCommand.php
+++ b/src/Command/ExtensionUpgradeDbCommand.php
@@ -1,0 +1,49 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionUpgradeDbCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:upgrade-db')
+      ->setAliases(array())
+      ->setDescription('Apply DB upgrades for any extensions')
+      ->setHelp('Apply DB upgrades for any extensions
+
+Examples:
+  cv ext:upgrade-db
+
+Note:
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.upgrade`.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+
+    $output->writeln("<info>Applying database upgrades from extensions</info>");
+    $result = $this->callApiSuccess($input, $output, 'Extension', 'upgrade', array());
+    if (!empty($result['is_error'])) {
+      return 1;
+    }
+  }
+
+}

--- a/src/Util/Process.php
+++ b/src/Util/Process.php
@@ -18,6 +18,22 @@ class Process {
   }
 
   /**
+   * Helper which synchronously runs a command and verifies that it generates an error.
+   *
+   * @param \Symfony\Component\Process\Process $process
+   * @return \Symfony\Component\Process\Process
+   * @throws \RuntimeException
+   */
+  public static function runFail(\Symfony\Component\Process\Process $process) {
+    $process->run();
+    if ($process->isSuccessful()) {
+      Process::dump($process);
+      throw new \Civi\Cv\Exception\ProcessErrorException($process, "Process succeeded unexpectedly");
+    }
+    return $process;
+  }
+
+  /**
    * Determine full path to an external command (by searching PATH).
    *
    * @param string $name

--- a/tests/Command/ExtensionLifecycleTest.php
+++ b/tests/Command/ExtensionLifecycleTest.php
@@ -27,45 +27,52 @@ class ExtensionLifecycleTest extends \Civi\Cv\CivilTestCase {
     $cvTestZip = $this->makeCvTestZip();
     $this->extractZip($cvTestZip, $this->tmpDir);
 
-    // A small snippet of PHP code which only executes if `org.example.cvtest` is enabled.
-    $doIWork = escapeshellarg('return cvtest_doiwork();');
-
     // Make sure we start in a clean environment without the extension
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
 
     // Activate and use the extension
     Process::runOk($this->cv("ext:enable -r org.example.cvtest"));
-    $p = Process::runOk($this->cv("ev $doIWork"));
+    $p = Process::runOk($this->cvTestEnabled());
     $result = json_decode($p->getOutput(), 1);
     $this->assertEquals('yes', $result['why']);
 
     // Cleanup and ensure we cleaned up.
     Process::runOk($this->cv("ext:disable org.example.cvtest"));
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
     Process::runOk($this->cv("ext:uninstall org.example.cvtest"));
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
   }
 
   public function testLifecycleWithShortNames() {
     $cvTestZip = $this->makeCvTestZip();
     $this->extractZip($cvTestZip, $this->tmpDir);
 
-    $doIWork = escapeshellarg('return cvtest_doiwork();');
-
     // Make sure we start in a clean environment without the extension
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
 
     // Activate and use the extension
     Process::runOk($this->cv("ext:enable -r cvtest"));
-    $p = Process::runOk($this->cv("ev $doIWork"));
+    $p = Process::runOk($this->cvTestEnabled());
     $result = json_decode($p->getOutput(), 1);
     $this->assertEquals('yes', $result['why']);
 
     // Cleanup and ensure we cleaned up.
     Process::runOk($this->cv("ext:disable cvtest"));
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
     Process::runOk($this->cv("ext:uninstall cvtest"));
-    Process::runFail($this->cv("ev $doIWork"));
+    Process::runFail($this->cvTestEnabled());
+  }
+
+  /**
+   * Prepare a subcommand which only succeeds if org.example.cvtest is
+   * enabled.
+   *
+   * @return \Symfony\Component\Process\Process
+   */
+  public function cvTestEnabled() {
+    // A small snippet of PHP code which only executes if `org.example.cvtest` is enabled.
+    $doIWork = escapeshellarg('return cvtest_doiwork();');
+    return $this->cv("ev $doIWork");
   }
 
   /**

--- a/tests/Command/ExtensionLifecycleTest.php
+++ b/tests/Command/ExtensionLifecycleTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\Process;
+
+class ExtensionLifecycleTest extends \Civi\Cv\CivilTestCase {
+
+  private $tmpDir;
+
+  public function setup() {
+    parent::setup();
+    $this->tmpDir = $this->getExampleDir() . '/vendor/cvtest';
+    $this->removeDir($this->tmpDir);
+    foreach (array('/vendor', '/vendor/cvtest') as $part) {
+      if (!is_dir($this->getExampleDir() . $part)) {
+        mkdir($this->getExampleDir() . $part);
+      }
+    }
+  }
+
+  public function tearDown() {
+    $this->cleanup();
+    parent::tearDown();
+  }
+
+  public function testLifecycleWithFullKeys() {
+    $cvTestZip = $this->makeCvTestZip();
+    $this->extractZip($cvTestZip, $this->tmpDir);
+
+    // A small snippet of PHP code which only executes if `org.example.cvtest` is enabled.
+    $doIWork = escapeshellarg('return cvtest_doiwork();');
+
+    // Make sure we start in a clean environment without the extension
+    Process::runFail($this->cv("ev $doIWork"));
+
+    // Activate and use the extension
+    Process::runOk($this->cv("ext:enable -r org.example.cvtest"));
+    $p = Process::runOk($this->cv("ev $doIWork"));
+    $result = json_decode($p->getOutput(), 1);
+    $this->assertEquals('yes', $result['why']);
+
+    // Cleanup and ensure we cleaned up.
+    Process::runOk($this->cv("ext:disable org.example.cvtest"));
+    Process::runFail($this->cv("ev $doIWork"));
+    Process::runOk($this->cv("ext:uninstall org.example.cvtest"));
+    Process::runFail($this->cv("ev $doIWork"));
+  }
+
+  public function testLifecycleWithShortNames() {
+    $cvTestZip = $this->makeCvTestZip();
+    $this->extractZip($cvTestZip, $this->tmpDir);
+
+    $doIWork = escapeshellarg('return cvtest_doiwork();');
+
+    // Make sure we start in a clean environment without the extension
+    Process::runFail($this->cv("ev $doIWork"));
+
+    // Activate and use the extension
+    Process::runOk($this->cv("ext:enable -r cvtest"));
+    $p = Process::runOk($this->cv("ev $doIWork"));
+    $result = json_decode($p->getOutput(), 1);
+    $this->assertEquals('yes', $result['why']);
+
+    // Cleanup and ensure we cleaned up.
+    Process::runOk($this->cv("ext:disable cvtest"));
+    Process::runFail($this->cv("ev $doIWork"));
+    Process::runOk($this->cv("ext:uninstall cvtest"));
+    Process::runFail($this->cv("ev $doIWork"));
+  }
+
+  /**
+   * Make a zip file for the placeholder extension, `org.example.cvtest`.
+   * @return string
+   *   Path to zip file
+   */
+  protected function makeCvTestZip() {
+    $cvTestSrc = dirname(__DIR__) . '/fixtures/org.example.cvtest';
+    $makePhp = $cvTestSrc . DIRECTORY_SEPARATOR . 'make.php';
+    $cvTestZip = $this->tmpDir . DIRECTORY_SEPARATOR . 'cvtest.zip';
+    Process::runOk(new \Symfony\Component\Process\Process(
+      escapeshellcmd($makePhp) . ' ' . escapeshellarg($cvTestZip),
+      $cvTestSrc
+    ));
+    return $cvTestZip;
+  }
+
+  protected function extractZip($zipFile, $path) {
+    Process::runOk(new \Symfony\Component\Process\Process(
+      "unzip " . escapeshellarg($zipFile),
+      $path
+    ));
+  }
+
+  /**
+   * @param string $dir
+   */
+  protected function removeDir($dir) {
+    if (!empty($dir) && file_exists($dir) && is_dir($dir)) {
+      exec("rm -rf " . escapeshellarg($dir));
+    }
+  }
+
+  protected function cleanup() {
+    $disablePhp = 'civicrm_api3("Extension", "disable", array("key" => "org.example.cvtest"));';
+    $disablePhp .= 'civicrm_api3("Extension", "uninstall", array("key" => "org.example.cvtest"));';
+    $this->cv('ev ' . escapeshellarg($disablePhp))->run();
+    $this->removeDir($this->tmpDir);
+  }
+
+}

--- a/tests/fixtures/org.example.cvtest/LICENSE.txt
+++ b/tests/fixtures/org.example.cvtest/LICENSE.txt
@@ -1,0 +1,20 @@
+org.civicrm.cvtest
+Copyright (c) 2016 Tim Otten
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tests/fixtures/org.example.cvtest/cvtest.php
+++ b/tests/fixtures/org.example.cvtest/cvtest.php
@@ -1,0 +1,5 @@
+<?php
+
+function cvtest_doiwork() {
+  return array("why" => "yes");
+}

--- a/tests/fixtures/org.example.cvtest/info.xml
+++ b/tests/fixtures/org.example.cvtest/info.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<extension key="org.example.cvtest" type="module">
+  <file>cvtest</file>
+  <name>cvtest example extension</name>
+  <description>Placeholder used to test cv functionality</description>
+  <license>MIT</license>
+  <maintainer>
+    <author>Tim Otten</author>
+    <email>totten@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Main Extension Page">http://FIXME</url>
+    <url desc="Documentation">http://FIXME</url>
+    <url desc="Support">http://FIXME</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2016-12-21</releaseDate>
+  <version>1.0</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>4.2</ver>
+  </compatibility>
+  <comments>This is a new, undeveloped module</comments>
+</extension>

--- a/tests/fixtures/org.example.cvtest/make.php
+++ b/tests/fixtures/org.example.cvtest/make.php
@@ -1,0 +1,35 @@
+#!/usr/bin/env php
+<?php
+if (PHP_SAPI !== 'cli') {
+  die("This tool can only be run from command line.");
+}
+
+if (empty($argv[1])) {
+  die(sprintf("usage: %s <zipfile>\n", $argv[0]));
+}
+
+
+if (file_exists($argv[1])) {
+  unlink($argv[1]);
+}
+
+$zip = new ZipArchive();
+if (TRUE !== $zip->open($argv[1], ZipArchive::CREATE)) {
+  printf("Failed to open %s\n", $argv[1]);
+  exit(1);
+}
+
+$zip->addFile('LICENSE.txt', 'org.example.cvtest/LICENSE.txt');
+$zip->addFile('cvtest.php', 'org.example.cvtest/cvtest.php');
+$zip->addFile('info.xml', 'org.example.cvtest/info.xml');
+
+$ok = $zip->close();
+
+if ($ok) {
+  printf("Created %s\n", $argv[1]);
+  exit(0);
+}
+else {
+  printf("Failed to create %s\n", $argv[1]);
+  exit(1);
+}

--- a/tests/fixtures/org.example.cvtest/make.php
+++ b/tests/fixtures/org.example.cvtest/make.php
@@ -19,6 +19,7 @@ if (TRUE !== $zip->open($argv[1], ZipArchive::CREATE)) {
   exit(1);
 }
 
+$zip->addEmptyDir('org.example.cvtest/');
 $zip->addFile('LICENSE.txt', 'org.example.cvtest/LICENSE.txt');
 $zip->addFile('cvtest.php', 'org.example.cvtest/cvtest.php');
 $zip->addFile('info.xml', 'org.example.cvtest/info.xml');


### PR DESCRIPTION
You can do extension management using `cv api`, but even that feels a bit
tedious. This adds support for commands like:

```
#### Brief examples ####
cv dl cividiscount
cv en bootstrapcivicrm styleguide flexmailer mosaico
cv dis bootstrapcivicrm styleguide flexmailer mosaico

#### Precise examples ####
cv ext:download org.civicrm.module.cividiscount
cv ext:download 'org.civicrm.module.cividiscount@https://download.example.org/cividiscount-beta5.zip'
cv ext:enable org.civicrm.bootstrapcivicrm
cv ext:uninstall org.civicrm.bootstrapcivicrm
cv ext:upgrade-db
```

A few general design notes:
 * All commands have names like `ext:enable`, `ext:disable`, `ext:download`.  A few commands have brief aliases (e.g. `en` or `dis`)
 * In most circumstances, you have a choice to identify extensions by the long key (`org.civicrm.module.cividiscount`) or the short file name (`cividiscount`). However, it's possible for the short name to be ambiguous. (In `universe` at time of writing, there are ~150 extensions with ~2 name conflicts.)
 * By default, the download command searches the `civicrm.org` extension directory; however, you can pass fully formed URLs.
 * The functionality exposed here is primarily meant for light-duty scripting and interactive use. They try to output in human-friendlyish format. If you're doing heavy-duty scripting or development, use the Extension API which provides more structured/supported data formats (e.g. `cv api extension.install key=... --in=... --out=...`).
