### PR TITLE
Changes for drupal7 multisite (closes #54)

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -382,10 +382,18 @@ class Bootstrap {
    * @return array
    */
   protected function findDrupalDirs($cmsRoot) {
+    $sites = array();
+    if (file_exists("$cmsRoot/sites/sites.php")) {
+      include("$cmsRoot/sites/sites.php");
+    }
     $dirs = array();
     $server = explode('.', implode('.', array_reverse(explode(':', rtrim($this->options['httpHost'], '.')))));
     for ($j = count($server); $j > 0; $j--) {
-      $dirs[] = "$cmsRoot/sites/" . implode('.', array_slice($server, -$j));
+      $s = implode('.', array_slice($server, -$j));
+      if (isset($sites[$s]) && file_exists("$cmsRoot/sites/" . $sites[$s])) {
+        $s = $sites[$s];
+      }
+      $dirs[] = "$cmsRoot/sites/$s";
     }
     $dirs[] = "$cmsRoot/sites/default";
     return $dirs;

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -14,6 +14,7 @@ trait BootTrait {
 
   public function configureBootOptions($defaultLevel = 'full') {
     $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full,cms-only,cms-full)', $defaultLevel);
+    $this->addOption('hostname', NULL, InputOption::VALUE_REQUIRED, 'Hostname (for a multisite system)');
     $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
     $this->addOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user');
   }
@@ -22,6 +23,7 @@ trait BootTrait {
     $output->writeln('<info>[BootTrait]</info> Start', OutputInterface::VERBOSITY_DEBUG);
 
     $this->setupErrorHandling($output);
+    $this->setupHost($input);
 
     if ($input->hasOption('test') && $input->getOption('test')) {
       $output->writeln('<info>[BootTrait]</info> Use test mode', OutputInterface::VERBOSITY_DEBUG);
@@ -208,6 +210,12 @@ trait BootTrait {
     }
 
     return \CRM_Core_Session::getLoggedInContactID();
+  }
+
+  protected function setupHost(InputInterface $input) {
+    if ($input->hasOption('hostname')) {
+      $_SERVER['HTTP_HOST'] = $input->getOption('hostname');
+    }
   }
 
   protected function setupErrorHandling(OutputInterface $output) {

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -51,6 +51,7 @@ trait SetupCommandTrait {
    * @throws \Exception
    */
   protected function bootSetupSubsystem(InputInterface $input, OutputInterface $output, $defaultOutputOptions = 0) {
+    $this->setupHost($input);
     $b = $this->_boot_cms_only($input, $output);
 
     // Initialize setup model.


### PR DESCRIPTION
To close the loop on issue #54 (problems with drupal7 multisite):

* add --hostname parameter for setting $_SERVER[HTTP_HOST] (needed to boot drupal; otherwise won't find the drupal settings file)
* make use of any directory mappings in drupal's sites.php (helps cv find civicrm.settings.php)

With these two changes, cv works well on drupal7 multisite.