### PR TITLE
Implement PathCommand

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -37,6 +37,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionListCommand();
+    $commands[] = new \Civi\Cv\Command\ExtensionPathCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUpgradeDbCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -37,11 +37,11 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\ExtensionEnableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionDisableCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionListCommand();
-    $commands[] = new \Civi\Cv\Command\ExtensionPathCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUninstallCommand();
     $commands[] = new \Civi\Cv\Command\ExtensionUpgradeDbCommand();
     $commands[] = new \Civi\Cv\Command\FillCommand();
     $commands[] = new \Civi\Cv\Command\FlushCommand();
+    $commands[] = new \Civi\Cv\Command\PathCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     $commands[] = new \Civi\Cv\Command\UrlCommand();
     if ($context !== 'repl') {

--- a/src/Command/ExtensionPathCommand.php
+++ b/src/Command/ExtensionPathCommand.php
@@ -1,0 +1,70 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Encoder;
+use Civi\Cv\Util\ExtensionUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class ExtensionPathCommand extends BaseExtensionCommand {
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('ext:path')
+      ->setAliases(array())
+      ->setDescription('Look up an extension path')
+      ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
+      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->setHelp('Look up an extension path
+
+Examples:
+  cv ext:path
+  cv ext:path cividiscount
+  cv ext:path org.civicrm.modules.cividiscount
+
+Note:
+  If you don\'t request a specific extension, this command returns the path
+  of the default extension container.
+
+  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
+  include a unique long name ("org.example.foobar") and a unique short
+  name ("foobar"). However, short names are not strongly guaranteed.
+');
+    parent::configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
+
+    foreach ($missingKeys as $key) {
+      $output->getErrorOutput()->writeln("<comment>Ignoring unrecognized extension \"$key\"</comment>");
+    }
+
+    $mapper = \CRM_Extension_System::singleton()->getMapper();
+    $results = array();
+    foreach ($foundKeys as $key) {
+      $results[] = array('key' => $key, 'path' => $mapper->keyToBasePath($key));
+    }
+
+    if (empty($missingKeys) && empty($foundKeys)) {
+      $results[] = array('key' => $key, 'path' => \CRM_Core_Config::singleton()->extensionsDir);
+    }
+
+    $this->sendTable($input, $output, $results, array('path'));
+
+    return empty($missingKeys) ? 0 : 1;
+  }
+
+}

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -21,50 +21,130 @@ class PathCommand extends BaseExtensionCommand {
 
   protected function configure() {
     $this
-      ->setName('ext:path')
+      ->setName('path')
       ->setAliases(array())
-      ->setDescription('Look up an extension path')
+      ->setDescription('Look up the path to a file or directory')
       ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
-      ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
-      ->setHelp('Look up an extension path
+      ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, name, value)')
+      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
+      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (Ex: "[civicrm.root]/packages")')
+      ->addArgument('file', InputArgument::IS_ARRAY, 'Optionally specify files')
+      ->setHelp('Look up the path to a file or directory
 
-Examples:
-  cv ext:path
-  cv ext:path cividiscount
-  cv ext:path org.civicrm.modules.cividiscount
+Examples (directories):
+  cv path -x cividiscount
+  cv path -x cividiscount -x styleguide -x flexmailer
+  cv path -c templateCompileDir
+  cv path -d \'[civicrm.root]/packages\'
 
-Note:
-  If you don\'t request a specific extension, this command returns the path
-  of the default extension container.
-
-  Beginning circa CiviCRM v4.2+, it has been recommended that extensions
-  include a unique long name ("org.example.foobar") and a unique short
-  name ("foobar"). However, short names are not strongly guaranteed.
+Examples (files):
+  cv path -x cividiscount -x styleguide -x flexmailer info.xml
+  cv path -c uploadDir hello.jpg
+  cv path -d \'[civicrm.root]\' packages/DB.php
 ');
     parent::configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     $this->boot($input, $output);
-    list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
 
-    foreach ($missingKeys as $key) {
-      $output->getErrorOutput()->writeln("<comment>Ignoring unrecognized extension \"$key\"</comment>");
-    }
+    $pathResults = array();
+    $returnValue = 0;
 
     $mapper = \CRM_Extension_System::singleton()->getMapper();
-    $results = array();
-    foreach ($foundKeys as $key) {
-      $results[] = array('key' => $key, 'path' => $mapper->keyToBasePath($key));
+    foreach ($input->getOption('ext') as $keyOrName) {
+      if (strpos($keyOrName, '.') === FALSE) {
+        $shortMap = $this->getShortMap();
+        if (isset($shortMap[$keyOrName]) && count($shortMap[$keyOrName]) === 1) {
+          $keyOrName = $shortMap[$keyOrName][0];
+        }
+      }
+
+      try {
+        $pathResults[] = array(
+          'type' => 'ext',
+          'name' => $keyOrName,
+          'value' => \CRM_Utils_File::addTrailingSlash($mapper->keyToBasePath($keyOrName)),
+        );
+      }
+      catch (\CRM_Extension_Exception_MissingException $e) {
+        $output->getErrorOutput()->writeln("<error>Ignoring unrecognized extension \"$keyOrName\"</error>");
+        $returnValue = 1;
+      }
     }
 
-    if (empty($missingKeys) && empty($foundKeys)) {
-      $results[] = array('key' => $key, 'path' => \CRM_Core_Config::singleton()->extensionsDir);
+    foreach ($input->getOption('config') as $configProperty) {
+      $pathResults[] = array(
+        'type' => 'config',
+        'name' => $configProperty,
+        'value' => \CRM_Core_Config::singleton()->{$configProperty},
+      );
     }
 
-    $this->sendTable($input, $output, $results, array('path'));
+    foreach ($input->getOption('dynamic') as $dynExpr) {
+      if (!is_callable(array('Civi', 'paths'))) {
+        $output->getErrorOutput()->writeln("<error>Dynamic path expressions are only available on CiviCRM v4.7+</error>");
+        $returnValue = 1;
+        break;
+      }
 
-    return empty($missingKeys) ? 0 : 1;
+      $fullExpr = preg_match(';^\[[^\]]+\]$;', $dynExpr) ? "$dynExpr/." : $dynExpr;
+
+      $pathResults[] = array(
+        'type' => 'dynamic',
+        'name' => $dynExpr,
+        'value' => \CRM_Utils_File::addTrailingSlash(\Civi::paths()->getPath($fullExpr)),
+      );
+    }
+
+    if (empty($pathResults)) {
+      $output->getErrorOutput()->writeln("<error>No paths found. Must specify -x, -s, or -d. (See also: cv path -h)</error>");
+      return 1;
+    }
+
+    $columns = $this->parseColumns($input, array(
+      'list' => array('value'),
+    ));
+
+    if (!$input->getArgument('file')) {
+      $this->sendTable($input, $output, $pathResults, $columns);
+      return $returnValue;
+    }
+    else {
+      $fileResults = array();
+      foreach ($pathResults as $pathResult) {
+        foreach ($input->getArgument('file') as $file) {
+          $fileResult = $pathResult;
+          $fileResult['value'] .= $file;
+          $fileResults[] = $fileResult;
+        }
+      }
+      $this->sendTable($input, $output, $fileResults, $columns);
+      return $returnValue;
+    }
+  }
+
+  /**
+   * Determine the columns to display.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param array $defaultColumns
+   *   Ex: $defaultColumns['table'] = array('name', 'value').
+   * @return array
+   *   Ex: array('*') or array('value').
+   */
+  protected function parseColumns(InputInterface $input, $defaultColumns = array()) {
+    $out = $input->getOption('out');
+    if ($input->getOption('columns')) {
+      return explode(',', $input->getOption('columns'));
+    }
+    elseif (isset($defaultColumns[$out])) {
+      return $defaultColumns[$out];
+    }
+    else {
+      return array('*');
+    }
   }
 
 }

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -26,7 +26,7 @@ class PathCommand extends BaseExtensionCommand {
       ->setDescription('Look up the path to a file or directory')
       ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
       ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, name, value)')
-      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar")')
+      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"); or use "." for the default extensions-dir')
       ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
       ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (Ex: "[civicrm.root]/packages")')
       ->addArgument('file', InputArgument::IS_ARRAY, 'Optionally specify files')
@@ -35,6 +35,7 @@ class PathCommand extends BaseExtensionCommand {
 Examples (directories):
   cv path -x cividiscount
   cv path -x cividiscount -x styleguide -x flexmailer
+  cv path -x .
   cv path -c templateCompileDir
   cv path -d \'[civicrm.root]/packages\'
 
@@ -54,6 +55,15 @@ Examples (files):
 
     $mapper = \CRM_Extension_System::singleton()->getMapper();
     foreach ($input->getOption('ext') as $keyOrName) {
+      if ($keyOrName === '.') {
+        $pathResults[] = array(
+          'type' => 'ext',
+          'name' => $keyOrName,
+          'value' => \CRM_Core_Config::singleton()->extensionsDir,
+        );
+        continue;
+      }
+
       if (strpos($keyOrName, '.') === FALSE) {
         $shortMap = $this->getShortMap();
         if (isset($shortMap[$keyOrName]) && count($shortMap[$keyOrName]) === 1) {

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -26,23 +26,33 @@ class PathCommand extends BaseExtensionCommand {
       ->setDescription('Look up the path to a file or directory')
       ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
       ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, expr, value)')
-      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar") or use "." for the default extensions-dir.')
-      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: configAndLogDir, customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
+      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
+      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
       ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")')
-      ->setHelp('Look up the path to a file or directory
+      ->setHelp('Look up the path to a file or directory within CiviCRM.
 
-Examples: Look extension paths
+Examples: Lookup extension paths
+  cv path -x org.civicrm.module.cividiscount
   cv path -x cividiscount
   cv path -x cividiscount/info.xml
   cv path -x .
 
-Examples: Lookup configured paths
+Examples: Lookup configuration properties
+  cv path -c configAndLogDir
+  cv path -c customFileUploadDir
+  cv path -c customPHPPathDir
+  cv path -c customTemplateDir
+  cv path -c extensionsDir
+  cv path -c imageUploadDir
+  cv path -c uploadDir
   cv path -c templateCompileDir
   cv path -c templateCompileDir/en_US
 
 Examples: Lookup dynamic paths
   cv path -d \'[civicrm.root]\'
   cv path -d \'[civicrm.root]/packages/DB.php\'
+  cv path -d \'[civicrm.files]\'
+  cv path -d \'[cms.root]/index.php\'
 
 Example: Lookup multiple items
   cv path -x cividiscount/info.xml -x flexmailer/info.xml -d \'[civicrm.root]/civicrm-version.php\'

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 
-class ExtensionPathCommand extends BaseExtensionCommand {
+class PathCommand extends BaseExtensionCommand {
 
   /**
    * @param string|null $name

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -27,7 +27,7 @@ class PathCommand extends BaseExtensionCommand {
       ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('list'))
       ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, expr, value)')
       ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar") or use "." for the default extensions-dir.')
-      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
+      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: configAndLogDir, customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
       ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (Ex: "[civicrm.root]/packages")')
       ->setHelp('Look up the path to a file or directory
 

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -28,7 +28,7 @@ class PathCommand extends BaseExtensionCommand {
       ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, expr, value)')
       ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar") or use "." for the default extensions-dir.')
       ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: configAndLogDir, customFileUploadDir, customPHPPathDir, customTemplateDir, extensionsDir, imageUploadDir, templateCompileDir, uploadDir)')
-      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (Ex: "[civicrm.root]/packages")')
+      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")')
       ->setHelp('Look up the path to a file or directory
 
 Examples: Look extension paths
@@ -95,10 +95,15 @@ Example: Lookup multiple items
 
     foreach ($input->getOption('config') as $configExpr) {
       list ($configProperty, $file) = explode('/', $configExpr, 2);
+      $dir = \CRM_Core_Config::singleton()->{$configProperty};
+      if (version_compare(\CRM_Utils_System::version(), '4.7', '<') && $configProperty === 'templateCompileDir') {
+        // Compatibility: 4.6 has weird notion of templates_c.
+        $dir = dirname($dir);
+      }
       $results[] = array(
         'type' => 'config',
         'expr' => $configExpr,
-        'value' => $this->pathJoin(\CRM_Core_Config::singleton()->{$configProperty}, $file),
+        'value' => $this->pathJoin($dir, $file),
       );
     }
 

--- a/tests/Command/PathCommandTest.php
+++ b/tests/Command/PathCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\Process;
+
+class PathCommandTest extends \Civi\Cv\CivilTestCase {
+
+  public function setup() {
+    parent::setup();
+  }
+
+  public function testPaths() {
+    $vars = $this->cvJsonOk('vars:show');
+    $this->assertTrue(is_dir($vars['CIVI_CORE']));
+    $this->assertTrue(file_exists($vars['CIVI_CORE']));
+
+    // Try "cv path -x <extension>".
+    $plain = rtrim($this->cvOk("path -x civicrm"), "\n");
+    $this->assertEquals($vars['CIVI_CORE'], $plain);
+    $json = $this->cvJsonOk("path -x civicrm --out=json");
+    $this->assertEquals('ext', $json[0]['type']);
+    $this->assertEquals('civicrm', $json[0]['name']);
+    $this->assertEquals($vars['CIVI_CORE'], $json[0]['value']);
+  }
+
+  public function testDynamicExprPaths() {
+    $vars = $this->cvJsonOk('vars:show');
+    $this->assertTrue(is_dir($vars['CIVI_CORE']));
+    $this->assertTrue(file_exists($vars['CIVI_CORE']));
+
+    if (version_compare($vars['CIVI_VERSION'], '4.7.0', '<')) {
+      $this->markTestSkipped('"cv path -d" requires v4.7+');
+    }
+
+    $plain = rtrim($this->cvOk("path -d '[civicrm.root]'"), "\n");
+    $this->assertEquals($vars['CIVI_CORE'], $plain);
+
+    $plain = rtrim($this->cvOk("path -d '[civicrm.root]/packages'"), "\n");
+    $this->assertEquals($vars['CIVI_CORE'] . 'packages/', $plain);
+
+    $json = $this->cvJsonOk("path -d '[civicrm.root]/packages' --out=json");
+    $this->assertEquals('dynamic', $json[0]['type']);
+    $this->assertEquals('[civicrm.root]/packages', $json[0]['name']);
+    $this->assertEquals($vars['CIVI_CORE'] . 'packages/', $json[0]['value']);
+  }
+
+  public function testConfigPaths() {
+    $vars = $this->cvJsonOk('vars:show');
+    $this->assertTrue(is_dir($vars['CIVI_CORE']));
+    $this->assertTrue(file_exists($vars['CIVI_CORE']));
+
+    $mandatorySettingNames = array(
+      'customFileUploadDir',
+      'extensionsDir',
+      'imageUploadDir',
+      'templateCompileDir',
+      'uploadDir',
+    );
+    foreach ($mandatorySettingNames as $settingName) {
+      $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
+      $this->assertTrue(file_exists($plain) && is_dir($plain));
+    }
+
+    $optionalSettingNames = array(
+      'customPHPPathDir',
+      'customTemplateDir',
+    );
+    foreach ($optionalSettingNames as $settingName) {
+      $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
+      $this->assertTrue((file_exists($plain) && is_dir($plain)) || empty($plain));
+    }
+  }
+
+  protected function cvOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return $p->getOutput();
+  }
+
+  protected function cvJsonOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return json_decode($p->getOutput(), 1);
+  }
+
+}

--- a/tests/Command/PathCommandTest.php
+++ b/tests/Command/PathCommandTest.php
@@ -65,7 +65,7 @@ class PathCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertTrue(file_exists($vars['CIVI_CORE']));
 
     $mandatorySettingNames = array(
-      'customFileUploadDir',
+      'configAndLogDir',
       'extensionsDir',
       'imageUploadDir',
       'templateCompileDir',
@@ -78,6 +78,7 @@ class PathCommandTest extends \Civi\Cv\CivilTestCase {
     }
 
     $optionalSettingNames = array(
+      'customFileUploadDir',
       'customPHPPathDir',
       'customTemplateDir',
     );

--- a/tests/Command/PathCommandTest.php
+++ b/tests/Command/PathCommandTest.php
@@ -69,22 +69,22 @@ class PathCommandTest extends \Civi\Cv\CivilTestCase {
       'extensionsDir',
       'imageUploadDir',
       'templateCompileDir',
-      'templateCompileDir/en_US',
       'uploadDir',
     );
     foreach ($mandatorySettingNames as $settingName) {
       $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
-      $this->assertTrue(file_exists($plain) && is_dir($plain));
+      $this->assertTrue(file_exists($plain) && is_dir($plain), "Check $settingName");
     }
 
     $optionalSettingNames = array(
       'customFileUploadDir',
       'customPHPPathDir',
       'customTemplateDir',
+      'templateCompileDir/en_US',
     );
     foreach ($optionalSettingNames as $settingName) {
       $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
-      $this->assertTrue((file_exists($plain) && is_dir($plain)) || empty($plain));
+      $this->assertTrue((file_exists($plain) && is_dir($plain)) || empty($plain), "Check $settingName");
     }
   }
 

--- a/tests/Command/PathCommandTest.php
+++ b/tests/Command/PathCommandTest.php
@@ -71,6 +71,17 @@ class PathCommandTest extends \Civi\Cv\CivilTestCase {
     }
   }
 
+  public function testExtDot() {
+    $this->assertEquals(
+      $this->cvOk('path -x.'),
+      $this->cvOk('path -c extensionsDir')
+    );
+    $this->assertEquals(
+      $this->cvOk('path -x .'),
+      $this->cvOk('path -c extensionsDir')
+    );
+  }
+
   protected function cvOk($cmd) {
     $p = Process::runOk($this->cv($cmd));
     return $p->getOutput();


### PR DESCRIPTION
This would be useful for writing simpler developer docs. Instead of asking the user to go look up a path, you'd give them a command to do it, e.g.

```
cd `cv path -x.`
civix generate:module org.example.foo
```

or

```
cd `cv path -x flexmailer`
civix generate:upgrader
```
or

```
cd `cv path -c templateCompileDir`
```

Generally, this has a few main properties:
 * In CLI usage, the default output is `list` which should be suitable for bash scripting.
 * You can manually set output using `--out` and `--format` (similar to `ext:path` command).
 * If you call `cv path` from a PHP or Javascript wrapper, it should use an env var to change the default output (e.g. `json`).
 * There's more than one way to look up a path:
   * Extension paths (`cv path -x cividiscount`; roughly like `CRM_Core_Resources::singleton()->getPath($key)`)
   * Config properties (`cv path -c templateCompileDir`; roughly, `CRM_Core_Config::singleton()->{$key}`)
   * Dynamic path expressions (`cv path -d '[cms.root]'`; roughly, `Civi::paths()->getPath($key)`)
 * The command is generally for looking up folders. If you need a specific file, then you can also add the files to the list.

(This is a replacement for PR #14.)
