### PR TITLE
Implement ExtensionPathCommand

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -37,6 +37,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionListCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionPathCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUpgradeDbCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();

--- a/src/Command/ExtensionPathCommand.php
+++ b/src/Command/ExtensionPathCommand.php
@@ -1,0 +1,70 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionPathCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:path')
+      ->setAliases(array())
+      ->setDescription('Look up an extension path')
+      ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->setHelp('Look up an extension path
+
+Examples:
+  cv ext:path
+  cv ext:path cividiscount
+  cv ext:path org.civicrm.modules.cividiscount
+
+Note:
+  If you don\'t request a specific extension, this command returns the path
+  of the default extension container.
+
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
+
+    foreach ($missingKeys as $key) {
+      $output->getErrorOutput()->writeln("<comment>Ignoring unrecognized extension \"$key\"</comment>");
+    }
+
+    $mapper = \CRM_Extension_System::singleton()->getMapper();
+    $results = array();
+    foreach ($foundKeys as $key) {
+      $results[] = array('key' => $key, 'path' => $mapper->keyToBasePath($key));
+    }
+
+    if (empty($missingKeys) && empty($foundKeys)) {
+      $results[] = array('key' => $key, 'path' => \CRM_Core_Config::singleton()->extensionsDir);
+    }
+
+    $this->sendTable($input, $output, $results, array('path'));
+
+    return empty($missingKeys) ? 0 : 1;
+  }
+
+}


### PR DESCRIPTION
This would be seem to be useful for writing simpler developer docs.
Instead of asking the user to go look up a path, you'd give them
a command to do it, e.g.

```
cd `cv ext:path`
civix generate:module org.example.foo
```

or

```
cd `cv ext:path flexmailer`
civix generate:upgrader
```

However, I'm unresolved on whether this is the best formulation for those
commands.  It feels like something a bit more generic might be better, but
I'm having trouble getting a formulation that feels perfect+simple.

Some ideas

```
cd `cv path extensionsDir`
cd `cv path imageUploadDir`
cd `cv path '[civicrm.files]'`
cd `cv path '[civicrm.root]'`
cd `cv path '[cms.root]'`

cd `cv ext:info flexmailer --path`

echo "Please send email to: "
cv ext:info flexmailer -x maintainer/author
```

The `ext:list` is already pretty generic and may actually give the desired
info, although it a bit of typing:

```
cd `cv ext:list -L /^flexmailer/ --columns=path --out=list`
```