### PR TITLE
HeadlessDownloader - Perform recursive mkdir

### DIFF
--- a/src/Util/HeadlessDownloader.php
+++ b/src/Util/HeadlessDownloader.php
@@ -96,7 +96,7 @@ class HeadlessDownloader {
         throw new \Exception("$extractedZipPath already exists");
       }
       if (!is_dir($tmpDir)) {
-        mkdir($tmpDir);
+        mkdir($tmpDir, 0777, TRUE);
       }
       if (!$zip->extractTo($tmpDir)) {
         throw new \Exception("Unable to extract the extension to $tmpDir.");


### PR DESCRIPTION
Ex: if you're trying to download to folder `civicrm/ext/iatspayments`, but
`civicrm/ext` doesn't exist, then it should be created.