### PR TITLE
Implement `core:install` and `core:uninstall` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ and loop through them, e.g.
 $ for CV_TEST_BUILD in /home/me/buildkit/build/{dmaster,wpmaster,bmaster} ; do export CV_TEST_BUILD; phpunit4 --group std; done
 ```
 
-Unit-Tests (Setup)
-==================
+Unit-Tests (Installer)
+======================
 
-The `cv core:setup` command has more stringent execution requirements, e.g.
+The `cv core:install` and `cv core:uninstall` commands have more stringent execution requirements, e.g.
 
 * Each test-run needs to work with an empty build (which does not have a Civi database or settings file).
   It specifically calls `civibuild` and `amp` to create+destroy builds during execution.
@@ -202,5 +202,5 @@ Given these extra requirements, this test runs as a separate group.
 A typical execution might look like:
 
 ```
-$ env DEBUG=1 OFFLINE=1 CV_SETUP_PATH=$HOME/src/civicrm-setup phpunit4 --group setup
+$ env DEBUG=1 OFFLINE=1 CV_SETUP_PATH=$HOME/src/civicrm-setup phpunit4 --group installer
 ```

--- a/README.md
+++ b/README.md
@@ -148,19 +148,19 @@ $ composer install
 $ php -dphar.readonly=0 `which box` build
 ```
 
-Unit-Tests
-==========
+Unit-Tests (Standard)
+=====================
 
-To run the test suite, you will need an existing CiviCRM installation,
-preferrably based on buildkit. (Example: `/home/me/buildkit/build/dmaster/`)
+To run the standard test suite, you will need to pick an existing CiviCRM
+installation and put it in `CV_TEST_BUILD`, as in:
 
 ```
 $ git clone https://github.com/civicrm/cv
 $ cd cv
 $ composer install
 $ export CV_TEST_BUILD=/home/me/buildkit/build/dmaster/
-$ ./bin/phpunit
-PHPUnit 3.7.10 by Sebastian Bergmann.
+$ phpunit4 --group std
+PHPUnit 4.8.21 by Sebastian Bergmann and contributors.
 
 Configuration read from /home/me/src/cv/phpunit.xml.dist
 
@@ -169,4 +169,38 @@ Configuration read from /home/me/src/cv/phpunit.xml.dist
 Time: 2 seconds, Memory: 6.50Mb
 
 OK (49 tests, 121 assertions)
+```
+
+> We generally choose an existing installation based on `civibuild`
+> configuration like `dmaster`. The above example assumes that your
+> build is located at `/home/me/buildkit/build/dmaster/`.
+
+
+To be quite thorough, you may want to test against multiple builds (e.g.
+with various CMS's and file structures).  Prepare these builds separately
+and loop through them, e.g.
+
+```
+$ for CV_TEST_BUILD in /home/me/buildkit/build/{dmaster,wpmaster,bmaster} ; do export CV_TEST_BUILD; phpunit4 --group std; done
+```
+
+Unit-Tests (Setup)
+==================
+
+The `cv core:setup` command has more stringent execution requirements, e.g.
+
+* Each test-run needs to work with an empty build (which does not have a Civi database or settings file).
+  It specifically calls `civibuild` and `amp` to create+destroy builds during execution.
+* These commands, in turn, may add new vhosts and databases. This can require elevated privileges (`sudo`).
+* These commands have more potential failure points (e.g. intermittent networking issues can disrupt
+  the test). To monitor them, you should set `DEBUG=1`.
+* There must be a copy of the `civicrm-setup` source tree.  At time of writing, this is not yet bundled with
+  the main tarballs, but you can set `CV_SETUP_PATH` to point to your own copy.
+
+Given these extra requirements, this test runs as a separate group.
+
+A typical execution might look like:
+
+```
+$ env DEBUG=1 OFFLINE=1 CV_SETUP_PATH=$HOME/src/civicrm-setup phpunit4 --group setup
 ```

--- a/bin/cv2
+++ b/bin/cv2
@@ -1,0 +1,36 @@
+#!/usr/bin/env php
+<?php
+ini_set('display_errors', 1);
+if (PHP_SAPI !== 'cli') {
+  echo "cv is a command-line tool\n";
+  exit(1);
+}
+$found = 0;
+$autoloaders = array(
+  dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+  dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'autoload.php',
+);
+foreach ($autoloaders as $autoloader) {
+  if (file_exists($autoloader)) {
+    require_once $autoloader;
+    $found = 1;
+    break;
+  }
+}
+if (!$found) {
+  die("Failed to find autoloader");
+}
+
+$output = new \Symfony\Component\Console\Output\ConsoleOutput();
+$output->setVerbosity(\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_DEBUG);
+\Civi\Cv\CmsBootstrap::singleton()->addOptions([
+  'output' => $output,
+]);
+
+$output->writeln("<info>[cv2]</info> Boot CMS");
+\Civi\Cv\CmsBootstrap::singleton()->bootCms();
+
+$output->writeln("<info>[cv2]</info> Boot CiviCRM");
+\Civi\Cv\CmsBootstrap::singleton()->bootCivi();
+
+$output->writeln("Hello from CiviCRM v" . CRM_Utils_System::version());

--- a/src/Application.php
+++ b/src/Application.php
@@ -53,6 +53,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\CliCommand();
       $commands[] = new \Civi\Cv\Command\EvalCommand();
       $commands[] = new \Civi\Cv\Command\ScriptCommand();
+      $commands[] = new \Civi\Cv\Command\SetupCommand();
     }
     return $commands;
   }

--- a/src/Application.php
+++ b/src/Application.php
@@ -53,7 +53,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\CliCommand();
       $commands[] = new \Civi\Cv\Command\EvalCommand();
       $commands[] = new \Civi\Cv\Command\ScriptCommand();
-      $commands[] = new \Civi\Cv\Command\SetupCommand();
+      $commands[] = new \Civi\Cv\Command\CoreInstallCommand();
     }
     return $commands;
   }

--- a/src/Application.php
+++ b/src/Application.php
@@ -54,6 +54,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\EvalCommand();
       $commands[] = new \Civi\Cv\Command\ScriptCommand();
       $commands[] = new \Civi\Cv\Command\CoreInstallCommand();
+      $commands[] = new \Civi\Cv\Command\CoreUninstallCommand();
     }
     return $commands;
   }

--- a/src/Application.php
+++ b/src/Application.php
@@ -53,6 +53,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\CliCommand();
       $commands[] = new \Civi\Cv\Command\EvalCommand();
       $commands[] = new \Civi\Cv\Command\ScriptCommand();
