### PR TITLE
Improve shell scripting support

### DIFF
--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -58,6 +58,7 @@ NOTE: To change the default output format, set CV_OUTPUT.
 
     $result = \civicrm_api($entity, $action, $params);
     $this->sendResult($input, $output, $result);
+    return empty($result['is_error']) ? 0 : 1;
   }
 
   /**

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -119,7 +119,11 @@ class BaseCommand extends Command {
    * @param $result
    */
   protected function sendResult(InputInterface $input, OutputInterface $output, $result) {
-    $output->writeln(Encoder::encode($result, $input->getOption('out')));
+    $buf = Encoder::encode($result, $input->getOption('out'));
+    $options = empty($result['is_error'])
+      ? (OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_NORMAL)
+      : (OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_QUIET);
+    $output->writeln($buf, $options);
   }
 
 }

--- a/tests/Command/ApiCommandTest.php
+++ b/tests/Command/ApiCommandTest.php
@@ -19,6 +19,19 @@ class ApiCommandTest extends \Civi\Cv\CivilTestCase {
     }
   }
 
+  public function testQuiet() {
+    $p = Process::runOk($this->cv("api -q System.get"));
+    $this->assertEmpty($p->getOutput());
+    $this->assertEmpty($p->getErrorOutput());
+  }
+
+  public function testQuietError() {
+    $p = Process::runFail($this->cv("api -q System.getzz"));
+    $data = json_decode($p->getOutput(), 1);
+    $this->assertTrue(!empty($data['is_error']));
+    $this->assertTrue(!empty($data['error_message']));
+  }
+
   public function testApiPipe() {
     $input = escapeshellarg(json_encode(array(
       'options' => array('limit' => 1),


### PR DESCRIPTION
This makes two main changes to better shell scripting norms:
 * Provide an exit code for `cv api` calls
 * Support the "quiet" mode (`-q` or `--quiet`) wherein successful output is ignored. Only display errors.