### PR TITLE
CRM-19115 - PHP and MySQL timezones should match

### DIFF
--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -183,6 +183,11 @@ class CmsBootstrap {
       $this->ensureUserContact();
     }
 
+    // Some UF integrations/versions don't seem to do this... work-around...
+    if (is_callable([\CRM_Core_Config::singleton()->userSystem, 'setMySQLTimeZone'])) {
+      \CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+    }
+
     return $this;
   }
 

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -117,6 +117,11 @@ trait BootTrait {
         $output->getErrorOutput()->writeln("<error>Failed to set user. Feature not supported by UF (" . CIVICRM_UF . ")</error>");
       }
     }
+
+    if (is_callable([\CRM_Core_Config::singleton()->userSystem, 'setMySQLTimeZone'])) {
+      $output->writeln('<info>[BootTrait]</info> Set active MySQL timezone', OutputInterface::VERBOSITY_DEBUG);
+      \CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+    }
   }
 
   /**


### PR DESCRIPTION
The general idea is to resync the MySQL timezone as soon as we've reached a
fairly high level of bootstrap (i.e.  once Civi+CMS are both loaded and the
current user is set).

* For the CMS-first protocol, we can put the fix directly into `CmsBootstrap.php`
* For the Civi-first protocol, the `Bootstrap.php` stops a bit sooner (i.e. 
  before the CMS or user has been loaded).

This fixes the problem where `testConcurrency` fails in some environments.
The test launches `cv api job.process_mailing`; but if the timezones aren't
sync'd correctly, then the filter on `civicrm_mailing_job.scheduled_date`
misbehaves.

Related: https://issues.civicrm.org/jira/browse/CRM-19115