### PR TITLE
UrlCommand - Add support for -x/-c/-d

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -223,4 +223,26 @@ class BaseCommand extends Command {
     return $omittedDefault;
   }
 
+  /**
+   * Determine the columns to display.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param array $defaultColumns
+   *   Ex: $defaultColumns['table'] = array('expr', 'value').
+   * @return array
+   *   Ex: array('*') or array('value').
+   */
+  protected function parseColumns(InputInterface $input, $defaultColumns = array()) {
+    $out = $input->getOption('out');
+    if ($input->getOption('columns')) {
+      return explode(',', $input->getOption('columns'));
+    }
+    elseif (isset($defaultColumns[$out])) {
+      return $defaultColumns[$out];
+    }
+    else {
+      return array('*');
+    }
+  }
+
 }

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -143,7 +143,6 @@ Example: Lookup multiple items
           'value' => \Civi::paths()->getPath($dynExpr),
         );
       }
-
     }
 
     $columns = $this->parseColumns($input, array(
@@ -152,28 +151,6 @@ Example: Lookup multiple items
 
     $this->sendTable($input, $output, $results, $columns);
     return $returnValue;
-  }
-
-  /**
-   * Determine the columns to display.
-   *
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param array $defaultColumns
-   *   Ex: $defaultColumns['table'] = array('expr', 'value').
-   * @return array
-   *   Ex: array('*') or array('value').
-   */
-  protected function parseColumns(InputInterface $input, $defaultColumns = array()) {
-    $out = $input->getOption('out');
-    if ($input->getOption('columns')) {
-      return explode(',', $input->getOption('columns'));
-    }
-    elseif (isset($defaultColumns[$out])) {
-      return $defaultColumns[$out];
-    }
-    else {
-      return array('*');
-    }
   }
 
   protected function pathJoin($folder, $file) {

--- a/src/Command/UrlCommand.php
+++ b/src/Command/UrlCommand.php
@@ -2,6 +2,7 @@
 namespace Civi\Cv\Command;
 
 use Civi\Cv\Application;
+use Civi\Cv\Encoder;
 use Civi\Cv\Util\Process;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -9,24 +10,49 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 
-class UrlCommand extends BaseCommand {
+class UrlCommand extends BaseExtensionCommand {
 
   protected function configure() {
     $this
       ->setName('url')
       ->setDescription('Compose a URL to a CiviCRM page')
       ->addArgument('path')
-      ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (json,none,php,pretty,shell)', \Civi\Cv\Encoder::getDefaultFormat())
+      ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat())
+      ->addOption('columns', NULL, InputOption::VALUE_REQUIRED, 'List of columns to display (comma separated; type, expr, value)')
       ->addOption('relative', 'r', InputOption::VALUE_NONE, 'Prefer relative URL format. (Default: absolute)')
       ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Generate a frontend URL (Default: backend)')
       ->addOption('open', 'O', InputOption::VALUE_NONE, 'Open a local web browser')
+      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
+      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
+      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")')
+      // The original contract only displayed one URL. We subsequently added support for list/csv/table output which require multi-record orientation.
+      // It's ambiguous whether JSON/serialize formats should stick to the old output or multi-record output.
+      ->addOption('tabular', NULL, InputOption::VALUE_NONE, 'Force display in multi-record mode. (Enabled by default for list,csv,table formats.)')
       ->setHelp('
 Compose a URL to a CiviCRM page
 
-Examples:
+Examples: Lookup the site root
+  cv url
+
+Examples: Lookup URLs with the standard router
   cv url civicrm/dashboard
   cv url civicrm/dashboard --open
   cv url \'civicrm/a/#/mailing/123?angularDebug=1\'
+
+Examples: Lookup URLs for extension resources
+  cv url -x org.civicrm.module.cividiscount
+  cv url -x cividiscount
+  cv url -x cividiscount/css/example.css
+
+Examples: Lookup URLs from configuration properties
+  cv url -c imageUploadUrl
+  cv url -c imageUploadUrl/example.png
+
+Examples: Lookup URLs using dynamic expressions
+  cv url -d \'[civicrm.root]\'
+  cv url -d \'[civicrm.root]/extern/ipn.php\'
+  cv url -d \'[civicrm.files]\'
+  cv url -d \'[cms.root]/index.php\'
 
 NOTE: To change the default output format, set CV_OUTPUT.
 ');
@@ -34,32 +60,79 @@ NOTE: To change the default output format, set CV_OUTPUT.
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    if (in_array($input->getOption('out'), Encoder::getTabularFormats())
+    && !in_array($input->getOption('out'), Encoder::getFormats())) {
+      $input->setOption('tabular', TRUE);
+    }
+
     $this->boot($input, $output);
 
-    $path = parse_url($input->getArgument('path'), PHP_URL_PATH);
-    $query = parse_url($input->getArgument('path'), PHP_URL_QUERY);
-    $fragment = parse_url($input->getArgument('path'), PHP_URL_FRAGMENT);
+    $rows = array();
+    if ($input->getOption('ext')) {
+      foreach ($input->getOption('ext') as $extExpr) {
+        $rows[] = $this->resolveExt($extExpr, $output);
+      }
+    }
+    elseif ($input->getOption('dynamic')) {
+      foreach ($input->getOption('dynamic') as $dynExpr) {
+        $rows[] = $this->resolveDynamic($dynExpr, $output);
+      }
+    }
+    elseif ($input->getOption('config')) {
+      foreach ($input->getOption('config') as $configExpr) {
+        $rows[] = $this->resolveConfig($configExpr, $output);
+      }
+    }
+    else {
+      $path = parse_url($input->getArgument('path'), PHP_URL_PATH);
+      $query = parse_url($input->getArgument('path'), PHP_URL_QUERY);
+      $fragment = parse_url($input->getArgument('path'), PHP_URL_FRAGMENT);
 
-    $value = \CRM_Utils_System::url(
-      $path,
-      $query,
-      !$input->getOption('relative'),
-      $fragment,
-      FALSE,
-      (bool) $input->getOption('frontend'),
-      (bool) !$input->getOption('frontend')
-    );
+      $rows[] = array(
+        'type' => 'router',
+        'expr' => $input->getArgument('path'),
+        'value' => \CRM_Utils_System::url(
+          $path,
+          $query,
+          !$input->getOption('relative'),
+          $fragment,
+          FALSE,
+          (bool) $input->getOption('frontend'),
+          (bool) !$input->getOption('frontend')
+        ),
+      );
+    }
 
     if ($input->getOption('open')) {
       $cmd = $this->pickCommand();
       if (!$cmd) {
         throw new \RuntimeException("Failed to locate 'xdg-open' or 'open'. Open not supported on this system.");
       }
-      $escaped = escapeshellarg($value);
-      Process::runOk(new \Symfony\Component\Process\Process("$cmd $escaped"));
+      foreach ($rows as $row) {
+        if (!empty($row['value'])) {
+          $escaped = escapeshellarg($row['value']);
+          Process::runOk(new \Symfony\Component\Process\Process("$cmd $escaped"));
+        }
+      }
     }
 
-    $this->sendResult($input, $output, $value);
+    if ($input->getOption('tabular')) {
+      $columns = $this->parseColumns($input, array(
+        'list' => array('value'),
+      ));
+      $this->sendTable($input, $output, $rows, $columns);
+    }
+    else {
+      if (count($rows) !== 1) {
+        $output->getErrorOutput()->writeln('<error>Detected multiple URLs. You must specify --tabular.</error>');
+        return 1;
+      }
+      else {
+        $this->sendResult($input, $output, $rows[0]['value']);
+      }
+    }
+
+    return (in_array(NULL, $rows)) ? 1 : 0;
   }
 
   protected function pickCommand($commands = array('xdg-open', 'open')) {
@@ -73,6 +146,120 @@ NOTE: To change the default output format, set CV_OUTPUT.
       }
     }
     return NULL;
+  }
+
+  /**
+   * Resolve the "--ext/-x" parameter to a URL.
+   *
+   * @param string $extExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveExt($extExpr, OutputInterface $output) {
+    $mapper = \CRM_Extension_System::singleton()->getMapper();
+
+    list ($keyOrName, $file) = explode('/', $extExpr, 2);
+    if ($keyOrName === '.') {
+      return array(
+        'type' => 'ext',
+        'expr' => $extExpr,
+        'value' => $this->urlJoin(\CRM_Core_Config::singleton()->extensionsURL, $file),
+      );
+    }
+
+    if (strpos($keyOrName, '.') === FALSE) {
+      $shortMap = $this->getShortMap();
+      if (isset($shortMap[$keyOrName]) && count($shortMap[$keyOrName]) === 1) {
+        $keyOrName = $shortMap[$keyOrName][0];
+      }
+    }
+
+    try {
+      return array(
+        'type' => 'ext',
+        'expr' => $extExpr,
+        'value' => $this->urlJoin($mapper->keyToUrl($keyOrName), $file),
+      );
+    }
+    catch (\CRM_Extension_Exception_MissingException $e) {
+      $output->getErrorOutput()
+        ->writeln("<error>Ignoring unrecognized extension \"$keyOrName\"</error>");
+      // $returnValue = 1;
+      return NULL;
+    }
+  }
+
+  /**
+   * Resolve the "--dynamic/-d" parameter to a URL.
+   *
+   * @param string $dynExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveDynamic($dynExpr, OutputInterface $output) {
+    if (!is_callable(array('Civi', 'paths'))) {
+      $output->getErrorOutput()
+        ->writeln("<error>Dynamic path expressions are only available on CiviCRM v4.7+</error>");
+      return NULL;
+    }
+
+    if (preg_match(';^(\[[^\]]+\])([\\/]?)$;', $dynExpr, $matches)) {
+      // getPath() is wonky about "[civicrm.root]" or "[civicrm.root]/",
+      // so we have to trick it.
+      $dyn = \Civi::paths()->getUrl($matches[1] . "/./", 'absolute');
+      $value = preg_replace(';/./$;', '', $dyn) . $matches[2];
+      return array(
+        'type' => 'dynamic',
+        'expr' => $dynExpr,
+        'value' => $value,
+      );
+    }
+    else {
+      // Phew, we can do a normal lookup.
+      return array(
+        'type' => 'dynamic',
+        'expr' => $dynExpr,
+        'value' => \Civi::paths()->getUrl($dynExpr, 'absolute'),
+      );
+    }
+  }
+
+  /**
+   * Resolve the "--config/-c" parameter to a URL.
+   *
+   * @param string $configExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveConfig($configExpr, OutputInterface $output) {
+    list ($configProperty, $file) = explode('/', $configExpr, 2);
+    $dir = \CRM_Core_Config::singleton()->{$configProperty};
+    return array(
+      'type' => 'config',
+      'expr' => $configExpr,
+      'value' => $this->urlJoin($dir, $file),
+    );
+  }
+
+  protected function urlJoin($folder, $file) {
+    if ($folder == NULL || $folder == FALSE) {
+      return $folder;
+    }
+    if ($file !== NULL && $file !== FALSE) {
+      return \CRM_Utils_File::addTrailingSlash($folder, '/') . $file;
+    }
+    else {
+      return rtrim($folder, DIRECTORY_SEPARATOR);
+    }
   }
 
 }

--- a/tests/CivilTestCase.php
+++ b/tests/CivilTestCase.php
@@ -3,6 +3,7 @@ namespace Civi\Cv;
 
 use Civi\Cv\Util\Process as ProcessUtil;
 use Civi\Cv\Application;
+use Civi\Cv\Util\Process;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -39,7 +40,11 @@ class CivilTestCase extends \PHPUnit_Framework_TestCase {
   }
 
   /**
+   * Create a process for `cv` subcommand.
+   *
    * @param string $command
+   *   Ex: "vars:show --out=serialize".
+   * @return \Symfony\Component\Process\Process
    */
   protected function cv($command) {
     $process = new \Symfony\Component\Process\Process("{$this->cv} $command");
@@ -61,6 +66,39 @@ class CivilTestCase extends \PHPUnit_Framework_TestCase {
     $commandTester = new CommandTester($command);
     $commandTester->execute($args);
     return $commandTester;
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return $p->getOutput();
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvFail($cmd) {
+    $p = Process::runFail($this->cv($cmd));
+    return $p->getErrorOutput() . $p->getOutput();
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvJsonOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return json_decode($p->getOutput(), 1);
   }
 
 }

--- a/tests/Command/PathCommandTest.php
+++ b/tests/Command/PathCommandTest.php
@@ -99,14 +99,4 @@ class PathCommandTest extends \Civi\Cv\CivilTestCase {
     );
   }
 
-  protected function cvOk($cmd) {
-    $p = Process::runOk($this->cv($cmd));
-    return $p->getOutput();
-  }
-
-  protected function cvJsonOk($cmd) {
-    $p = Process::runOk($this->cv($cmd));
-    return json_decode($p->getOutput(), 1);
-  }
-
 }

--- a/tests/Command/UrlCommandTest.php
+++ b/tests/Command/UrlCommandTest.php
@@ -3,7 +3,7 @@ namespace Civi\Cv\Command;
 
 use Civi\Cv\Util\Process;
 
-class UrllCommandTest extends \Civi\Cv\CivilTestCase {
+class UrlCommandTest extends \Civi\Cv\CivilTestCase {
 
   public function setup() {
     parent::setup();
@@ -18,6 +18,87 @@ class UrllCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp(':angularDebug=1:', $fullUrl);
     $this->assertRegExp(':foo=bar:', $fullUrl);
     $this->assertRegExp(':/mailing/new:', $fullUrl);
+  }
+
+  public function testOutput() {
+    $output = $this->cvFail('url -x. -x. --out=json');
+    $this->assertRegExp(';specify --tabular;', $output);
+
+    $output = $this->cvJsonOk('url -x. -x. --out=json --tabular');
+    $this->assertEquals(2, count($output));
+    $this->assertRegExp(';https?://.*;', $output[0]['value']);
+    $this->assertRegExp(';https?://.*;', $output[1]['value']);
+
+    $output = explode("\n", trim($this->cvOk('url -x. -x. --out=list')));
+    $this->assertEquals(2, count($output));
+    $this->assertRegExp(';https?://.*;', $output[0]);
+    $this->assertRegExp(';https?://.*;', $output[1]);
+
+    $output = $this->cvJsonOk('url -x. --out=json');
+    $this->assertRegExp(';https?://.*;', $output);
+  }
+
+  public function testExtPaths() {
+    $plain = rtrim($this->cvJsonOk("url -x civicrm"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -x civicrm/"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -x civicrm/packages"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
+  }
+
+  public function testDynamicExprPaths() {
+    $vars = $this->cvJsonOk('vars:show');
+    if (version_compare($vars['CIVI_VERSION'], '4.7.0', '<')) {
+      $this->markTestSkipped('"cv path -d" requires v4.7+');
+    }
+
+    $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]'"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/'"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/packages'"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
+  }
+
+  public function testConfigPaths() {
+    $vars = $this->cvJsonOk('vars:show');
+    $this->assertTrue(is_dir($vars['CIVI_CORE']));
+    $this->assertTrue(file_exists($vars['CIVI_CORE']));
+
+    $mandatorySettingNames = array(
+      'extensionsURL',
+      'imageUploadURL',
+      'userFrameworkBaseURL',
+      'userFrameworkResourceURL',
+    );
+    foreach ($mandatorySettingNames as $settingName) {
+      $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
+      $this->assertRegExp(';^https?://.*;', $plain, "Check $settingName");
+    }
+
+    $optionalSettingNames = array(
+      'customCSSURL',
+    );
+    foreach ($optionalSettingNames as $settingName) {
+      $plain = rtrim($this->cvOk("path -c $settingName"), "\n");
+      $this->assertRegExp(';^(|https?://.*);', $plain, "Check $settingName");
+    }
+  }
+
+  public function testExtDot() {
+    $this->assertEquals(
+      $this->cvOk('url -c extensionsURL'),
+      $this->cvOk('url -x.')
+    );
+    $this->assertEquals(
+      $this->cvOk('url -c extensionsURL'),
+      $this->cvOk('url -x .')
+    );
   }
 
 }


### PR DESCRIPTION
This creates a parallel with the `PathCommand` so that you can lookup paths and URLs in the same way, e.g.

```
cv path -x cividiscount/hello.css
cv url -x cividiscount/hello.css

cv path -d '[cms.root]/index.php'
cv url -d '[cms.root]/index.php'

cv path -c 'extensionsDir'
cv url -c 'extensionsDir'
```

Note that the parallel isn't quite perfect because I wanted to preserve backward compatibility with existing `cv url` consumers. The main difference:
 * `cv path` always uses `sendTable()` to output results. It defaults to `list` format. This is handy for shell-scripting (where we often need paths).
 * `cv url` (in the typical case) sends a single string with a single URL (aka `sendResults()`). It defaults to `json` format. However, if you specify a tabular output mode (`table`, `csv`, `list`), it will use `sendTable()`. Also, if you want JSON in a tabular output, then you must explicitly set `--tabular`.
 * If we find a good moment to break the contract, then we should change `url`'s default to `list` for sake of consistency.