### PR TITLE
BootTrait - If no active user is given, then run CLI as superuser

### DIFF
--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -42,6 +42,15 @@ trait BootTrait {
       throw new \Exception("Unrecognized bootstrap level");
     }
 
+    if (!$input->getOption('user') && is_callable(['Civi', 'dispatcher'])) {
+      // The CLI user has superpowers.
+      \Civi::dispatcher()->addListener('hook_civicrm_permission_check', function($e) {
+        if ($e->contactId === NULL) {
+          $e->granted = TRUE;
+        }
+      });
+    }
+
     $output->writeln('<info>[BootTrait]</info> Finished', OutputInterface::VERBOSITY_DEBUG);
   }
 


### PR DESCRIPTION
Example:

* Initially, the `cv api4` command tended to complain because the default/unauthenticated condition was to fail the permission check. `cv api4` currently has a work-around to set `checkPermissions=>FALSE`, although this wouldn't apply if you used  `cv ev civicrm_api4(...);`
* The `ang:module:list` has problems listing CiviMail modules b/c they have a funny perm check.

I think this may actually be better than the current workaround in `api4`, e.g.

* Using `checkPermissions => FALSE` means that it *never* checks permissions.
* Using this would mean `cv api4 Contact.get` would run without permission checks... but if you specified `cv api4 Contact.get -U alice`, then it *would* apply the permissions of the named user. 

I haven't tested the impact on that api4 use-case. I initially wanted to improve the `ang:module:list` case, but something else in CiviMail still makes that funky.

This could be a change if someone has a custom-script that is *intended* to run as anonymous+unprivileged user (`cv scr my-script.php`), although I suspect that's the exception rather the rule.

Anyway, I'm just gonna file the PR and the let idea gel a bit more.