### PR TITLE
support D8 in the project root as well as webroot

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -300,7 +300,6 @@ class Bootstrap {
    */
   protected function findCivicrmSettingsPhp($searchDir) {
     list ($cmsType, $cmsRoot) = $this->findCmsRoot($searchDir);
-
     $settings = NULL;
     switch ($cmsType) {
       case 'backdrop':
@@ -379,8 +378,8 @@ class Bootstrap {
       'drupal' => array(
         // D7
         'modules/system/system.module',
-        // D8
-        'core/core.services.yml',
+        // D8 - this finds the project root - the directory ABOVE the webroot - comparable to drush 9+.
+        'web/core/core.services.yml',
       ),
       'backdrop' => array(
         'core/modules/layout/layout.module',
@@ -398,11 +397,14 @@ class Bootstrap {
         foreach ($relPaths as $relPath) {
           $matches = glob("$basePath/$relPath");
           if (!empty($matches)) {
+            // Support D8 in the directory root, not just the webroot.
+            if ($relPath == 'web/core/core.services.yml') {
+              $basePath .= '/web';
+            }
             return array($cmsType, $basePath);
           }
         }
       }
-
       array_pop($parts);
     }
 


### PR DESCRIPTION
D8 has a "project root", which is the folder above the "webroot", to support the `vendor` directory outside the webroot, etc.  Drush 9+ can detect your install anywhere inside the project root, not just the webroot, and it'd be nice for `cv` to do the same.