### PR TITLE
Provide access to developmental extensions (ext:download, ext:list)

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -36,6 +36,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\ExtensionDownloadCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionListCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUpgradeDbCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();

--- a/src/Command/BaseExtensionCommand.php
+++ b/src/Command/BaseExtensionCommand.php
@@ -2,9 +2,44 @@
 namespace Civi\Cv\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BaseExtensionCommand extends BaseCommand {
+
+  /**
+   * Register CLI options for filtering the extension feed, such as "--dev" or "--filter-ver".
+   */
+  public function configureRepoOptions() {
+    $this
+      ->addOption('dev', NULL, InputOption::VALUE_NONE, 'Include developmental extensions. (Equivalent to "--filter-status=* --filter-ready=*")')
+      ->addOption('filter-ver', NULL, InputOption::VALUE_REQUIRED, 'Filter available extensions by Civi version (Ex: "4.7.15","4.6.20")', '{ver}')
+      ->addOption('filter-uf', NULL, InputOption::VALUE_REQUIRED, 'Filter available extensions by CMS compatiblity (Ex: "Drupal", "WordPress")', '{uf}')
+      ->addOption('filter-status', NULL, InputOption::VALUE_REQUIRED, 'Filter available extensions by stability flag (Ex: "stable", "*")', 'stable')
+      ->addOption('filter-ready', NULL, InputOption::VALUE_REQUIRED, 'Filter available extensions based on reviewers\' approval (Ex: "ready", "*")', 'ready');
+  }
+
+  /**
+   * Create a URL for the extension feed (based on user options).
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return string|NULL
+   */
+  public function parseRepoUrl(InputInterface $input) {
+    if ($input->getOption('dev')) {
+      $input->setOption('filter-status', '*');
+      $input->setOption('filter-ready', '*');
+    }
+    $parts = array();
+    foreach (array('ver', 'uf', 'status', 'ready') as $key) {
+      $value = $input->getOption("filter-" . $key);
+      if ($value === '*') {
+        $value = '';
+      }
+      $parts[] = $key . '=' . $value;
+    }
+    return 'https://civicrm.org/extdir/' . implode('|', $parts);
+  }
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -27,7 +27,9 @@ Dump the container configuration
     // To probe definitions, we need access to the raw ContainerBuilder.
     $z = new \Civi\Core\Container();
     $c = $z->createContainer();
-    $c->compile();
+    if (version_compare(\CRM_Utils_System::version(), '4.7.0', '>=')) {
+      $c->compile();
+    }
 
     $rows = array();
     $definitions = $c->getDefinitions();

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -154,8 +154,8 @@ Note:
             $keyOrName = $shortMap[$keyOrName][0];
           }
           else {
-            $otherNames = implode(', ', $shortMap[$keyOrName]);
-            $errors[] = "Ambiguous extension \"$keyOrName\". ($otherNames)";
+            $otherNames = '"' . implode('", "', $shortMap[$keyOrName]) . '"';
+            $errors[] = "Ambiguous name \"$keyOrName\". Use a more specific key: $otherNames";
             continue;
           }
         }

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -31,6 +31,7 @@ class ExtensionDownloadCommand extends BaseExtensionCommand {
 Examples:
   cv ext:download org.example.foobar
   cv dl foobar
+  cv dl --dev foobar
   cv dl "org.example.foobar@http://example.org/files/foobar.zip"
 
 Note:
@@ -43,11 +44,20 @@ Note:
   This subcommand does not output parseable data. For parseable output,
   consider using `cv api extension.install`.
 ');
+    parent::configureRepoOptions();
     parent::configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    if ($extRepoUrl = $this->parseRepoUrl($input)) {
+      global $civicrm_setting;
+      $civicrm_setting['Extension Preferences']['ext_repo_url'] = $extRepoUrl;
+    }
+
     $this->boot($input, $output);
+
+    $output->writeln("<info>Using extension feed (" . \CRM_Extension_System::singleton()->getBrowser()->getRepositoryUrl() . ")</info>");
+
     if ($input->getOption('refresh')) {
       $output->writeln("<info>Refreshing extensions</info>");
       $result = $this->callApiSuccess($input, $output, 'Extension', 'refresh', array(

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -1,0 +1,180 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionListCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:list')
+      ->setAliases(array())
+      ->setDescription('List extensions')
+      ->addOption('local', 'L', InputOption::VALUE_NONE, 'Show local extensions')
+      ->addOption('remote', 'R', InputOption::VALUE_NONE, 'Show remote extensions')
+      ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the list of extensions')
+      ->addArgument('regex', InputArgument::OPTIONAL, 'Filter extensions by full key, short name, or description')
+      ->setHelp('List extensions
+
+Examples:
+  cv ext:list
+  cv ext:list --remote --dev /mail/
+  cv ext:list /^org.civicrm.*/
+
+Note:
+  Short names ("foobar") do not work when passing an explicit URL.
+
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+
+  This subcommand does not output parseable data. For parseable output,
+  consider using `cv api extension.get`.
+');
+    parent::configureRepoOptions();
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    if ($input->getOption('local') || $input->getOption('remote')) {
+      $local = (bool) $input->getOption('local');
+      $remote = (bool) $input->getOption('remote');
+    }
+    else {
+      $local = $remote = TRUE;
+    }
+
+    if ($extRepoUrl = $this->parseRepoUrl($input)) {
+      global $civicrm_setting;
+      $civicrm_setting['Extension Preferences']['ext_repo_url'] = $extRepoUrl;
+    }
+
+    $this->boot($input, $output);
+
+    if ($remote) {
+      $output->writeln("<info>Using extension feed (" . \CRM_Extension_System::singleton()->getBrowser()->getRepositoryUrl() . ")</info>");
+    }
+
+    if ($input->getOption('refresh')) {
+      $output->writeln("<info>Refreshing extensions</info>");
+      $result = $this->callApiSuccess($input, $output, 'Extension', 'refresh', array(
+        'local' => $local,
+        'remote' => $remote,
+      ));
+      if (!empty($result['is_error'])) {
+        return 1;
+      }
+    }
+
+    $table = new Table($output);
+    $table->setHeaders(array('location', 'name', 'key', 'version', 'status'));
+    $table->addRows($this->find($input->getArgument('regex'), $remote, $local));
+    $table->render();
+
+    return 0;
+  }
+
+  /**
+   * Get a list of all available extensions.
+   *
+   * @return array
+   *   ($key => CRM_Extension_Info)
+   */
+  protected function getRemoteInfos() {
+    static $cache = NULL;
+    if ($cache === NULL) {
+      $cache = \CRM_Extension_System::singleton()
+        ->getBrowser()->getExtensions();
+    }
+    return $cache;
+  }
+
+  /**
+   * @param string|NULL $regex
+   *   Filter by regex.
+   * @param bool $remote
+   *   Include remote extensions.
+   * @param bool $local
+   *   Include local extensions.
+   * @return array
+   */
+  protected function find($regex, $remote, $local) {
+    $rows = array();
+
+    if ($remote) {
+      foreach ($this->getRemoteInfos() as $info) {
+        $rows[] = array('remote', $info->file, $info->key, $info->version, '');
+      }
+    }
+
+    if ($local) {
+      $keys = \CRM_Extension_System::singleton()->getFullContainer()->getKeys();
+      $statuses = \CRM_Extension_System::singleton()->getManager()->getStatuses();
+      foreach ($keys as $key) {
+        $info = \CRM_Extension_System::singleton()
+          ->getMapper()
+          ->keyToInfo($key);
+        $rows[] = array(
+          'local',
+          $info->file,
+          $key,
+          $info->version,
+          isset($statuses[$key]) ? $statuses[$key] : '',
+        );
+      }
+    }
+
+    if ($regex) {
+      $rows = array_filter($rows, function ($row) use ($regex) {
+        // Match on name or key.
+        return preg_match($regex, $row[1]) || preg_match($regex, $row[2]);
+      });
+    }
+
+    usort($rows, function ($a, $b) {
+      // location, descending
+      if ($a[0] < $b[0]) {
+        return 1;
+      }
+      if ($a[0] > $b[0]) {
+        return -1;
+      }
+
+      // name, ascending
+      if ($a[1] < $b[1]) {
+        return -1;
+      }
+      if ($a[1] > $b[1]) {
+        return 1;
+      }
+
+      // key, ascending
+      if ($a[2] < $b[2]) {
+        return -1;
+      }
+      if ($a[2] > $b[2]) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    return $rows;
+  }
+
+}

--- a/tests/Command/BaseExtensionCommandTest.php
+++ b/tests/Command/BaseExtensionCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Exception\ProcessErrorException;
+use Civi\Cv\Util\Process;
+use Symfony\Component\Console\Input\ArgvInput;
+
+class BaseExtensionCommandTest extends \Civi\Cv\CivilTestCase {
+
+  public function repoOptionExamples() {
+    $cases = array();
+    $cases[] = array(
+      array('examplecmd'),
+      'https://civicrm.org/extdir/ver={ver}|uf={uf}|status=stable|ready=ready',
+    );
+    $cases[] = array(
+      array('examplecmd', '--filter-uf=Drupal8'),
+      'https://civicrm.org/extdir/ver={ver}|uf=Drupal8|status=stable|ready=ready',
+    );
+    $cases[] = array(
+      array('examplecmd', '--dev'),
+      'https://civicrm.org/extdir/ver={ver}|uf={uf}|status=|ready=',
+    );
+    $cases[] = array(
+      array('examplecmd', '--filter-status=*'),
+      'https://civicrm.org/extdir/ver={ver}|uf={uf}|status=|ready=ready',
+    );
+    return $cases;
+  }
+
+  /**
+   * @param array $inputArgv
+   * @param string $expectUrl
+   * @dataProvider repoOptionExamples
+   */
+  public function testParseRepo($inputArgv, $expectUrl) {
+    $c = new BaseExtensionCommand('ext:example');
+    $c->configureRepoOptions();
+
+    $input = new ArgvInput($inputArgv, $c->getDefinition());
+    $this->assertEquals($expectUrl, $c->parseRepoUrl($input));
+  }
+
+}

--- a/tests/Command/DebugContainerCommandTest.php
+++ b/tests/Command/DebugContainerCommandTest.php
@@ -11,7 +11,7 @@ class DebugContainerCommandTest extends \Civi\Cv\CivilTestCase {
 
   public function testShowAll() {
     $p = Process::runOk($this->cv("debug:container"));
-    $this->assertRegExp('/cache.default.*CRM_Utils_Cache/', $p->getOutput());
+    $this->assertRegExp('/cxn_reg_client.*Civi.Cxn.Rpc.RegistrationClient/', $p->getOutput());
     $this->assertRegExp('/civi_api_kernel.*Civi.API.Kernel/', $p->getOutput());
   }
 

--- a/tests/Command/ExtensionListCommandTest.php
+++ b/tests/Command/ExtensionListCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Exception\ProcessErrorException;
+use Civi\Cv\Util\Process;
+
+class ExtensionListCommandTest extends \Civi\Cv\CivilTestCase {
+
+  /**
+   * List extensions using local or remote filters.
+   */
+  public function testGetLocalOrRemote() {
+    $regex = '/^\| /';
+
+    $localProc = Process::runOk($this->cv('ext:list -L'));
+    $localLines = preg_grep($regex, explode("\n", $localProc->getOutput() . $localProc->getErrorOutput()));
+    $this->assertTrue(count($localLines) > 2);
+    $this->assertNotEmpty(preg_grep('/^\| local/', $localLines));
+    $this->assertEmpty(preg_grep('/^\| remote/', $localLines));
+
+    $remoteProc = Process::runOk($this->cv('ext:list -R'));
+    $remoteLines = preg_grep($regex, explode("\n", $remoteProc->getOutput() . $remoteProc->getErrorOutput()));
+    $this->assertTrue(count($remoteLines) > 2);
+    $this->assertEmpty(preg_grep('/^\| local/', $remoteLines));
+    $this->assertNotEmpty(preg_grep('/^\| remote/', $remoteLines));
+
+    $allProc = Process::runOk($this->cv('ext:list -LR'));
+    $allLines = preg_grep($regex, explode("\n", $allProc->getOutput() . $allProc->getErrorOutput()));
+    $this->assertTrue(count($allLines) > 2);
+    $this->assertNotEmpty(preg_grep('/^\| local/', $allLines));
+    $this->assertNotEmpty(preg_grep('/^\| remote/', $allLines));
+
+    $defaultProc = Process::runOk($this->cv('ext:list'));
+    $defaultLines = preg_grep($regex, explode("\n", $defaultProc->getOutput() . $defaultProc->getErrorOutput()));
+    $this->assertTrue(count($defaultLines) > 3);
+    $this->assertEquals($defaultLines, $allLines, 'The default behavior should match -LR');
+
+    $this->assertEquals($this->digest($localLines, $remoteLines), $this->digest($allLines), 'The full list should be the union of the local and remote lists');
+  }
+
+  /**
+   * List extensions using a regular expression.
+   */
+  public function testGetRegex() {
+    $p = Process::runOk($this->cv('ext:list'));
+    $this->assertRegexp('/remote.*cividiscount.*org.civicrm.module.cividiscount/', $p->getOutput());
+
+    $p = Process::runOk($this->cv('ext:list /org.civicrm/')); // matches key
+    $this->assertRegexp('/remote.*cividiscount.*org.civicrm.module.cividiscount/', $p->getOutput());
+
+    $p = Process::runOk($this->cv('ext:list /^cividiscount/')); // matches name
+    $this->assertRegexp('/remote.*cividiscount.*org.civicrm.module.cividiscount/', $p->getOutput());
+
+    $p = Process::runOk($this->cv('ext:list /^com\./')); // matches name
+    $this->assertNotRegexp('/remote.*cividiscount.*org.civicrm.module.cividiscount/', $p->getOutput());
+  }
+
+  /**
+   * Combine a bunch of arrays into a normalized form, sorted and only containing
+   * unique rows.
+   *
+   * e.g. $combined = $this->digest($array_a, $array_b);
+   *
+   * @return array
+   */
+  public function digest() {
+    $args = func_get_args();
+    $rows = array();
+    foreach ($args as $arg) {
+      foreach ($arg as $line) {
+        if (!empty($line)) {
+          // Tabular output includes a variable number of spaces. Normalize.
+          $rows[] = preg_replace('/ +/', ' ', $line);
+        }
+      }
+    }
+
+    sort($rows);
+    return array_values(array_unique($rows));
+  }
+
+}


### PR DESCRIPTION
This revision has two main updates:
 * `cv ext:download` supports `--dev` which allows it to pull in a feed of unreviewed/alpha/beta releases.
 * `cv ext:list` is new command for browsing local and remote extensions. It also supports `--dev`.

There are also a couple tangential tweaks.