### PR TITLE
ScriptCommand - Fix relative path handling. Add debug output.

### DIFF
--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Util\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,8 +19,41 @@ class ScriptCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $fs = new Filesystem();
+    $origScript = $fs->toAbsolutePath($input->getArgument('script'));
+
+    $origCwd = getcwd();
     $this->boot($input, $output);
-    require $input->getArgument('script');
+    $postCwd = getcwd();
+
+    // Normal operation: Use the script path provided at input.
+    if (file_exists($origScript)) {
+      chdir($origCwd);
+      $this->runScript($output, $origScript);
+      return 0;
+    }
+
+    // Backward compat: Try script relative the post-boot CWD.
+    $postScript = $fs->toAbsolutePath($input->getArgument('script'));
+    if (file_exists($postScript)) {
+      $output->getErrorOutput()->writeln("<comment>WARNING: Loaded script relative to CMS root -- which is deprecated. Script path should be (a) absolute or (b) relative to CWD.</comment>");
+      chdir($postCwd);
+      $this->runScript($output, $postScript);
+      return 0;
+    }
+
+    $output->getErrorOutput()->writeln("<error>Failed to locate script: " . $input->getArgument('script') . "</error>");
+    return 1;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param $script
+   */
+  protected function runScript(OutputInterface $output, $script) {
+    $output->writeln("<info>[ScriptCommand]</info> Start \"$script\"", OutputInterface::VERBOSITY_DEBUG);
+    require $script;
+    $output->writeln("<info>[ScriptCommand]</info> Finish \"$script\"", OutputInterface::VERBOSITY_DEBUG);
   }
 
 }


### PR DESCRIPTION
The `php:script` subcommand would fail to run scripts in the current
directory -- because it attempted to load them post-boot (in the CMS's root
directory).

With this revision, we default to checking in the original CWD.  For
backward compat, we'll also fallback to the CMS CWD if necessary and display a
warning.