### PR TITLE
Bootstrap - Port changes to WP search paths

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -329,6 +329,8 @@ class Bootstrap {
         $wpDirs = array(
           $cmsRoot . '/*/uploads/civicrm',
           $cmsRoot . '/*/plugins/civicrm',
+          $cmsRoot . '/*/uploads/sites/*/civicrm',
+          $cmsRoot . '/*/blogs.dir/*/files/civicrm',
         );
         $settings = $this->findFirstFile($wpDirs, 'civicrm.settings.php');
         break;


### PR DESCRIPTION
This was merged in the `civicrm-wordpress` fork of `Bootstrap.php`:

https://github.com/civicrm/civicrm-wordpress/commit/48bc99f8f90a5f7fef6ad223b1f04f4a06cad533