+      $commands[] = new \Civi\Cv\Command\CoreCheckReqCommand();
       $commands[] = new \Civi\Cv\Command\CoreInstallCommand();
       $commands[] = new \Civi\Cv\Command\CoreUninstallCommand();
     }

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -1,0 +1,392 @@
+<?php
+namespace Civi\Cv;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Bootstrap the CMS runtime.
+ *
+ * @code
+ * // Use default bootstrap
+ * require_once '/path/to/CmsBootstrap.php';
+ * Civi\Cv\CmsBootstrap::singleton()->bootCms()->bootCivi();
+ *
+ * // Use custom bootstrap
+ * require_once '/path/to/CmsBootstrap.php';
+ * Civi\Cv\CmsBootstrap::singleton()
+ *   ->addOptions(array(...))
+ *   ->bootCms()
+ *   ->bootCivi();
+ * @endcode
+ *
+ * This class is intended to be run *before* the classloader is available. Therefore, it
+ * must be self-sufficient.
+ *
+ * By default, bootstrap will scan PWD and every ancestor directory to see if it
+ * contains a supported CMS. If you have performance considerations, or if the
+ * directory structure is not amenable to scanning, then set the environment
+ * variable CIVICRM_BOOT (in bashrc and/or httpd vhost).
+ *
+ * The bootstrapper accepts a few options (either via the constructor or addOptions()). They are:
+ *   - env: string|NULL. The environment variable which may contain boot options
+ *     Ex: 'Drupal://var/www' or 'WordPress://admin@var/www'. Set NULL to disable.
+ *     (Default: CIVICRM_BOOT)
+ *   - search: bool|string. Attempt to determine root+settings by searching
+ *     the file system and checking against common Civi directory structures.
+ *     Boolean TRUE means it should use a default (PWD).
+ *     (Default: TRUE aka PWD)
+ *   - user: string|NULL. The name of a CMS user to authenticate as.
+ *
+ * @package Civi
+ */
+class CmsBootstrap {
+
+  protected static $singleton = NULL;
+
+  protected $options = array();
+
+  /**
+   * Symphony OutputInterface provide during booting to enable the command-line
+   * 'v', 'vv' and 'vvv' options
+   * @see http://symfony.com/doc/current/console/verbosity.html
+   */
+  protected $output = FALSE;
+
+  /**
+   * @var array|NULL
+   */
+  protected $bootedCms = NULL;
+
+  /**
+   * Wrapper around OutputInterface::writeln()
+   *
+   * @param string $text
+   * @param int $level
+   */
+  public function writeln($text, $level = OutputInterface::VERBOSITY_NORMAL) {
+    if ($this->output) {
+      $this->output->writeln("<info>[Bootstrap2]</info> $text", $level);
+    }
+  }
+
+  /**
+   * @return CmsBootstrap
+   */
+  public static function singleton() {
+    if (self::$singleton === NULL) {
+      self::$singleton = new CmsBootstrap(array(
+        'env' => 'CIVICRM_BOOT',
+        'search' => TRUE,
+        'httpHost' => array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : 'localhost',
+        'user' => NULL,
+      ));
+    }
+    return self::$singleton;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   */
+  public function __construct($options = array()) {
+    $this->addOptions($options);
+  }
+
+  /**
+   * Bootstrap the CiviCRM runtime.
+   *
+   * @return CmsBootstrap
+   * @throws \Exception
+   */
+  public function bootCms() {
+    $this->writeln("Options: " . Encoder::encode($this->options, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+
+    if ($this->options['env'] && getenv($this->options['env'])) {
+      $cmsExpr = getenv($this->options['env']);
+      $this->writeln("Parse CMS options ($cmsExpr)", OutputInterface::VERBOSITY_DEBUG);
+      $cms = array(
+        'type' => parse_url($cmsExpr, PHP_URL_SCHEME),
+        'path' => '/' . parse_url($cmsExpr, PHP_URL_HOST) . parse_url($cmsExpr, PHP_URL_PATH),
+      );
+      $cms['path'] = preg_replace(';^//+;', '/', $cms['path']);
+      if (!isset($this->options['user']) && parse_url($cmsExpr, PHP_URL_USER)) {
+        $this->options['user'] = parse_url($cmsExpr, PHP_URL_USER);
+      }
+    }
+    else {
+      $this->writeln("Find CMS...", OutputInterface::VERBOSITY_DEBUG);
+      $cms = $this->findCmsRoot($this->getSearchDir());
+    }
+
+    $this->writeln("CMS: " . Encoder::encode($cms, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
+      throw new \Exception("Failed to parse or find a CMS");
+    }
+
+    if (PHP_SAPI === "cli") {
+      $this->writeln("Simulate web environment in CLI", OutputInterface::VERBOSITY_DEBUG);
+      $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
+    }
+
+    $func = 'boot' . $cms['type'];
+    if (!is_callable([$this, $func])) {
+      throw new \Exception("Failed to locate boot function ($func)");
+    }
+
+    call_user_func([$this, $func],
+      $cms['path'], $this->options['user'], $this->options['httpHost']);
+
+    if (!empty($this->options['user'])) {
+      $this->ensureUserContact();
+    }
+
+    if (PHP_SAPI === "cli") {
+      error_reporting(1);
+    }
+
+    $this->writeln("Finished", OutputInterface::VERBOSITY_DEBUG);
+    $this->bootedCms = $cms;
+    return $this;
+  }
+
+  /**
+   * Determine what, if any, CMS has been bootstrapped.
+   *
+   * @return string|NULL
+   *   Ex: 'Backdrop', 'Drupal', 'Drupal8', 'Joomla', 'WordPress'.
+   */
+  public function getBootedCmsType() {
+    return isset($this->bootedCms['type']) ? $this->bootedCms['type'] : NULL;
+  }
+
+  /**
+   * Determine what, if any, CMS has been bootstrapped.
+   *
+   * @return string|NULL
+   *   Ex: '/var/www'.
+   */
+  public function getBootedCmsPath() {
+    return isset($this->bootedCms['path']) ? $this->bootedCms['path'] : NULL;
+  }
+
+  /**
+   * @return $this
+   * @throws \Exception
+   */
+  public function bootCivi() {
+    // PRE-CONDITIONS: CMS has already been booted, and Civi is already installed.
+    if (function_exists('civicrm_initialize')) {
+      civicrm_initialize();
+    }
+    // else if Joomla weirdness, do that
+    else {
+      throw new \Exception("This system does not appear to have CiviCRM");
+    }
+    $this->ensureUserContact();
+    return $this;
+  }
+
+  public function bootBackdrop($cmsPath, $cmsUser) {
+    if (!file_exists("$cmsPath/core/includes/bootstrap.inc")) {
+      throw new \Exception('Sorry, could not locate Backdrop\'s bootstrap.inc');
+    }
+    chdir($cmsPath);
+    define('BACKDROP_ROOT', $cmsPath);
+    require_once "$cmsPath/core/includes/bootstrap.inc";
+    require_once "$cmsPath/core/includes/config.inc";
+    \backdrop_bootstrap(BACKDROP_BOOTSTRAP_FULL);
+
+    if (!function_exists('module_exists')) {
+      throw new \Exception('Sorry, could not bootstrap Backdrop.');
+    }
+
+    if ($cmsUser) {
+      global $user;
+      $user = \user_load(array('name' => $cmsUser));
+    }
+
+    return $this;
+  }
+
+  public function bootDrupal($cmsPath, $cmsUser) {
+    if (!file_exists("$cmsPath/includes/bootstrap.inc")) {
+      throw new \Exception('Sorry, could not locate Drupal\'s bootstrap.inc');
+    }
+    chdir($cmsPath);
+    define('DRUPAL_ROOT', $cmsPath);
+    require_once 'includes/bootstrap.inc';
+    \drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
+
+    if (!function_exists('module_exists')) {
+      throw new \Exception('Sorry, could not bootstrap Drupal.');
+    }
+
+    if ($cmsUser) {
+      global $user;
+      $user = \user_load(array('name' => $cmsUser));
+    }
+
+    return $this;
+  }
+
+  // TODO public function bootDrupal8($cmsRootPath, $cmsUser) { }
+  // TODO public function bootJoomla($cmsRootPath, $cmsUser) { }
+
+  /**
+   * @param string $cmsRootPath
+   * @param string $cmsUser
+   * @return $this
+   */
+  public function bootWordPress($cmsRootPath, $cmsUser) {
+    chdir($cmsRootPath);
+    require_once $cmsRootPath . DIRECTORY_SEPARATOR . 'wp-load.php';
+    if ($cmsUser) {
+      wp_set_current_user(NULL, $cmsUser);
+    }
+
+    return $this;
+  }
+
+  /**
+   * @return array
+   *   See options in class doc.
+   */
+  public function getOptions() {
+    return $this->options;
+  }
+
+  /**
+   * @param array $options
+   *   See options in class doc.
+   * @return CmsBootstrap
+   */
+  public function addOptions($options) {
+    $this->options = array_merge($this->options, $options);
+
+    if (!empty($options['output'])) {
+      $this->output = $options['output'];
+    }
+
+    return $this;
+  }
+
+  /**
+   * @param string $searchDir
+   *   The directory from which to begin the upward search.
+   * @return array|NULL
+   *   Ex: ['path' => '/var/www', 'type' => 'WordPress]
+   */
+  protected function findCmsRoot($searchDir) {
+    // A list of file patterns; if one of the patterns matches a give
+    // directory, then we can assume that this directory is the
+    // CMS root.
+    $cmsPatterns = array(
+      'WordPress' => array(
+        // 'wp-includes/version.php',
+        'wp-load.php',
+      ),
+      'Joomla' => array(
+        'administrator/components/com_users/users.php',
+      ),
+      'Drupal' => array(
+        'modules/system/system.module',
+      ),
+      'Drupal8' => array(
+        'core/core.services.yml',
+      ),
+      'Backdrop' => array(
+        'core/modules/layout/layout.module',
+      ),
+    );
+
+    $parts = explode('/', str_replace('\\', '/', $searchDir));
+    while (!empty($parts)) {
+      $basePath = implode('/', $parts);
+
+      foreach ($cmsPatterns as $cmsType => $relPaths) {
+        if (!empty($this->options['cmsType']) && $this->options['cmsType'] != $cmsType) {
+          continue;
+        }
+        foreach ($relPaths as $relPath) {
+          $matches = glob("$basePath/$relPath");
+          if (!empty($matches)) {
+            return array('path' => $basePath, 'type' => $cmsType);
+          }
+        }
+      }
+
+      array_pop($parts);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @return string
+   */
+  protected function getSearchDir() {
+    if ($this->options['search'] === TRUE) {
+      // exec(pwd) works better with symlinked source trees, but it's
+      // probably not portable to Windows.
+      if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        return getcwd();
+      }
+      else {
+        exec('pwd', $output);
+        return trim(implode("\n", $output));
+      }
+    }
+    else {
+      return $this->options['search'];
+    }
+  }
+
+  /**
+   * @param $scriptFile
+   * @param $host
+   */
+  protected function simulateWebEnv($host, $scriptFile) {
+    $_SERVER['SCRIPT_FILENAME'] = $scriptFile;
+    $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+    $_SERVER['SERVER_SOFTWARE'] = NULL;
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['SERVER_NAME'] = $host;
+    $_SERVER['HTTP_HOST'] = $host;
+    if (ord($_SERVER['SCRIPT_NAME']) != 47) {
+      $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
+    }
+  }
+
+  protected function ensureUserContact() {
+    if ($cid = \CRM_Core_Session::getLoggedInContactID()) {
+      return $cid;
+    }
+
+    // Ugh, this codepath.
+    switch (CIVICRM_UF) {
+      case 'Drupal':
+      case 'Drupal6':
+      case 'Backdrop':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['user'], TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Drupal8':
+        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Joomla':
+        \CRM_Core_BAO_UFMatch::synchronize(\JFactory::getUser(), TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      case 'WordPress':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['current_user'], TRUE, CIVICRM_UF, 'Individual');
+        break;
+
+      default:
+        $this->output->writeln("<error>Unrecognized UF: " . CIVICRM_UF . "</error>");
+    }
+
+    return \CRM_Core_Session::getLoggedInContactID();
+  }
+
+}

--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AngularHtmlListCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * @param string|null $name
    */
@@ -41,7 +43,7 @@ Examples:
   cv ang:html:list crmUi/*
   cv ang:html:list \';(tabset|wizard)\\.html;\'
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/AngularHtmlShowCommand.php
+++ b/src/Command/AngularHtmlShowCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AngularHtmlShowCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * @param string|null $name
    */
@@ -41,7 +43,7 @@ Examples:
   cv ang:html:show crmMailing/BlockMailing.html --diff | colordiff
   cv ang:html:show "~/crmMailing/BlockMailing.html"
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/AngularModuleListCommand.php
+++ b/src/Command/AngularModuleListCommand.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AngularModuleListCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * @param string|null $name
    */
@@ -43,7 +45,7 @@ Examples:
   cv ang:module:list \'/crmMail/\' --user=admin --columns=extDir,css
   cv ang:module:list --columns=name,js,css --out=json-pretty
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ApiBatchCommand.php
+++ b/src/Command/ApiBatchCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ApiBatchCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * @var array
    */
@@ -41,7 +43,7 @@ of API calls.
 Each line of output is encoded as a JSON document. The JSON document is an array
 of API results.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -8,8 +8,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 class ApiCommand extends BaseCommand {
+
+  use \Civi\Cv\Util\BootTrait;
 
   /**
    * @var array
@@ -41,7 +42,7 @@ Examples:
 
 NOTE: To change the default output format, set CV_OUTPUT.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -14,76 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BaseCommand extends Command {
 
-  protected function configureBootOptions() {
-    $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full)', 'full');
-    $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
-    $this->addOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user');
-  }
-
-  protected function boot(InputInterface $input, OutputInterface $output) {
-    if ($output->isDebug()) {
-      $output->writeln(
-        'Attempting to set verbose error reporting',
-        OutputInterface::VERBOSITY_DEBUG);
-      // standard php debug chat settings
-      error_reporting(E_ALL | E_STRICT);
-      ini_set('display_errors', TRUE);
-      ini_set('display_startup_errors', TRUE);
-      // add the output object to allow the bootstrapper to output debug messages
-      // and track verboisty
-      $boot_params = array(
-        'output' => $output,
-      );
-    }
-    else {
-      $boot_params = array();
-    }
-
-    $output->writeln('<info>[BaseCommand::boot]</info> Start', OutputInterface::VERBOSITY_DEBUG);
-
-    if ($input->hasOption('test') && $input->getOption('test')) {
-      $output->writeln('<info>[BaseCommand::boot]</info> Use test mode', OutputInterface::VERBOSITY_DEBUG);
-      putenv('CIVICRM_UF=UnitTests');
-      $_ENV['CIVICRM_UF'] = 'UnitTests';
-    }
-
-    if ($input->hasOption('level') && $input->getOption('level') === 'none') {
-      $output->writeln('<info>[BaseCommand::boot]</info> Skip', OutputInterface::VERBOSITY_DEBUG);
-      return;
-    }
-    elseif ($input->hasOption('level') && $input->getOption('level') !== 'full') {
-      $output->writeln('<info>[BaseCommand::boot]</info> Call basic cv bootstrap (' . $input->getOption('level') . ')', OutputInterface::VERBOSITY_DEBUG);
-      \Civi\Cv\Bootstrap::singleton()->boot($boot_params + array(
-        'prefetch' => FALSE,
-      ));
-    }
-    else {
-      $output->writeln('<info>[BaseCommand::boot]</info> Call standard cv bootstrap', OutputInterface::VERBOSITY_DEBUG);
-      \Civi\Cv\Bootstrap::singleton()->boot($boot_params);
-
-      $output->writeln('<info>[BaseCommand::boot]</info> Call core bootstrap', OutputInterface::VERBOSITY_DEBUG);
-      \CRM_Core_Config::singleton();
-
-      $output->writeln('<info>[BaseCommand::boot]</info> Call CMS bootstrap', OutputInterface::VERBOSITY_DEBUG);
-      \CRM_Utils_System::loadBootStrap(array(), FALSE);
-
-      if ($input->getOption('user')) {
-        $output->writeln('<info>[BaseCommand::boot]</info> Set system user', OutputInterface::VERBOSITY_DEBUG);
-        if (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
-          \CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user'));
-          if (!$this->ensureUserContact($output)) {
-            throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
-          }
-        }
-        else {
-          $output->getErrorOutput()->writeln("<error>Failed to set user. Feature not supported by UF (" . CIVICRM_UF . ")</error>");
-        }
-      }
-    }
-
-    $output->writeln('<info>[BaseCommand::boot]</info> Finished', OutputInterface::VERBOSITY_DEBUG);
-  }
-
   protected function assertBooted() {
     if (!$this->isBooted()) {
       throw new \Exception("Error: This command requires bootstrapping, but the system does not appear to be bootstrapped. Perhaps you set --level=none?");
@@ -258,49 +188,6 @@ class BaseCommand extends Command {
     else {
       return array('*');
     }
-  }
-
-  /**
-   * Ensure that the current user has a contact record.
-   *
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @return int|NULL
-   *   The user's contact ID, or NULL
-   */
-  private function ensureUserContact(OutputInterface $output) {
-    if ($cid = \CRM_Core_Session::getLoggedInContactID()) {
-      return $cid;
-    }
-
-    // Ugh, this codepath is ridiculous.
-    switch (CIVICRM_UF) {
-      case 'Drupal':
-      case 'Drupal6':
-      case 'Backdrop':
-        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['user'], TRUE,
-          CIVICRM_UF, 'Individual');
-        break;
-
-      case 'Drupal8':
-        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE,
-          CIVICRM_UF, 'Individual');
-        break;
-
-      case 'Joomla':
-        \CRM_Core_BAO_UFMatch::synchronize(\JFactory::getUser(), TRUE,
-          CIVICRM_UF, 'Individual');
-        break;
-
-      case 'WordPress':
-        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['current_user'], TRUE,
-          CIVICRM_UF, 'Individual');
-        break;
-
-      default:
-        $output->writeln("<error>Unrecognized UF: " . CIVICRM_UF . "</error>");
-    }
-
-    return \CRM_Core_Session::getLoggedInContactID();
   }
 
   /**

--- a/src/Command/BaseExtensionCommand.php
+++ b/src/Command/BaseExtensionCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BaseExtensionCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * Register CLI options for filtering the extension feed, such as "--dev" or "--filter-ver".
    */

--- a/src/Command/BootCommand.php
+++ b/src/Command/BootCommand.php
@@ -8,11 +8,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BootCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('php:boot')
       ->setDescription('Generate PHP bootstrap code');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/CliCommand.php
+++ b/src/Command/CliCommand.php
@@ -15,11 +15,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CliCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('cli')
       ->setDescription('Load interactive command line');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/CoreCheckReqCommand.php
+++ b/src/Command/CoreCheckReqCommand.php
@@ -46,11 +46,13 @@ $ cv core:check-req -we
     $messages = array_filter($reqs->getMessages(), function ($m) use ($filterLevels) {
       return in_array($m['level'], $filterLevels);
     });
-    usort($messages, function($a, $b){
-      $nameCmp = strcmp($a['name'], $b['name']);
-      return $nameCmp;
+    uasort($messages, function ($a, $b) {
+      return strcmp(
+        $a['level'] . '-' . $a['section'] . '-' . $a['name'],
+        $b['level'] . '-' . $b['section'] . '-' . $b['name']
+      );
     });
-    $this->sendTable($input, $output, $messages, array('level', 'name', 'message'));
+    $this->sendTable($input, $output, $messages, array('level', 'section', 'name', 'message'));
     return $reqs->getErrors() ? 1 : 0;
   }
 

--- a/src/Command/CoreCheckReqCommand.php
+++ b/src/Command/CoreCheckReqCommand.php
@@ -1,0 +1,79 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Encoder;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+class CoreCheckReqCommand extends BaseCommand {
+
+  use \Civi\Cv\Util\SetupCommandTrait;
+  use \Civi\Cv\Util\DebugDispatcherTrait;
+
+  protected function configure() {
+    $this
+      ->setName('core:check-req')
+      ->setDescription('Check installation requirements')
+      ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getTabularFormats()) . ')', Encoder::getDefaultFormat('table'))
+      ->addOption('filter-warnings', 'w', InputOption::VALUE_NONE, 'Show warnings')
+      ->addOption('filter-errors', 'e', InputOption::VALUE_NONE, 'Show errors')
+      ->addOption('filter-infos', 'i', InputOption::VALUE_NONE, 'Show info')
+      ->configureSetupOptions()
+      ->setHelp('
+Check whether installation requirements are met.
+
+Example: Show all checks
+$ cv core:check-req
+
+Example: Show only errors
+$ cv core:check-req -e
+
+Example: Show warnings and errors
+$ cv core:check-req -we
+');
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $filterLevels = $this->parseFilter($input);
+
+    $showBootMsgsByDefault = in_array($input->getOption('out'), ['table', 'pretty']);
+    $setup = $this->bootSetupSubsystem($input, $output, $showBootMsgsByDefault ? 0 : OutputInterface::VERBOSITY_VERBOSE);
+    $reqs = $setup->checkRequirements();
+    $messages = array_filter($reqs->getMessages(), function ($m) use ($filterLevels) {
+      return in_array($m['level'], $filterLevels);
+    });
+    usort($messages, function($a, $b){
+      $nameCmp = strcmp($a['name'], $b['name']);
+      return $nameCmp;
+    });
+    $this->sendTable($input, $output, $messages, array('level', 'name', 'message'));
+    return $reqs->getErrors() ? 1 : 0;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return array
+   */
+  protected function parseFilter(InputInterface $input) {
+    $filterLevels = array();
+    if ($input->getOption('filter-warnings')) {
+      $filterLevels[] = 'warning';
+    }
+    if ($input->getOption('filter-errors')) {
+      $filterLevels[] = 'error';
+    }
+    if ($input->getOption('filter-infos')) {
+      $filterLevels[] = 'info';
+    }
+    if ($filterLevels === array()) {
+      $filterLevels = array('warning', 'error', 'info');
+      return $filterLevels;
+    }
+    return $filterLevels;
+  }
+
+}

--- a/src/Command/CoreCheckReqCommand.php
+++ b/src/Command/CoreCheckReqCommand.php
@@ -38,21 +38,21 @@ $ cv core:check-req -we
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $filterLevels = $this->parseFilter($input);
+    $filterSeverities = $this->parseFilter($input);
 
     $showBootMsgsByDefault = in_array($input->getOption('out'), ['table', 'pretty']);
     $setup = $this->bootSetupSubsystem($input, $output, $showBootMsgsByDefault ? 0 : OutputInterface::VERBOSITY_VERBOSE);
     $reqs = $setup->checkRequirements();
-    $messages = array_filter($reqs->getMessages(), function ($m) use ($filterLevels) {
-      return in_array($m['level'], $filterLevels);
+    $messages = array_filter($reqs->getMessages(), function ($m) use ($filterSeverities) {
+      return in_array($m['severity'], $filterSeverities);
     });
     uasort($messages, function ($a, $b) {
       return strcmp(
-        $a['level'] . '-' . $a['section'] . '-' . $a['name'],
-        $b['level'] . '-' . $b['section'] . '-' . $b['name']
+        $a['severity'] . '-' . $a['section'] . '-' . $a['name'],
+        $b['severity'] . '-' . $b['section'] . '-' . $b['name']
       );
     });
-    $this->sendTable($input, $output, $messages, array('level', 'section', 'name', 'message'));
+    $this->sendTable($input, $output, $messages, array('severity', 'section', 'name', 'message'));
     return $reqs->getErrors() ? 1 : 0;
   }
 
@@ -61,21 +61,20 @@ $ cv core:check-req -we
    * @return array
    */
   protected function parseFilter(InputInterface $input) {
-    $filterLevels = array();
+    $filterSeverities = array();
     if ($input->getOption('filter-warnings')) {
-      $filterLevels[] = 'warning';
+      $filterSeverities[] = 'warning';
     }
     if ($input->getOption('filter-errors')) {
-      $filterLevels[] = 'error';
+      $filterSeverities[] = 'error';
     }
     if ($input->getOption('filter-infos')) {
-      $filterLevels[] = 'info';
+      $filterSeverities[] = 'info';
     }
-    if ($filterLevels === array()) {
-      $filterLevels = array('warning', 'error', 'info');
-      return $filterLevels;
+    if ($filterSeverities === array()) {
+      $filterSeverities = array('warning', 'error', 'info');
     }
-    return $filterLevels;
+    return $filterSeverities;
   }
 
 }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -16,20 +16,29 @@ class CoreInstallCommand extends BaseCommand {
   protected function configure() {
     $this
       ->setName('core:install')
-      ->setDescription('Install CiviCRM schema and settings files')
+      ->setDescription('Initialize the CiviCRM data-files and database-schema')
       ->configureSetupOptions()
       ->addOption('abort', 'A', InputOption::VALUE_NONE, 'In the event of conflict, abort.')
       ->addOption('keep', 'K', InputOption::VALUE_NONE, 'In the event of conflict, keep existing files/tables.')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'In the event of conflict, overwrite existing files/tables.')
       ->addOption('debug-event', NULL, InputOption::VALUE_OPTIONAL, 'Display debug information about events and exit. Give an event name or regex.')
       ->setHelp('
-Install CiviCRM schema and settings files
+Initialize the CiviCRM data-files and database-schema
 
-Example: Install on a typical Drupal site. Autodetect settings.
+Example: Install on a basic WordPress build.
 $ cv core:install
+$ wp plugin activate civicrm
 
-Example: Install on a custom DB with an alternative language.
-$ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
+Example: Install on a basic Drupal 7 build.
+$ cv core:install --cms-base-url=http://example.com/
+$ drush -y en civicrm
+
+Example: Install on WordPress with a custom language and database.
+$ cv core:install --lang=fr_FR --db=mysql://user:pass@host:3306/database
+$ wp plugin activate civicrm
+
+Example: Forcibly reinstall/overwrite. Display verbose debug info.
+$ cv core:install -f -vv
 ');
     $this->configureBootOptions();
   }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -21,7 +21,6 @@ class CoreInstallCommand extends BaseCommand {
       ->addOption('abort', 'A', InputOption::VALUE_NONE, 'In the event of conflict, abort.')
       ->addOption('keep', 'K', InputOption::VALUE_NONE, 'In the event of conflict, keep existing files/tables.')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'In the event of conflict, overwrite existing files/tables.')
-      ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (auto,' . implode(',', Encoder::getFormats()) . ')', Encoder::getDefaultFormat())
       ->addOption('debug-event', NULL, InputOption::VALUE_OPTIONAL, 'Display debug information about events and exit. Give an event name or regex.')
       ->setHelp('
 Install CiviCRM schema and settings files
@@ -46,9 +45,9 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
     }
 
     $this->runSetup($input, $output, $setup);
-    $this->sendResult($input, $output, [
-      'model' => $setup->getModel()->getValues()
-    ]);
+    if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+      $output->writeln(Encoder::encode($setup->getModel()->getValues(), 'json-pretty'));
+    }
   }
 
   /**
@@ -124,15 +123,15 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
       $setup->installSettings();
     }
     else {
-      $output->writeln(sprintf("<info>Found existing file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+      $output->writeln(sprintf("<info>Found existing <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
       switch ($this->pickConflictAction($input, $output, 'civicrm.settings.php')) {
         case 'abort':
           throw new \Exception("Aborted");
 
         case 'overwrite':
-          $output->writeln(sprintf("<info>Removing file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+          $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
           $setup->removeSettings();
-          $output->writeln(sprintf("<info>Creating file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+          $output->writeln(sprintf("<info>Creating <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
           $setup->installSettings();
           break;
 

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -8,14 +8,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
-class SetupCommand extends BaseCommand {
+class CoreInstallCommand extends BaseCommand {
 
   use \Civi\Cv\Util\SetupCommandTrait;
   use \Civi\Cv\Util\DebugDispatcherTrait;
 
   protected function configure() {
     $this
-      ->setName('core:setup')
+      ->setName('core:install')
       ->setDescription('Install CiviCRM schema and settings files')
       ->configureSetupOptions()
       ->addOption('abort', 'A', InputOption::VALUE_NONE, 'In the event of conflict, abort.')
@@ -27,10 +27,10 @@ class SetupCommand extends BaseCommand {
 Install CiviCRM schema and settings files
 
 Example: Install on a typical Drupal site. Autodetect settings.
-$ cv core:setup
+$ cv core:install
 
 Example: Install on a custom DB with an alternative language.
-$ cv core:setup --db=mysql://user:pass@host:3306/database --lang=fr_FR
+$ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
 ');
     $this->configureBootOptions();
   }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -120,7 +120,7 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
     $installed = $setup->checkInstalled();
     if (!$installed->isSettingInstalled()) {
       $output->writeln(sprintf("<info>Creating file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
-      $setup->installSettings();
+      $setup->installFiles();
     }
     else {
       $output->writeln(sprintf("<info>Found existing <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
@@ -130,9 +130,9 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
 
         case 'overwrite':
           $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
-          $setup->removeSettings();
+          $setup->uninstallFiles();
           $output->writeln(sprintf("<info>Creating <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
-          $setup->installSettings();
+          $setup->installFiles();
           break;
 
         case 'keep':
@@ -145,7 +145,7 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
 
     if (!$installed->isDatabaseInstalled()) {
       $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
-      $setup->installSchema();
+      $setup->installDatabase();
     }
     else {
       $output->writeln(sprintf("<info>Found existing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
@@ -155,9 +155,9 @@ $ cv core:install --db=mysql://user:pass@host:3306/database --lang=fr_FR
 
         case 'overwrite':
           $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
-          $setup->removeSchema();
+          $setup->uninstallDatabase();
           $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
-          $setup->installSchema();
+          $setup->installDatabase();
           break;
 
         case 'keep':

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -43,6 +43,10 @@ $ cv core:install -f -vv
 
 Example: Inspect the installer events+plugins
 $ cv core:install --debug-event
+
+Example: Install while setting a hidden option
+$ cv core:install --model=extras.opt-in.versionCheck=1
+$ cv core:install -m extras.opt-in.versionCheck=1
 ');
     $this->configureBootOptions();
   }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -39,6 +39,9 @@ $ wp plugin activate civicrm
 
 Example: Forcibly reinstall/overwrite. Display verbose debug info.
 $ cv core:install -f -vv
+
+Example: Inspect the installer events+plugins
+$ cv core:install --debug-event
 ');
     $this->configureBootOptions();
   }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -128,19 +128,19 @@ $ cv core:install -f -vv
     // Install!
     $installed = $setup->checkInstalled();
     if (!$installed->isSettingInstalled()) {
-      $output->writeln(sprintf("<info>Creating file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+      $output->writeln(sprintf("<info>Creating file <comment>%s</comment></info>", $setup->getModel()->settingsPath));
       $setup->installFiles();
     }
     else {
-      $output->writeln(sprintf("<info>Found existing <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+      $output->writeln(sprintf("<info>Found existing <comment>%s</comment> in <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
       switch ($this->pickConflictAction($input, $output, 'civicrm.settings.php')) {
         case 'abort':
           throw new \Exception("Aborted");
 
         case 'overwrite':
-          $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+          $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
           $setup->uninstallFiles();
-          $output->writeln(sprintf("<info>Creating <comment>%s</comment> in <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+          $output->writeln(sprintf("<info>Creating <comment>%s</comment> in <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
           $setup->installFiles();
           break;
 
@@ -153,19 +153,19 @@ $ cv core:install -f -vv
     }
 
     if (!$installed->isDatabaseInstalled()) {
-      $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
       $setup->installDatabase();
     }
     else {
-      $output->writeln(sprintf("<info>Found existing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      $output->writeln(sprintf("<info>Found existing <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
       switch ($this->pickConflictAction($input, $output, 'database tables')) {
         case 'abort':
           throw new \Exception("Aborted");
 
         case 'overwrite':
-          $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+          $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
           $setup->uninstallDatabase();
-          $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+          $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
           $setup->installDatabase();
           break;
 

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -136,10 +136,13 @@ $ cv core:install -m extras.opt-in.versionCheck=1
   protected function runSetup(InputInterface $input, OutputInterface $output, $setup) {
     // Validate system requirements
     $reqs = $setup->checkRequirements();
+    foreach ($reqs->getWarnings() as $msg) {
+      $output->writeln(sprintf("<comment>WARNING: (<info>%s</info>) %s:</comment> %s", $msg['section'], $msg['name'], $msg['message']));
+    }
     $errors = $reqs->getErrors();
     if ($errors) {
       foreach ($errors as $msg) {
-        $output->writeln(sprintf("<error>(%s) %s</error>", $msg['name'], $msg['message']));
+        $output->writeln(sprintf("<error>ERROR: (%s) %s:</error> %s", $msg['section'], $msg['name'], $msg['message']));
       }
       throw new \Exception('Requirements check failed.');
     }

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -88,9 +88,9 @@ $ cv core:install -f -vv
     $question = new ChoiceQuestion(
       "The $title already exists. What you like to do?",
       array(
-        'a' => "Abort (default).",
-        'k' => "Keep existing $title. (WARNING: This may fail if the existing version is out-of-date.)",
-        'o' => "Overwrite with new $title. (WARNING: This may destroy data.)",
+        'a' => "Abort. (Default.) (Equivalent to -A.)",
+        'k' => "Keep existing $title. (WARNING: This may fail if the existing version is out-of-date.) (Equivalent to -K.)",
+        'o' => "Overwrite with new $title. (WARNING: This may destroy data.) (Equivalent to -f.)",
       ),
       'a'
     );

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -22,6 +22,7 @@ class CoreInstallCommand extends BaseCommand {
       ->addOption('keep', 'K', InputOption::VALUE_NONE, 'In the event of conflict, keep existing files/tables.')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'In the event of conflict, overwrite existing files/tables.')
       ->addOption('debug-event', NULL, InputOption::VALUE_OPTIONAL, 'Display debug information about events and exit. Give an event name or regex.')
+      ->addOption('debug-model', NULL, InputOption::VALUE_NONE, 'Display debug information about model and exit.')
       ->setHelp('
 Initialize the CiviCRM data-files and database-schema
 
@@ -49,10 +50,21 @@ $ cv core:install --debug-event
   protected function execute(InputInterface $input, OutputInterface $output) {
     $setup = $this->bootSetupSubsystem($input, $output);
 
+    $debugMode = FALSE;
+
     $debugEvent = $this->parseOptionalOption($input, ['--debug-event'], NULL, '');
     if ($debugEvent !== NULL) {
       $eventNames = $this->findEventNames($setup->getDispatcher(), $debugEvent);
       $this->printEventListeners($output, $setup->getDispatcher(), $eventNames);
+      $debugMode = TRUE;
+    }
+
+    if ($input->getOption('debug-model')) {
+      $output->writeln(Encoder::encode($setup->getModel()->getValues(), 'json-pretty'));
+      $debugMode = 1;
+    }
+
+    if ($debugMode) {
       return 0;
     }
 

--- a/src/Command/CoreUninstallCommand.php
+++ b/src/Command/CoreUninstallCommand.php
@@ -1,0 +1,68 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Encoder;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class CoreUninstallCommand extends BaseCommand {
+
+  use \Civi\Cv\Util\SetupCommandTrait;
+  use \Civi\Cv\Util\DebugDispatcherTrait;
+
+  protected function configure() {
+    $this
+      ->setName('core:uninstall')
+      ->setDescription('Purge CiviCRM schema and settings files')
+      ->configureSetupOptions()
+      ->addOption('force', 'f', InputOption::VALUE_NONE, 'Remove without any prompt or confirmation')
+      ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (auto,' . implode(',', Encoder::getFormats()) . ')', Encoder::getDefaultFormat())
+      ->setHelp('
+Purge CiviCRM schema and settings files
+
+TIP: If you have a special system configuration, it may help to pass the same
+options for "core:uninstall" as the preceding "core:install".
+');
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $setup = $this->bootSetupSubsystem($input, $output);
+
+    $debugEvent = $this->parseOptionalOption($input, ['--debug-event'], NULL, '');
+    if ($debugEvent !== NULL) {
+      $eventNames = $this->findEventNames($setup->getDispatcher(), $debugEvent);
+      $this->printEventListeners($output, $setup->getDispatcher(), $eventNames);
+      return 0;
+    }
+
+    $installed = $setup->checkInstalled();
+    if (!$installed->isDatabaseInstalled() && !$installed->isSettingInstalled()) {
+      $output->writeln("<comment>CiviCRM does not appear to be installed.</comment>");
+      return 0;
+    }
+
+    if (!$input->getOption('force')) {
+      $helper = $this->getHelper('question');
+      $question = new ConfirmationQuestion('<comment>Are you sure want to purge CiviCRM schema and settings? Data may be permanently destroyed.</comment> (y/N) ', FALSE);
+      if (!$helper->ask($input, $output, $question)) {
+        return 1;
+      }
+    }
+
+    if ($installed->isDatabaseInstalled()) {
+      $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      $setup->removeSchema();
+    }
+
+    if ($installed->isSettingInstalled()) {
+      $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+      $setup->removeSettings();
+    }
+  }
+
+}

--- a/src/Command/CoreUninstallCommand.php
+++ b/src/Command/CoreUninstallCommand.php
@@ -56,12 +56,12 @@ options for "core:uninstall" as the preceding "core:install".
 
     if ($installed->isDatabaseInstalled()) {
       $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
-      $setup->removeSchema();
+      $setup->uninstallDatabase();
     }
 
     if ($installed->isSettingInstalled()) {
       $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
-      $setup->removeSettings();
+      $setup->uninstallFiles();
     }
   }
 

--- a/src/Command/CoreUninstallCommand.php
+++ b/src/Command/CoreUninstallCommand.php
@@ -55,12 +55,12 @@ options for "core:uninstall" as the preceding "core:install".
     }
 
     if ($installed->isDatabaseInstalled()) {
-      $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
       $setup->uninstallDatabase();
     }
 
     if ($installed->isSettingInstalled()) {
-      $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment>.</info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+      $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
       $setup->uninstallFiles();
     }
   }

--- a/src/Command/CoreUninstallCommand.php
+++ b/src/Command/CoreUninstallCommand.php
@@ -46,10 +46,20 @@ options for "core:uninstall" as the preceding "core:install".
       return 0;
     }
 
+    if ($installed->isDatabaseInstalled()) {
+      $output->writeln(sprintf("<info>Found <comment>civicrm_*</comment> database tables in <comment>%s</comment></info>", $setup->getModel()->db['database']));
+    }
+
+    if ($installed->isSettingInstalled()) {
+      $output->writeln(sprintf("<info>Found <comment>%s</comment> in <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
+    }
+
     if (!$input->getOption('force')) {
+      $output->writeln('');
       $helper = $this->getHelper('question');
-      $question = new ConfirmationQuestion('<comment>Are you sure want to purge CiviCRM schema and settings? Data may be permanently destroyed.</comment> (y/N) ', FALSE);
+      $question = new ConfirmationQuestion('<comment>Are you sure want to purge the CiviCRM database and data files? Data may be permanently destroyed.</comment> (y/N) ', FALSE);
       if (!$helper->ask($input, $output, $question)) {
+        $output->writeln("<comment>Aborted</comment>");
         return 1;
       }
     }

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugContainerCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('debug:container')
@@ -17,7 +19,7 @@ class DebugContainerCommand extends BaseCommand {
       ->setHelp('
 Dump the container configuration
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/DebugDispatcherCommand.php
+++ b/src/Command/DebugDispatcherCommand.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugDispatcherCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('debug:event-dispatcher')
@@ -21,7 +23,7 @@ Examples:
   cv debug:event-dispatcher actionSchedule.getMappings
   cv debug:event-dispatcher /^actionSchedule/
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/DebugDispatcherCommand.php
+++ b/src/Command/DebugDispatcherCommand.php
@@ -1,7 +1,6 @@
 <?php
 namespace Civi\Cv\Command;
 
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,57 +45,12 @@ Examples:
       $container->get('civi_api_kernel');
     }
 
-    $d = $container->get('dispatcher');
-
+    $dispatcher = $container->get('dispatcher');
     $eventFilter = $input->getArgument('event');
-    if (!$eventFilter) {
-      $listenersByEvent = $d->getListeners();
-    }
-    elseif ($eventFilter{0} === '/') {
-      $listenersByEvent = array();
-      foreach ($d->getListeners() as $e => $ls) {
-        if (preg_match($eventFilter, $e)) {
-          $listenersByEvent[$e] = $ls;
-        }
-      }
-    }
-    else {
-      $listenersByEvent = array($eventFilter => $d->getListeners($eventFilter));
-    }
-
-    ksort($listenersByEvent);
-    foreach ($listenersByEvent as $event => $rawListeners) {
-      $rows = array();
-      $i = 0;
-      foreach ($d->getListeners($event) as $listener) {
-        $handled = FALSE;
-        if (is_array($listener)) {
-          list ($a, $b) = $listener;
-          if (is_object($a)) {
-            $rows[] = array('#' . ++$i, get_class($a) . "->$b()");
-            $handled = TRUE;
-          }
-          elseif (is_string($a)) {
-            $rows[] = array('#' . ++$i, "$a::$b()");
-            $handled = TRUE;
-          }
-        }
-        elseif (is_string($listener)) {
-          $rows[] = array('#' . ++$i, $listener);
-          $handled = TRUE;
-        }
-        if (!$handled) {
-          $rows[] = array('#' . ++$i, "unidentified");
-        }
-      }
-
-      $output->writeln("<info>[Event]</info> $event");
-      $table = new Table($output);
-      $table->setHeaders(array('Order', 'Callable'));
-      $table->addRows($rows);
-      $table->render();
-      $output->writeln("");
-    }
+    $eventNames = $this->findEventNames($dispatcher, $eventFilter);
+    $this->printEventListeners($output, $dispatcher, $eventNames);
   }
+
+  use \Civi\Cv\Util\DebugDispatcherTrait;
 
 }

--- a/src/Command/EditCommand.php
+++ b/src/Command/EditCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EditCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   /**
    * @var \Civi\Cv\Util\CliEditor
    */
@@ -28,7 +30,7 @@ class EditCommand extends BaseCommand {
     $this
       ->setName('vars:edit')
       ->setDescription('Edit configuration values for this build');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   public function __construct($name = NULL) {
@@ -40,7 +42,7 @@ class EditCommand extends BaseCommand {
       if ($data === NULL) {
         return array(
           FALSE,
-          '// The JSON document was malformed. Please resolve syntax errors and then remove this message.'
+          '// The JSON document was malformed. Please resolve syntax errors and then remove this message.',
         );
       }
       else {
@@ -60,10 +62,10 @@ class EditCommand extends BaseCommand {
 
     print "NEW DATA\n\n====\n$newJson\n====\n";
 
-//    Config::update(function ($config) use ($newSiteData) {
-//      $config['sites'][CIVICRM_SETTINGS_PATH] = $newSiteData;
-//      return $config;
-//    });
+    //    Config::update(function ($config) use ($newSiteData) {
+    //      $config['sites'][CIVICRM_SETTINGS_PATH] = $newSiteData;
+    //      return $config;
+    //    });
   }
 
 }

--- a/src/Command/EvalCommand.php
+++ b/src/Command/EvalCommand.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EvalCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('php:eval')
@@ -35,7 +37,7 @@ you use a "return" statement. In that case, it will use the default (' . \Civi\C
 
 NOTE: To change the default output format, set CV_OUTPUT.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionDisableCommand.php
+++ b/src/Command/ExtensionDisableCommand.php
@@ -39,7 +39,7 @@ Note:
   This subcommand does not output parseable data. For parseable output,
   consider using `cv api extension.disable`.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -61,7 +61,7 @@ Note:
   consider using `cv api extension.install`.
 ');
     parent::configureRepoOptions();
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function initialize(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionEnableCommand.php
+++ b/src/Command/ExtensionEnableCommand.php
@@ -40,7 +40,7 @@ Note:
   This subcommand does not output parseable data. For parseable output,
   consider using `cv api extension.install`.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -50,7 +50,7 @@ Note:
   name ("foobar"). However, short names are not strongly guaranteed.
 ');
     parent::configureRepoOptions();
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionUninstallCommand.php
+++ b/src/Command/ExtensionUninstallCommand.php
@@ -39,7 +39,7 @@ Note:
   This subcommand does not output parseable data. For parseable output,
   consider using `cv api extension.uninstall`.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ExtensionUpgradeDbCommand.php
+++ b/src/Command/ExtensionUpgradeDbCommand.php
@@ -33,7 +33,7 @@ Note:
   This subcommand does not output parseable data. For parseable output,
   consider using `cv api extension.upgrade`.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/FillCommand.php
+++ b/src/Command/FillCommand.php
@@ -16,15 +16,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class FillCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected $fields;
 
   protected function configure() {
     $this
       ->setName('vars:fill')
       ->setDescription('Generate a configuration file for any missing site data')
-      ->addOption('file', NULL, InputOption::VALUE_REQUIRED, 'Read existing configuration from a file')
-    ;
-    parent::configureBootOptions();
+      ->addOption('file', NULL, InputOption::VALUE_REQUIRED, 'Read existing configuration from a file');
+    $this->configureBootOptions();
   }
 
   public function __construct($name = NULL) {

--- a/src/Command/FlushCommand.php
+++ b/src/Command/FlushCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class FlushCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('flush')
@@ -19,7 +21,7 @@ class FlushCommand extends BaseCommand {
       ->setHelp('
 Flush system caches
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -58,7 +58,7 @@ Examples: Lookup dynamic paths
 Example: Lookup multiple items
   cv path -x cividiscount/info.xml -x flexmailer/info.xml -d \'[civicrm.root]/civicrm-version.php\'
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -9,13 +9,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ScriptCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('php:script')
       ->setAliases(array('scr'))
       ->setDescription('Execute a PHP script')
       ->addArgument('script', InputArgument::REQUIRED);
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/SetupCommand.php
+++ b/src/Command/SetupCommand.php
@@ -1,0 +1,173 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Encoder;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+class SetupCommand extends BaseCommand {
+
+  use \Civi\Cv\Util\SetupCommandTrait;
+  use \Civi\Cv\Util\DebugDispatcherTrait;
+
+  protected function configure() {
+    $this
+      ->setName('core:setup')
+      ->setDescription('Install CiviCRM schema and settings files')
+      ->configureSetupOptions()
+      ->addOption('abort', 'A', InputOption::VALUE_NONE, 'In the event of conflict, abort.')
+      ->addOption('keep', 'K', InputOption::VALUE_NONE, 'In the event of conflict, keep existing files/tables.')
+      ->addOption('force', 'f', InputOption::VALUE_NONE, 'In the event of conflict, overwrite existing files/tables.')
+      ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (auto,' . implode(',', Encoder::getFormats()) . ')', Encoder::getDefaultFormat())
+      ->addOption('debug-event', NULL, InputOption::VALUE_OPTIONAL, 'Display debug information about events and exit. Give an event name or regex.')
+      ->setHelp('
+Install CiviCRM schema and settings files
+
+Example: Install on a typical Drupal site. Autodetect settings.
+$ cv core:setup
+
+Example: Install on a custom DB with an alternative language.
+$ cv core:setup --db=mysql://user:pass@host:3306/database --lang=fr_FR
+');
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $setup = $this->bootSetupSubsystem($input, $output);
+
+    $debugEvent = $this->parseOptionalOption($input, ['--debug-event'], NULL, '');
+    if ($debugEvent !== NULL) {
+      $eventNames = $this->findEventNames($setup->getDispatcher(), $debugEvent);
+      $this->printEventListeners($output, $setup->getDispatcher(), $eventNames);
+      return 0;
+    }
+
+    $this->runSetup($input, $output, $setup);
+    $this->sendResult($input, $output, [
+      'model' => $setup->getModel()->getValues()
+    ]);
+  }
+
+  /**
+   * Determine what action to take to resolve a conflict.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param string $title
+   *   The thing which had a conflict.
+   * @return string
+   *   Ex: 'abort', 'keep', 'overwrite'.
+   */
+  protected function pickConflictAction(
+    InputInterface $input,
+    OutputInterface $output,
+    $title
+  ) {
+    if ($input->getOption('abort')) {
+      return 'abort';
+    }
+    if ($input->getOption('keep')) {
+      return 'keep';
+    }
+    if ($input->getOption('force')) {
+      return 'overwrite';
+    }
+
+    $helper = $this->getHelper('question');
+    $question = new ChoiceQuestion(
+      "The $title already exists. What you like to do?",
+      array(
+        'a' => "Abort (default).",
+        'k' => "Keep existing $title. (WARNING: This may fail if the existing version is out-of-date.)",
+        'o' => "Overwrite with new $title. (WARNING: This may destroy data.)",
+      ),
+      'a'
+    );
+    switch ($helper->ask($input, $output, $question)) {
+      case 'k':
+        return 'keep';
+
+      case 'o':
+        return 'overwrite';
+
+      case 'a':
+      default:
+        return 'abort';
+    }
+  }
+
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param $setup
+   * @throws \Exception
+   */
+  protected function runSetup(InputInterface $input, OutputInterface $output, $setup) {
+    // Validate system requirements
+    $reqs = $setup->checkRequirements();
+    $errors = $reqs->getErrors();
+    if ($errors) {
+      foreach ($errors as $msg) {
+        $output->writeln(sprintf("<error>(%s) %s</error>", $msg['name'], $msg['message']));
+      }
+      throw new \Exception('Requirements check failed.');
+    }
+
+    // Install!
+    $installed = $setup->checkInstalled();
+    if (!$installed->isSettingInstalled()) {
+      $output->writeln(sprintf("<info>Creating file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+      $setup->installSettings();
+    }
+    else {
+      $output->writeln(sprintf("<info>Found existing file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+      switch ($this->pickConflictAction($input, $output, 'civicrm.settings.php')) {
+        case 'abort':
+          throw new \Exception("Aborted");
+
+        case 'overwrite':
+          $output->writeln(sprintf("<info>Removing file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+          $setup->removeSettings();
+          $output->writeln(sprintf("<info>Creating file <comment>%s</comment>.</info>", $setup->getModel()->settingsPath));
+          $setup->installSettings();
+          break;
+
+        case 'keep':
+          break;
+
+        default:
+          throw new \Exception("Unrecognized action");
+      }
+    }
+
+    if (!$installed->isDatabaseInstalled()) {
+      $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      $setup->installSchema();
+    }
+    else {
+      $output->writeln(sprintf("<info>Found existing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+      switch ($this->pickConflictAction($input, $output, 'database tables')) {
+        case 'abort':
+          throw new \Exception("Aborted");
+
+        case 'overwrite':
+          $output->writeln(sprintf("<info>Removing <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+          $setup->removeSchema();
+          $output->writeln(sprintf("<info>Creating <comment>civicrm_*</comment> database tables in <comment>%s</comment>.</info>", $setup->getModel()->db['database']));
+          $setup->installSchema();
+          break;
+
+        case 'keep':
+          break;
+
+        default:
+          throw new \Exception("Unrecognized action");
+      }
+    }
+  }
+
+}

--- a/src/Command/ShowCommand.php
+++ b/src/Command/ShowCommand.php
@@ -9,12 +9,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowCommand extends BaseCommand {
 
+  use \Civi\Cv\Util\BootTrait;
+
   protected function configure() {
     $this
       ->setName('vars:show')
       ->setDescription('Show the configuration of the local CiviCRM installation')
       ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', Encoder::getFormats()) . ')', Encoder::getDefaultFormat());
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Command/UrlCommand.php
+++ b/src/Command/UrlCommand.php
@@ -59,7 +59,7 @@ Examples: Lookup multiple URLs
 
 NOTE: To change the default output format, set CV_OUTPUT.
 ');
-    parent::configureBootOptions();
+    $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -28,6 +28,28 @@ class ArrayUtil {
   }
 
   /**
+   * Set a single value in an array tree.
+   *
+   * @param array $arr
+   *   Ex: array('foo'=>array('bar'=>123)).
+   * @param array $pathParts
+   *   Ex: array('foo',bar').
+   * @param $value
+   *   Ex: 456.
+   */
+  public static function pathSet(&$arr, $pathParts, $value) {
+    $r = &$arr;
+    $last = array_pop($pathParts);
+    foreach ($pathParts as $part) {
+      if (!isset($r[$part])) {
+        $r[$part] = array();
+      }
+      $r = &$r[$part];
+    }
+    $r[$last] = $value;
+  }
+
+  /**
    * Convert a list of records from associative-arrays to numeric-arrays.
    *
    * @param array $records

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -99,11 +99,12 @@ class ArrayUtil {
    * Grab the first non-empty-ish value.
    *
    * @param array $values
+   * @param callable|NULL $filter
    * @return mixed|NULL
    */
-  public static function pickFirst($values) {
+  public static function pickFirst($values, $filter = NULL) {
     foreach ($values as $value) {
-      if ($value) {
+      if (($filter !== NULL && $filter($value)) || ($filter === NULL && $value)) {
         return $value;
       }
     }

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -1,0 +1,135 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Civi\Cv\Encoder;
+use Civi\Cv\Json;
+use Civi\Cv\SiteConfigReader;
+use Civi\Cv\Util\ArrayUtil;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This trait can be mixed into a Symfony `Command` to provide Civi/CMS-bootstrap options.
+ *
+ * It first boots Civi and then boots the CMS.
+ */
+trait BootTrait {
+
+  public function configureBootOptions() {
+    $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full)', 'full');
+    $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
+    $this->addOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user');
+  }
+
+  public function boot(InputInterface $input, OutputInterface $output) {
+    if ($output->isDebug()) {
+      $output->writeln(
+        'Attempting to set verbose error reporting',
+        OutputInterface::VERBOSITY_DEBUG);
+      // standard php debug chat settings
+      error_reporting(E_ALL | E_STRICT);
+      ini_set('display_errors', TRUE);
+      ini_set('display_startup_errors', TRUE);
+      // add the output object to allow the bootstrapper to output debug messages
+      // and track verboisty
+      $boot_params = array(
+        'output' => $output,
+      );
+    }
+    else {
+      $boot_params = array();
+    }
+
+    $output->writeln('<info>[BaseCommand::boot]</info> Start', OutputInterface::VERBOSITY_DEBUG);
+
+    if ($input->hasOption('test') && $input->getOption('test')) {
+      $output->writeln('<info>[BaseCommand::boot]</info> Use test mode', OutputInterface::VERBOSITY_DEBUG);
+      putenv('CIVICRM_UF=UnitTests');
+      $_ENV['CIVICRM_UF'] = 'UnitTests';
+    }
+
+    if ($input->hasOption('level') && $input->getOption('level') === 'none') {
+      $output->writeln('<info>[BaseCommand::boot]</info> Skip', OutputInterface::VERBOSITY_DEBUG);
+      return;
+    }
+    elseif ($input->hasOption('level') && $input->getOption('level') !== 'full') {
+      $output->writeln('<info>[BaseCommand::boot]</info> Call basic cv bootstrap (' . $input->getOption('level') . ')', OutputInterface::VERBOSITY_DEBUG);
+      \Civi\Cv\Bootstrap::singleton()->boot($boot_params + array(
+          'prefetch' => FALSE,
+        ));
+    }
+    else {
+      $output->writeln('<info>[BaseCommand::boot]</info> Call standard cv bootstrap', OutputInterface::VERBOSITY_DEBUG);
+      \Civi\Cv\Bootstrap::singleton()->boot($boot_params);
+
+      $output->writeln('<info>[BaseCommand::boot]</info> Call core bootstrap', OutputInterface::VERBOSITY_DEBUG);
+      \CRM_Core_Config::singleton();
+
+      $output->writeln('<info>[BaseCommand::boot]</info> Call CMS bootstrap', OutputInterface::VERBOSITY_DEBUG);
+      \CRM_Utils_System::loadBootStrap(array(), FALSE);
+
+      if ($input->getOption('user')) {
+        $output->writeln('<info>[BaseCommand::boot]</info> Set system user', OutputInterface::VERBOSITY_DEBUG);
+        if (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
+          \CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user'));
+          if (!$this->ensureUserContact($output)) {
+            throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
+          }
+        }
+        else {
+          $output->getErrorOutput()->writeln("<error>Failed to set user. Feature not supported by UF (" . CIVICRM_UF . ")</error>");
+        }
+      }
+    }
+
+    $output->writeln('<info>[BaseCommand::boot]</info> Finished', OutputInterface::VERBOSITY_DEBUG);
+  }
+
+  /**
+   * Ensure that the current user has a contact record.
+   *
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return int|NULL
+   *   The user's contact ID, or NULL
+   */
+  public function ensureUserContact(OutputInterface $output) {
+    if ($cid = \CRM_Core_Session::getLoggedInContactID()) {
+      return $cid;
+    }
+
+    // Ugh, this codepath is ridiculous.
+    switch (CIVICRM_UF) {
+      case 'Drupal':
+      case 'Drupal6':
+      case 'Backdrop':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['user'], TRUE,
+          CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Drupal8':
+        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE,
+          CIVICRM_UF, 'Individual');
+        break;
+
+      case 'Joomla':
+        \CRM_Core_BAO_UFMatch::synchronize(\JFactory::getUser(), TRUE,
+          CIVICRM_UF, 'Individual');
+        break;
+
+      case 'WordPress':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['current_user'], TRUE,
+          CIVICRM_UF, 'Individual');
+        break;
+
+      default:
+        $output->writeln("<error>Unrecognized UF: " . CIVICRM_UF . "</error>");
+    }
+
+    return \CRM_Core_Session::getLoggedInContactID();
+  }
+
+}

--- a/src/Util/CmsBootTrait.php
+++ b/src/Util/CmsBootTrait.php
@@ -1,0 +1,106 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Civi\Cv\Encoder;
+use Civi\Cv\Json;
+use Civi\Cv\SiteConfigReader;
+use Civi\Cv\Util\ArrayUtil;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This trait can be mixed into a Symfony `Command` to provide Civi/CMS-bootstrap options.
+ *
+ * It first boots the CMS and then boots Civi.
+ */
+trait CmsBootTrait {
+
+  protected function configureBootOptions() {
+    // TODO $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full)', 'full');
+    // TODO $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
+    $this->addOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user');
+  }
+
+  private $bootstrap;
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return \Civi\Cv\CmsBootstrap
+   */
+  protected function boot(InputInterface $input, OutputInterface $output) {
+    $output->writeln('<info>[CmsBootTrait]</info> Start', OutputInterface::VERBOSITY_DEBUG);
+    $this->bootCms($input, $output);
+    $this->bootCivi($input, $output);
+    $output->writeln('<info>[CmsBootTrait]</info> Finished', OutputInterface::VERBOSITY_DEBUG);
+
+    return $this->getBootstrap($input, $output);
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return \Civi\Cv\CmsBootstrap
+   */
+  protected function bootCms(InputInterface $input, OutputInterface $output) {
+    $bootstrap = $this->getBootstrap($input, $output);
+    $output->writeln('<info>[CmsBootTrait]</info> Call CMS bootstrap', OutputInterface::VERBOSITY_DEBUG);
+    $bootstrap->bootCms();
+
+    return $bootstrap;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return \Civi\Cv\CmsBootstrap
+   */
+  protected function bootCivi(InputInterface $input, OutputInterface $output) {
+    $bootstrap = $this->getBootstrap($input, $output);
+    $output->writeln('<info>[CmsBootTrait]</info> Call Civi bootstrap', OutputInterface::VERBOSITY_DEBUG);
+    $bootstrap->bootCivi();
+
+    return $bootstrap;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return \Civi\Cv\CmsBootstrap
+   */
+  protected function getBootstrap(InputInterface $input, OutputInterface $output) {
+    if ($this->bootstrap) {
+      return $this->bootstrap;
+    }
+
+    if ($output->isDebug()) {
+      $output->writeln(
+        'Attempting to set verbose error reporting',
+        OutputInterface::VERBOSITY_DEBUG);
+      // standard php debug chat settings
+      error_reporting(E_ALL | E_STRICT);
+      ini_set('display_errors', TRUE);
+      ini_set('display_startup_errors', TRUE);
+      // add the output object to allow the bootstrapper to output debug messages
+      // and track verboisty
+      $boot_params = array(
+        'output' => $output,
+      );
+    }
+    else {
+      $boot_params = array();
+    }
+
+    if ($input->getOption('user')) {
+      $boot_params['user'] = $input->getOption('user');
+    }
+
+    $this->bootstrap = \Civi\Cv\CmsBootstrap::singleton()->addOptions($boot_params);
+    return $this->bootstrap;
+  }
+
+}

--- a/src/Util/DebugDispatcherTrait.php
+++ b/src/Util/DebugDispatcherTrait.php
@@ -62,11 +62,23 @@ trait DebugDispatcherTrait {
             $handled = TRUE;
           }
         }
+        elseif (is_string($listener)) {
+          $handled = TRUE;
+          $rows[] = array('#' . ++$i, $listener . '()');
+        }
+        else {
+          $f = new \ReflectionFunction($listener);
+          $rows[] = array(
+            '#' . ++$i,
+            'closure(' . $f->getFileName() . '@' . $f->getStartLine() . ')',
+          );
+          $handled = TRUE;
+        }
+
         if (!$handled) {
           $rows[] = array('#' . ++$i, "unidentified");
         }
       }
-
       $output->writeln("<info>[Event]</info> $event");
       $table = new Table($output);
       $table->setHeaders(array('Order', 'Callable'));

--- a/src/Util/DebugDispatcherTrait.php
+++ b/src/Util/DebugDispatcherTrait.php
@@ -1,0 +1,79 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait DebugDispatcherTrait {
+
+  /**
+   * Extract the full list of available event names.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+   * @param string $eventFilter
+   *   Filter the list of events by name. This can be:
+   *   - Exact name, e.g. 'hook_civicrm_foo'
+   *   - Regex, e.g. '/^hook_/'
+   * @return array
+   *   Ex: array('hook_civicrm_fo', 'hook_civicrm_bar')
+   */
+  public function findEventNames($dispatcher, $eventFilter) {
+    if (!$eventFilter) {
+      $listenersByEvent = $dispatcher->getListeners();
+    }
+    elseif ($eventFilter{0} === '/') {
+      $listenersByEvent = array();
+      foreach ($dispatcher->getListeners() as $e => $ls) {
+        if (preg_match($eventFilter, $e)) {
+          $listenersByEvent[$e] = $ls;
+        }
+      }
+    }
+    else {
+      $listenersByEvent = array($eventFilter => $dispatcher->getListeners($eventFilter));
+    }
+
+    $eventNames = array_keys($listenersByEvent);
+    sort($eventNames);
+    return $eventNames;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+   * @param array $eventNames
+   */
+  public function printEventListeners(OutputInterface $output, $dispatcher, $eventNames) {
+    foreach ($eventNames as $event) {
+      $rows = array();
+      $i = 0;
+      foreach ($dispatcher->getListeners($event) as $listener) {
+        $handled = FALSE;
+        if (is_array($listener)) {
+          list ($a, $b) = $listener;
+          if (is_object($a)) {
+            $rows[] = array('#' . ++$i, get_class($a) . "->$b()");
+            $handled = TRUE;
+          }
+          elseif (is_string($a)) {
+            $rows[] = array('#' . ++$i, "$a::$b()");
+            $handled = TRUE;
+          }
+        }
+        if (!$handled) {
+          $rows[] = array('#' . ++$i, "unidentified");
+        }
+      }
+
+      $output->writeln("<info>[Event]</info> $event");
+      $table = new Table($output);
+      $table->setHeaders(array('Order', 'Callable'));
+      $table->addRows($rows);
+      $table->render();
+      $output->writeln("");
+    }
+  }
+
+}

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -1,0 +1,138 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Civi\Setup\DbUtil;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This trait can be mixed into a Symfony `Command` to take advantage of the
+ * civicrm-setup framework.
+ */
+trait SetupCommandTrait {
+  use \Civi\Cv\Util\CmsBootTrait;
+
+  /**
+   * Register any CLI options which affect the initialization of the
+   * Civi\Setup runtime.
+   *
+   * @return $this
+   */
+  public function configureSetupOptions() {
+    $this
+      ->addOption('settings-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM settings file. (If omitted, use CV_SETUP_SETTINGS or try to use default.)')
+      ->addOption('setup-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM-Setup source tree. (If omitted, read CV_SETUP_PATH or scan common defaults.)')
+      ->addOption('src-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM-Core source tree. (If omitted, read CV_SETUP_SRC_PATH or scan common defaults.)')
+      ->addOption('cms-base-url', NULL, InputOption::VALUE_OPTIONAL, 'The URL of the CMS (If omitted, attempt to autodetect.)')
+      ->addOption('lang', NULL, InputOption::VALUE_OPTIONAL, 'Specify the installation language')
+      ->addOption('db', NULL, InputOption::VALUE_OPTIONAL, 'Database credentials for primary Civi database.');
+    return $this;
+  }
+
+  /**
+   * Initialize the Civi\Setup environment.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return \Civi\Setup
+   * @throws \Exception
+   */
+  protected function bootSetupSubsystem(InputInterface $input, OutputInterface $output) {
+    $b = $this->bootCms($input, $output);
+
+    // Initialize setup model.
+    $setupOptions = array();
+    $setupOptions['cms'] = $b->getBootedCmsType();
+
+    $setupOptions['srcPath'] = ArrayUtil::pickFirst([
+      $input->getOption('src-path'),
+      getenv('CV_SETUP_SRC_PATH'),
+      $this->findCiviSrcPath($b->getBootedCmsType(), $b->getBootedCmsPath()),
+    ]);
+    $setupOptions['setupPath'] = ArrayUtil::pickFirst([
+      $input->getOption('setup-path'),
+      getenv('CV_SETUP_PATH'),
+      implode(DIRECTORY_SEPARATOR, [$setupOptions['srcPath'], 'setup']),
+    ]);
+    foreach (['srcPath', 'setupPath'] as $key) {
+      if (!$setupOptions[$key] || !file_exists($setupOptions[$key])) {
+        throw new \Exception("The $key is not a valid directory ($setupOptions[$key]).");
+      }
+    }
+
+    $this->setupAutoloaders($setupOptions['srcPath'], $setupOptions['setupPath']);
+    \Civi\Setup::init($setupOptions, NULL, new ConsoleLogger($output));
+    $setup = \Civi\Setup::instance();
+
+    // Override defaults detected by setup initialization.
+    $setup->getModel()->settingsPath = ArrayUtil::pickFirst([
+      $input->getOption('settings-path'),
+      getenv('CV_SETUP_SETTINGS'),
+      $setup->getModel()->settingsPath,
+    ]);
+    $setup->getModel()->cmsBaseUrl = ArrayUtil::pickFirst([
+      $input->getOption('cms-base-url'),
+      $setup->getModel()->cmsBaseUrl
+    ]);
+    if ($input->getOption('db')) {
+      $setup->getModel()->db = DbUtil::parseDsn($input->getOption('db'));
+      return $setup;
+    }
+    if ($input->getOption('lang')) {
+      $setup->getModel()->lang = $input->getOption('lang');
+    }
+
+    return $setup;
+  }
+
+  /**
+   * @param string $srcPath
+   *   Path to civicrm-core code.
+   * @param string|NULL $setupPath
+   *   Path to civicrm-setup code.
+   * @throws \Exception
+   */
+  protected function setupAutoloaders($srcPath, $setupPath) {
+    $autoloaders = [];
+    $autoloaders[] = implode(DIRECTORY_SEPARATOR,
+      [$setupPath, 'civicrm-setup-autoload.php']);
+    $autoloaders[] = implode(DIRECTORY_SEPARATOR,
+      [$srcPath, 'CRM', 'Core', 'ClassLoader.php']);
+
+    foreach ($autoloaders as $autoloader) {
+      if (!file_exists($autoloader)) {
+        throw new \Exception("Failed to load $autoloader");
+      }
+      require_once $autoloader;
+    }
+    \CRM_Core_ClassLoader::singleton()->register();
+  }
+
+  /**
+   * Try to guess the location of the main "civicrm" source tree.
+   *
+   * @param string $cmsType
+   *   Ex: 'Backdrop', 'Drupal', 'Drupal8', 'Joomla', 'WordPress'.
+   * @param string $cmsPath
+   *   Ex: '/var/www'.
+   * @return null|string
+   */
+  protected function findCiviSrcPath($cmsType, $cmsPath) {
+    $commonDirs = array(
+      'sites/all/modules/civicrm',
+      'wp-content/plugins/civicrm/civicrm',
+      'modules/civicrm',
+    );
+    foreach ($commonDirs as $commonDir) {
+      if (file_exists($cmsPath . DIRECTORY_SEPARATOR . $commonDir)) {
+        return $cmsPath . DIRECTORY_SEPARATOR . $commonDir;
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -57,10 +57,12 @@ trait SetupCommandTrait {
       getenv('CV_SETUP_PATH'),
       implode(DIRECTORY_SEPARATOR, [$setupOptions['srcPath'], 'setup']),
     ]);
-    foreach (['srcPath', 'setupPath'] as $key) {
-      if (!$setupOptions[$key] || !file_exists($setupOptions[$key])) {
-        throw new \Exception("The $key is not a valid directory ($setupOptions[$key]).");
-      }
+
+    if (!$setupOptions['srcPath'] || !file_exists($setupOptions['srcPath'])) {
+      throw new \Exception("The 'srcPath' is not a valid directory ({$setupOptions['srcPath']}). Consider downloading it, setting --src-path, or setting CV_SETUP_SRC_PATH.");
+    }
+    if (!$setupOptions['setupPath'] || !file_exists($setupOptions['setupPath'])) {
+      throw new \Exception("The 'setupPath' is not a valid directory ({$setupOptions['setupPath']}). Consider downloading it, setting --setup-path, or setting CV_SETUP_PATH.");
     }
 
     $this->setupAutoloaders($setupOptions['srcPath'], $setupOptions['setupPath']);

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -28,6 +28,8 @@ trait SetupCommandTrait {
       ->addOption('src-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM-Core source tree. (If omitted, read CV_SETUP_SRC_PATH or scan common defaults.)')
       ->addOption('cms-base-url', NULL, InputOption::VALUE_OPTIONAL, 'The URL of the CMS (If omitted, attempt to autodetect.)')
       ->addOption('lang', NULL, InputOption::VALUE_OPTIONAL, 'Specify the installation language')
+      ->addOption('comp', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM components to enable. (Ex: CiviEvent,CiviContribute,CiviMember,CiviMail,CiviReport)')
+      ->addOption('ext', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM extensions to enable. (Ex: org.civicrm.shoreditch,org.civicrm.flexmailer)')
       ->addOption('db', NULL, InputOption::VALUE_OPTIONAL, 'Database credentials for primary Civi database.');
     return $this;
   }
@@ -85,6 +87,17 @@ trait SetupCommandTrait {
     }
     if ($input->getOption('lang')) {
       $setup->getModel()->lang = $input->getOption('lang');
+    }
+    if ($input->getOption('comp')) {
+      $setup->getModel()->components = explode(',', $input->getOption('comp'));
+    }
+    if ($input->getOption('ext')) {
+      $setup->getModel()->extensions = array_unique(
+        array_merge(
+          $setup->getModel()->extensions,
+          explode(',', $input->getOption('ext'))
+        )
+      );
     }
 
     return $setup;

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -67,6 +67,9 @@ trait SetupCommandTrait {
       throw new \Exception("The 'setupPath' is not a valid directory ({$setupOptions['setupPath']}). Consider downloading it, setting --setup-path, or setting CV_SETUP_PATH.");
     }
 
+    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment>.</info>', 'civicrm-core', $setupOptions['srcPath']));
+    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment>.</info>', 'civicrm-setup', $setupOptions['setupPath']));
+
     $this->setupAutoloaders($setupOptions['srcPath'], $setupOptions['setupPath']);
     \Civi\Setup::init($setupOptions, NULL, new ConsoleLogger($output));
     $setup = \Civi\Setup::instance();

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -30,7 +30,9 @@ trait SetupCommandTrait {
       ->addOption('lang', NULL, InputOption::VALUE_OPTIONAL, 'Specify the installation language')
       ->addOption('comp', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM components to enable. (Ex: CiviEvent,CiviContribute,CiviMember,CiviMail,CiviReport)')
       ->addOption('ext', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM extensions to enable. (Ex: org.civicrm.shoreditch,org.civicrm.flexmailer)')
-      ->addOption('db', NULL, InputOption::VALUE_OPTIONAL, 'Database credentials for primary Civi database.');
+      ->addOption('db', NULL, InputOption::VALUE_OPTIONAL, 'Database credentials for primary Civi database.')
+      ->addOption('model', 'm', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Set additional field in the model. Key-value pair.');
+
     return $this;
   }
 
@@ -112,6 +114,18 @@ trait SetupCommandTrait {
           explode(',', $input->getOption('ext'))
         )
       );
+    }
+    foreach ($input->getOption('model') as $modelExpr) {
+      $obj = $setup->getModel();
+      list ($key, $value) = explode('=', $modelExpr, 2);
+      $keyPath = explode('.', $key);
+      $firstKey = array_shift($keyPath);
+      if ($keyPath) {
+        ArrayUtil::pathSet($obj->{$firstKey}, $keyPath, $value);
+      }
+      else {
+        $obj->{$firstKey} = $value;
+      }
     }
 
     return $setup;

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -98,7 +98,6 @@ trait SetupCommandTrait {
     ]);
     if ($input->getOption('db')) {
       $setup->getModel()->db = DbUtil::parseDsn($input->getOption('db'));
-      return $setup;
     }
     if ($input->getOption('lang')) {
       $setup->getModel()->lang = $input->getOption('lang');

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -42,7 +42,7 @@ trait SetupCommandTrait {
    * @return \Civi\Setup
    * @throws \Exception
    */
-  protected function bootSetupSubsystem(InputInterface $input, OutputInterface $output) {
+  protected function bootSetupSubsystem(InputInterface $input, OutputInterface $output, $defaultOutputOptions = 0) {
     $b = $this->bootCms($input, $output);
 
     // Initialize setup model.
@@ -58,7 +58,7 @@ trait SetupCommandTrait {
     ];
     $setupOptions['srcPath'] = ArrayUtil::pickFirst($possibleSrcPaths, 'file_exists');
     if ($setupOptions['srcPath']) {
-      $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-core', $setupOptions['srcPath']));
+      $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-core', $setupOptions['srcPath']), $defaultOutputOptions);
     }
     else {
       $this->printPathError($output, 'civicrm-core', '--src-path', 'CV_SETUP_SRC_PATH', $possibleSrcPaths);
@@ -75,7 +75,7 @@ trait SetupCommandTrait {
     ];
     $setupOptions['setupPath'] = ArrayUtil::pickFirst($possibleSetupPaths, 'file_exists');
     if ($setupOptions['setupPath']) {
-      $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-setup', $setupOptions['setupPath']));
+      $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-setup', $setupOptions['setupPath']), $defaultOutputOptions);
     }
     else {
       $this->printPathError($output, 'civicrm-setup', '--setup-path', 'CV_SETUP_PATH', $possibleSetupPaths);

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+define('CV_SETUP_PROTOCOL_VER', '0.1');
+
 /**
  * This trait can be mixed into a Symfony `Command` to take advantage of the
  * civicrm-setup framework.
@@ -85,6 +87,7 @@ trait SetupCommandTrait {
     }
 
     $this->setupAutoloaders($setupOptions['srcPath'], $setupOptions['setupPath']);
+    \Civi\Setup::assertProtocolCompatibility(CV_SETUP_PROTOCOL_VER);
     \Civi\Setup::init($setupOptions, NULL, new ConsoleLogger($output));
     $setup = \Civi\Setup::instance();
 

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -67,8 +67,8 @@ trait SetupCommandTrait {
       throw new \Exception("The 'setupPath' is not a valid directory ({$setupOptions['setupPath']}). Consider downloading it, setting --setup-path, or setting CV_SETUP_PATH.");
     }
 
-    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment>.</info>', 'civicrm-core', $setupOptions['srcPath']));
-    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment>.</info>', 'civicrm-setup', $setupOptions['setupPath']));
+    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-core', $setupOptions['srcPath']));
+    $output->writeln(sprintf('<info>Found code for <comment>%s</comment> in <comment>%s</comment></info>', 'civicrm-setup', $setupOptions['setupPath']));
 
     $this->setupAutoloaders($setupOptions['srcPath'], $setupOptions['setupPath']);
     \Civi\Setup::init($setupOptions, NULL, new ConsoleLogger($output));

--- a/tests/CivilTestCase.php
+++ b/tests/CivilTestCase.php
@@ -1,30 +1,20 @@
 <?php
 namespace Civi\Cv;
 
-use Civi\Cv\Util\Process as ProcessUtil;
-use Civi\Cv\Application;
-use Civi\Cv\Util\Process;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Filesystem\Filesystem;
 
 class CivilTestCase extends \PHPUnit_Framework_TestCase {
+
+  use CvTestTrait;
 
   /**
    * @var string
    */
   private $originalCwd;
 
-  /**
-   * Path to the "cv" binary.
-   *
-   * @var string
-   */
-  protected $cv;
-
   public function setup() {
     $this->originalCwd = getcwd();
     chdir($this->getExampleDir());
-    $this->cv = dirname(__DIR__) . '/bin/cv';
   }
 
   public function tearDown() {
@@ -37,18 +27,6 @@ class CivilTestCase extends \PHPUnit_Framework_TestCase {
       throw new \RuntimeException('Environment variable CV_TEST_BUILD must point to a civicrm-cms build');
     }
     return $dir;
-  }
-
-  /**
-   * Create a process for `cv` subcommand.
-   *
-   * @param string $command
-   *   Ex: "vars:show --out=serialize".
-   * @return \Symfony\Component\Process\Process
-   */
-  protected function cv($command) {
-    $process = new \Symfony\Component\Process\Process("{$this->cv} $command");
-    return $process;
   }
 
   /**
@@ -66,39 +44,6 @@ class CivilTestCase extends \PHPUnit_Framework_TestCase {
     $commandTester = new CommandTester($command);
     $commandTester->execute($args);
     return $commandTester;
-  }
-
-  /**
-   * Run a `cv` subcommand. Assert success and return output.
-   *
-   * @param string $cmd
-   * @return string
-   */
-  protected function cvOk($cmd) {
-    $p = Process::runOk($this->cv($cmd));
-    return $p->getOutput();
-  }
-
-  /**
-   * Run a `cv` subcommand. Assert success and return output.
-   *
-   * @param string $cmd
-   * @return string
-   */
-  protected function cvFail($cmd) {
-    $p = Process::runFail($this->cv($cmd));
-    return $p->getErrorOutput() . $p->getOutput();
-  }
-
-  /**
-   * Run a `cv` subcommand. Assert success and return output.
-   *
-   * @param string $cmd
-   * @return string
-   */
-  protected function cvJsonOk($cmd) {
-    $p = Process::runOk($this->cv($cmd));
-    return json_decode($p->getOutput(), 1);
   }
 
 }

--- a/tests/Command/CoreInstallCommandTest.php
+++ b/tests/Command/CoreInstallCommandTest.php
@@ -6,9 +6,9 @@ use Civi\Cv\Exception\ProcessErrorException;
 use Civi\Cv\Util\Process;
 
 /**
- * @group setup
+ * @group installer
  */
-class SetupCommandTest extends \PHPUnit_Framework_TestCase {
+class CoreInstallCommandTest extends \PHPUnit_Framework_TestCase {
 
   use CvTestTrait;
 
@@ -79,7 +79,7 @@ class SetupCommandTest extends \PHPUnit_Framework_TestCase {
 
     // $this->cvFail("ev 'return CRM_Utils_System::version();'");
 
-    $this->cvOk('core:setup -f');
+    $this->cvOk('core:install -f');
 
     $result = $this->cvJsonOk("ev 'return CRM_Utils_System::version();'");
     $this->assertRegExp('/^[0-9\.]+$/', $result);

--- a/tests/Command/CoreLifecycleTest.php
+++ b/tests/Command/CoreLifecycleTest.php
@@ -26,15 +26,18 @@ class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
     // $cases[] = [
     //   'backdrop-empty',
     //   ['modules' => 'https://download.civicrm.org/latest/civicrm-RC-backdrop.tar.gz'],
+    //   'core:install -f --cms-base-url=http://localhost',
     // ];
     $cases[] = [
       'drupal-empty',
       ['sites/all/modules' => 'https://download.civicrm.org/latest/civicrm-RC-drupal.tar.gz'],
+      'core:install -f --cms-base-url=http://localhost',
       'drush -y en civicrm'
     ];
     $cases[] = [
       'wp-empty',
       ['wp-content/plugins' => 'https://download.civicrm.org/latest/civicrm-RC-wordpress.zip'],
+      'core:install -f',
       'wp plugin activate civicrm'
     ];
     return $cases;
@@ -69,11 +72,13 @@ class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
    *   Ex: 'drupal-empty'.
    * @param array $downloads
    *   Ex: ['my/rel/path' => 'http://example/foo.zip']
+   * @param string $installCmd
+   *   Ex: 'core:install -f'
    * @param string $postInstallCmd
    *   Ex: 'drush -y en civicrm' or 'wp plugin activate civicrm'.
    * @dataProvider getTestCases
    */
-  public function testStandardLifecycle($buildType, $downloads, $postInstallCmd) {
+  public function testStandardLifecycle($buildType, $downloads, $installCmd, $postInstallCmd) {
     $createResult = Process::runOk($this->proc(
       sprintf('civibuild create %s --type %s', escapeshellarg($this->buildName), escapeshellarg($buildType))
     ));
@@ -90,7 +95,7 @@ class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
     $output = $this->cvFail("ev 'return CRM_Utils_System::version();'");
     $this->assertRegExp('/Failed to locate civicrm.settings.php/', $output);
 
-    $output = $this->cvOk('core:install -f');
+    $output = $this->cvOk($installCmd);
     $this->assertRegExp('/Creating file.*civicrm.settings.php/', $output);
     $this->assertRegExp('/Creating civicrm_\* database/', $output);
 

--- a/tests/Command/CoreLifecycleTest.php
+++ b/tests/Command/CoreLifecycleTest.php
@@ -95,6 +95,11 @@ class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
     $output = $this->cvFail("ev 'return CRM_Utils_System::version();'");
     $this->assertRegExp('/Failed to locate civicrm.settings.php/', $output);
 
+    $output = Process::runDebug($this->cv('core:check-req --out=table'))->getOutput();
+    $this->assertRegExp('/Found.*civicrm-core/', $output);
+    $this->assertRegExp('/Found.*civicrm-setup/', $output);
+    $this->assertRegExp('/| *info *| *lang/', $output);
+
     $output = $this->cvOk($installCmd);
     $this->assertRegExp('/Creating file.*civicrm.settings.php/', $output);
     $this->assertRegExp('/Creating civicrm_\* database/', $output);

--- a/tests/Command/CoreLifecycleTest.php
+++ b/tests/Command/CoreLifecycleTest.php
@@ -32,13 +32,13 @@ class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
       'drupal-empty',
       ['sites/all/modules' => 'https://download.civicrm.org/latest/civicrm-RC-drupal.tar.gz'],
       'core:install -f --cms-base-url=http://localhost',
-      'drush -y en civicrm'
+      '', // 'drush -y en civicrm', // No longer needed -- FlushDrupal plugin autoenables.
     ];
     $cases[] = [
       'wp-empty',
       ['wp-content/plugins' => 'https://download.civicrm.org/latest/civicrm-RC-wordpress.zip'],
       'core:install -f',
-      'wp plugin activate civicrm'
+      'wp plugin activate civicrm',
     ];
     return $cases;
   }

--- a/tests/Command/SetupCommandTest.php
+++ b/tests/Command/SetupCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\CvTestTrait;
+use Civi\Cv\Exception\ProcessErrorException;
+use Civi\Cv\Util\Process;
+
+/**
+ * @group setup
+ */
+class SetupCommandTest extends \PHPUnit_Framework_TestCase {
+
+  use CvTestTrait;
+
+  protected $build;
+  protected $buildName;
+  protected $originalCwd;
+
+  const CACHE_TTL = 21600;
+  const TIMEOUT = 600;
+
+  public function getTestCases() {
+    $cases = [];
+    // $cases[] = [
+    //   'backdrop-empty',
+    //   ['modules' => 'https://download.civicrm.org/latest/civicrm-RC-backdrop.tar.gz'],
+    // ];
+    // $cases[] = [
+    //   'drupal-empty',
+    //   ['sites/all/modules' => 'https://download.civicrm.org/latest/civicrm-RC-drupal.tar.gz'],
+    // ];
+    $cases[] = [
+      'wp-empty',
+      ['wp-content/plugins' => 'https://download.civicrm.org/latest/civicrm-RC-wordpress.zip'],
+    ];
+    return $cases;
+  }
+
+  public function setup() {
+    foreach (array('civibuild', 'cv') as $cmd) {
+      if (Process::findCommand($cmd) === NULL) {
+        $this->markTestSkipped("The SetupCommandTest requires $cmd to be available in the PATH.");
+      }
+    }
+    $this->originalCwd = getcwd();
+    $this->buildName = 'tmpcvsetup' . rand(0, 100000);
+    $this->build = NULL;
+    parent::setup();
+  }
+
+  public function tearDown() {
+    chdir($this->originalCwd);
+    if (!empty($this->build['CMS_ROOT'])) {
+      $this->removeDir($this->build['CMS_ROOT']);
+    }
+    Process::runOk($this->proc("amp cleanup"));
+    parent::tearDown();
+  }
+
+  /**
+   * @param string $buildType
+   *   Ex: 'drupal-empty'.
+   * @param array $downloads
+   *   Ex: ['my/rel/path' => 'http://example/foo.zip']
+   * @dataProvider getTestCases
+   */
+  public function testSetup($buildType, $downloads) {
+    $createResult = Process::runOk($this->proc(
+      sprintf('civibuild create %s --type %s', escapeshellarg($this->buildName), escapeshellarg($buildType))
+    ));
+    $this->build = $this->parseCivibuild($createResult->getOutput());
+    chdir($this->build['CMS_ROOT']);
+
+    foreach ($downloads as $path => $url) {
+      Process::runOk($this->proc(
+        sprintf('extract-url --cache-ttl %d %s=%s', self::CACHE_TTL, escapeshellarg($path), escapeshellarg($url))
+      ));
+    }
+
+    // $this->cvFail("ev 'return CRM_Utils_System::version();'");
+
+    $this->cvOk('core:setup -f');
+
+    $result = $this->cvJsonOk("ev 'return CRM_Utils_System::version();'");
+    $this->assertRegExp('/^[0-9\.]+$/', $result);
+    $this->assertTrue(version_compare($result, '4.6.0', '>='));
+  }
+
+  /**
+   * @param string $dir
+   */
+  protected function removeDir($dir) {
+    if (!empty($dir) && file_exists($dir) && is_dir($dir)) {
+      exec("rm -rf " . escapeshellarg($dir));
+    }
+  }
+
+  /**
+   * @param string $text
+   *   Output from civibuild.
+   * @return array
+   *   Ex: ['CMS_ROOT' => '/var/www', 'CMS_URL' => 'http://mybuild.localhost']
+   */
+  protected function parseCivibuild($text) {
+    $values = array();
+    $lines = explode("\n", $text);
+    foreach ($lines as $line) {
+      if (preg_match(';^ - (CMS_ROOT|CMS_URL|ADMIN_USER|DEMO_USER): (.*);', $line, $matches)) {
+        $key = trim($matches[1], " \t\r\n");
+        $value = trim($matches[2], " \t\r\n");
+        $values[$key] = $value;
+      }
+    }
+    return $values;
+  }
+
+  protected function proc($commandline, $cwd = NULL, array $env = NULL, $input = NULL, $timeout = self::TIMEOUT, array $options = array()) {
+    $p = new \Symfony\Component\Process\Process($commandline, $cwd, $env, $input, $timeout, $options);
+    return $p;
+  }
+
+}

--- a/tests/CvTestTrait.php
+++ b/tests/CvTestTrait.php
@@ -1,0 +1,54 @@
+<?php
+namespace Civi\Cv;
+
+use Civi\Cv\Util\Process;
+
+trait CvTestTrait {
+
+  /**
+   * Create a process for `cv` subcommand.
+   *
+   * @param string $command
+   *   Ex: "vars:show --out=serialize".
+   * @return \Symfony\Component\Process\Process
+   */
+  protected function cv($command) {
+    $cvPath = dirname(__DIR__) . '/bin/cv';
+    $process = new \Symfony\Component\Process\Process("{$cvPath} $command");
+    return $process;
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return $p->getOutput();
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvFail($cmd) {
+    $p = Process::runFail($this->cv($cmd));
+    return $p->getErrorOutput() . $p->getOutput();
+  }
+
+  /**
+   * Run a `cv` subcommand. Assert success and return output.
+   *
+   * @param string $cmd
+   * @return string
+   */
+  protected function cvJsonOk($cmd) {
+    $p = Process::runOk($this->cv($cmd));
+    return json_decode($p->getOutput(), 1);
+  }
+
+}


### PR DESCRIPTION
__Context__: I'm working on installer customizations for the would-be build
intended for wordpress.org.  But I need ways to quickly (re)try the new
installer library, and this helps.

See also: https://github.com/civicrm/civicrm-setup/