### PR TITLE
Don't assume _ENV is available in example boot script, prefer getenv()

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ and output parsing:
 function cv($cmd, $decode = 'json') {
   $cmd = 'cv ' . $cmd;
   $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $env = getenv() + array('CV_OUTPUT' => 'json');
+  $env = (function_exists('getenv') ? getenv() : $_ENV) + array('CV_OUTPUT' => 'json');
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__, $env);
   fclose($pipes[0]);
   $result = stream_get_contents($pipes[1]);

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ and output parsing:
 function cv($cmd, $decode = 'json') {
   $cmd = 'cv ' . $cmd;
   $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $env = $_ENV + array('CV_OUTPUT' => 'json');
+  $env = getenv() + array('CV_OUTPUT' => 'json');
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__, $env);
   fclose($pipes[0]);
   $result = stream_get_contents($pipes[1]);

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ and output parsing:
 function cv($cmd, $decode = 'json') {
   $cmd = 'cv ' . $cmd;
   $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $env = (function_exists('getenv') ? getenv() : $_ENV) + array('CV_OUTPUT' => 'json');
+  $env = (!empty($_ENV) ? $_ENV : getenv()) + array('CV_OUTPUT' => 'json');
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__, $env);
   fclose($pipes[0]);
   $result = stream_get_contents($pipes[1]);
@@ -133,7 +133,7 @@ function cv($cmd, $decode = 'json') {
 
 eval(cv('php:boot', 'phpcode'));
 $config = cv('vars:show');
-printf("We should navigate to the dsahboard: %s\n\n", cv('url civicrm/dashboard'));
+printf("We should navigate to the dashboard: %s\n\n", cv('url civicrm/dashboard'));
 ```
 
 Example: NodeJS


### PR DESCRIPTION
The example boot script assumes that the superglobal `$_ENV` is populated. However PHP now recommends that this variable is NOT normally included in [`variables_order`](https://www.php.net/manual/en/ini.core.php#ini.variables-order) configuration.

> There is a performance penalty paid for the registration of these arrays and because ENV is not as commonly used as the others, ENV is not recommended on productions servers. You can still get access to the environment variables through getenv() should you need to.
>
> Source: `/etc/php/7.2/cli/php.ini` (as packaged by Debian)

By switching the example code to use `getenv()` it is more robust and does not depend on a particular configuration of the server.