### PR TITLE
Require PHP v5.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Requirements
 
 A local CiviCRM installation.
 
+PHP v5.4+.
+
 Support may vary depending on the host environment (CMS type, file-structure, symlinks, etc).
  * *Tested heavily*: Drupal 7 single-site, WordPress single-site, UnitTests
  * *Tested lightly*: Backdrop single-site, WordPress (alternate content root)
@@ -25,6 +27,9 @@ Simply download [`cv`](https://download.civicrm.org/cv/cv.phar) and put it somew
 sudo curl -LsS https://download.civicrm.org/cv/cv.phar -o /usr/local/bin/cv
 sudo chmod +x /usr/local/bin/cv
 ```
+
+> __Need PHP 5.3?__: The last version to support PHP v5.3 was [cv v0.1.32](https://download.civicrm.org/cv/cv.phar-2018-01-11-8dd41af7).
+> Please note that the current version of `civicrm-core` no longer supports PHP v5.3.
 
 Documentation
 =============

--- a/bin/cv
+++ b/bin/cv
@@ -5,6 +5,10 @@ if (PHP_SAPI !== 'cli') {
   echo "cv is a command-line tool\n";
   exit(1);
 }
+if (version_compare(PHP_VERSION, '5.4', '<')) {
+  echo "cv requires PHP 5.4+\n";
+  exit(2);
+}
 $found = 0;
 $autoloaders = array(
   dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',


### PR DESCRIPTION
The recent #31 introduced the use of traits, which will fail to load on PHP 5.3 or earlier. Moreover,  `civicrm-core` now requires PHP 5.4+. 

When running on an older system, we should fail with pleasant error message.

Just in case anyone *hasn't* transitioned yet, I've also added a link in the README to the last version that supports PHP 5.3.