### PR TITLE
debug:event-dispatcher - Display autoregistered/wildcard listeners

### DIFF
--- a/src/Command/DebugDispatcherCommand.php
+++ b/src/Command/DebugDispatcherCommand.php
@@ -49,10 +49,10 @@ Examples:
     }
 
     ksort($listenersByEvent);
-    foreach ($listenersByEvent as $event => $listeners) {
+    foreach ($listenersByEvent as $event => $rawListeners) {
       $rows = array();
       $i = 0;
-      foreach ($listeners as $listener) {
+      foreach ($d->getListeners($event) as $listener) {
         $handled = FALSE;
         if (is_array($listener)) {
           list ($a, $b) = $listener;


### PR DESCRIPTION
When using autoregistered/wildcard listeners, the listener may not appear
when viewing `getListeners(NULL)`.  Using `getListeners($name)` should be
more authoritative.