### PR TITLE
Multiple updates for drupal7 multisite (closes #54)

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -382,10 +382,18 @@ class Bootstrap {
    * @return array
    */
   protected function findDrupalDirs($cmsRoot) {
+    $sites = array();
+    if (file_exists("$cmsRoot/sites/sites.php")) {
+      include("$cmsRoot/sites/sites.php");
+    }
     $dirs = array();
     $server = explode('.', implode('.', array_reverse(explode(':', rtrim($this->options['httpHost'], '.')))));
     for ($j = count($server); $j > 0; $j--) {
-      $dirs[] = "$cmsRoot/sites/" . implode('.', array_slice($server, -$j));
+      $s = implode('.', array_slice($server, -$j));
+      if (isset($sites[$s]) && file_exists("$cmsRoot/sites/" . $sites[$s])) {
+        $s = $sites[$s];
+      }
+      $dirs[] = "$cmsRoot/sites/$s";
     }
     $dirs[] = "$cmsRoot/sites/default";
     return $dirs;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -63,6 +63,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *   - env: string|NULL. The environment variable which may contain the path to
  *     civicrm.settings.php. Set NULL to disable.
  *     (Default: CIVICRM_SETTINGS)
+ *   - httpHost: string|NULL. For multisite, the HTTP hostname.
  *   - prefetch: bool. Whether to load various caches.
  *     (Default: TRUE)
  *   - settingsFile: string|NULL. The full path to the civicrm.settings.php

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -340,13 +340,13 @@ class Bootstrap {
     switch ($cmsType) {
       case 'backdrop':
         $settings = $this->findFirstFile(
-           array_merge($this->findDrupalDirs($cmsRoot), array($cmsRoot)),
+           array_merge($this->findDrupalDirs($cmsRoot, $searchDir), array($cmsRoot)),
           'civicrm.settings.php'
         );
         break;
 
       case 'drupal':
-        $settings = $this->findFirstFile($this->findDrupalDirs($cmsRoot), 'civicrm.settings.php');
+        $settings = $this->findFirstFile($this->findDrupalDirs($cmsRoot, $searchDir), 'civicrm.settings.php');
         break;
 
       case 'joomla':
@@ -379,9 +379,20 @@ class Bootstrap {
    *
    * @param string $cmsRoot
    *   The root of the Drupal installation.
+   * @param string $searchDir
+   *   The location from which we're searching. Usually PWD.
    * @return array
    */
-  protected function findDrupalDirs($cmsRoot) {
+  protected function findDrupalDirs($cmsRoot, $searchDir) {
+    // If there's no explicit host and we start the search from "web/sites/FOO/...", then infer subsite path.
+    $sitesRoot = "$cmsRoot/sites";
+    $sitesRootQt = preg_quote($sitesRoot, ';');
+    if (empty($this->options['httpHost']) && preg_match(";^($sitesRootQt/[^/]+);", $searchDir, $m)) {
+      if (basename($m[1]) !== 'all') {
+        return [$m[1]];
+      }
+    }
+
     $sites = array();
     if (file_exists("$cmsRoot/sites/sites.php")) {
       include("$cmsRoot/sites/sites.php");

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -208,6 +208,10 @@ class Bootstrap {
         $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
         $_SERVER['SERVER_SOFTWARE'] = NULL;
         $_SERVER['REQUEST_METHOD'] = 'GET';
+        if (!empty($options['httpHost'])) {
+          // Hint for D7 multisite
+          $_SERVER['HTTP_HOST'] = $options['httpHost'];
+        }
         if (ord($_SERVER['SCRIPT_NAME']) != 47) {
           $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
         }

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -46,8 +46,9 @@ class CmsBootstrap {
   protected $options = array();
 
   /**
-   * Symphony OutputInterface provide during booting to enable the command-line
-   * 'v', 'vv' and 'vvv' options
+   * @var \Symfony\Component\Console\Output\OutputInterface
+   *   Provide during booting to enable the command-line verbosity
+   *   options ('v', 'vv' and 'vvv').
    * @see http://symfony.com/doc/current/console/verbosity.html
    */
   protected $output = FALSE;
@@ -112,6 +113,12 @@ class CmsBootstrap {
       if (!isset($this->options['user']) && parse_url($cmsExpr, PHP_URL_USER)) {
         $this->options['user'] = parse_url($cmsExpr, PHP_URL_USER);
       }
+      if (parse_url($cmsExpr, PHP_URL_QUERY)) {
+        parse_str(parse_url($cmsExpr, PHP_URL_QUERY), $query);
+        if (!empty($query['host'])) {
+          $this->options['httpHost'] = $query['host'];
+        }
+      }
     }
     else {
       $this->writeln("Find CMS...", OutputInterface::VERBOSITY_DEBUG);
@@ -120,7 +127,8 @@ class CmsBootstrap {
 
     $this->writeln("CMS: " . Encoder::encode($cms, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
     if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
-      throw new \Exception("Failed to parse or find a CMS");
+      $cmsJson = json_encode($cms, JSON_UNESCAPED_SLASHES);
+      throw new \Exception("Failed to parse or find a CMS $cmsJson");
     }
 
     if (PHP_SAPI === "cli") {

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -36,6 +36,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     Boolean TRUE means it should use a default (PWD).
  *     (Default: TRUE aka PWD)
  *   - user: string|NULL. The name of a CMS user to authenticate as.
+ *   - httpHost: string|NULL. For multisite, the HTTP hostname.
  *
  * @package Civi
  */

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -30,10 +30,6 @@ trait BootTrait {
       $_ENV['CIVICRM_UF'] = 'UnitTests';
     }
 
-    if ($input->hasOption('hostname')) {
-      $_SERVER['HTTP_HOST'] = $input->getOption('hostname');
-    }
-
     if ($input->getOption('level') === 'full|cms-full') {
       $input->setOption('level', getenv('CIVICRM_BOOT') ? 'cms-full' : 'full');
     }
@@ -72,7 +68,7 @@ trait BootTrait {
    */
   public function _boot_classloader(InputInterface $input, OutputInterface $output) {
     $output->writeln('<info>[BootTrait]</info> Call basic cv bootstrap (' . $input->getOption('level') . ')', OutputInterface::VERBOSITY_DEBUG);
-    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($output) + array(
+    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($input, $output) + array(
       'prefetch' => FALSE,
     ));
   }
@@ -85,7 +81,7 @@ trait BootTrait {
    */
   public function _boot_settings(InputInterface $input, OutputInterface $output) {
     $output->writeln('<info>[BootTrait]</info> Call basic cv bootstrap (' . $input->getOption('level') . ')', OutputInterface::VERBOSITY_DEBUG);
-    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($output) + array(
+    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($input, $output) + array(
       'prefetch' => FALSE,
     ));
   }
@@ -99,7 +95,7 @@ trait BootTrait {
    */
   public function _boot_full(InputInterface $input, OutputInterface $output) {
     $output->writeln('<info>[BootTrait]</info> Call standard cv bootstrap', OutputInterface::VERBOSITY_DEBUG);
-    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($output));
+    \Civi\Cv\Bootstrap::singleton()->boot($this->createBootParams($input, $output));
 
     $output->writeln('<info>[BootTrait]</info> Call core bootstrap', OutputInterface::VERBOSITY_DEBUG);
     \CRM_Core_Config::singleton();
@@ -172,6 +168,9 @@ trait BootTrait {
     if ($input->getOption('user')) {
       $boot_params['user'] = $input->getOption('user');
     }
+    if ($input->getOption('hostname')) {
+      $boot_params['httpHost'] = $input->getOption('hostname');
+    }
 
     return \Civi\Cv\CmsBootstrap::singleton()->addOptions($boot_params);
   }
@@ -231,12 +230,13 @@ trait BootTrait {
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @return array
    */
-  protected function createBootParams(OutputInterface $output) {
+  protected function createBootParams(InputInterface $input, OutputInterface $output) {
+    $boot_params = [] ;
     if ($output->isDebug()) {
-      $boot_params = array('output' => $output);
+      $boot_params['output'] = $output;
     }
-    else {
-      $boot_params = array();
+    if ($input->getOption('hostname')) {
+      $boot_params['httpHost'] = $input->getOption('hostname');
     }
     return $boot_params;
   }

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 trait BootTrait {
 
-  public function configureBootOptions($defaultLevel = 'full') {
+  public function configureBootOptions($defaultLevel = 'full|cms-full') {
     $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full,cms-only,cms-full)', $defaultLevel);
     $this->addOption('hostname', NULL, InputOption::VALUE_REQUIRED, 'Hostname (for a multisite system)');
     $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
@@ -32,6 +32,10 @@ trait BootTrait {
 
     if ($input->hasOption('hostname')) {
       $_SERVER['HTTP_HOST'] = $input->getOption('hostname');
+    }
+
+    if ($input->getOption('level') === 'full|cms-full') {
+      $input->setOption('level', getenv('CIVICRM_BOOT') ? 'cms-full' : 'full');
     }
 
     if (getenv('CIVICRM_UF') === 'UnitTests' && preg_match('/^cms-/', $input->getOption('level'))) {

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -14,6 +14,7 @@ trait BootTrait {
 
   public function configureBootOptions($defaultLevel = 'full') {
     $this->addOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full,cms-only,cms-full)', $defaultLevel);
+    $this->addOption('hostname', NULL, InputOption::VALUE_REQUIRED, 'Hostname (for a multisite system)');
     $this->addOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)');
     $this->addOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user');
   }
@@ -27,6 +28,10 @@ trait BootTrait {
       $output->writeln('<info>[BootTrait]</info> Use test mode', OutputInterface::VERBOSITY_DEBUG);
       putenv('CIVICRM_UF=UnitTests');
       $_ENV['CIVICRM_UF'] = 'UnitTests';
+    }
+
+    if ($input->hasOption('hostname')) {
+      $_SERVER['HTTP_HOST'] = $input->getOption('hostname');
     }
 
     if (getenv('CIVICRM_UF') === 'UnitTests' && preg_match('/^cms-/', $input->getOption('level'))) {


### PR DESCRIPTION
This is a continuation of #57. A few additions/changes:

* Both `Bootstrap` and `CmsBootstrap` protocols should accept the `httpHost` option. (Previously, only `CmsBootstrap` accepted it.) The `httpHost` should be passed in as a documented option.
* Add some options for multisite usage in which you don't have to explicitly pass `--hostname`:
    * For `Bootstrap`, check if the PWD indicates the preferred site.
    * For `CmsBootstrap`, when using the environment `CIVICRM_BOOT`, look for a parameter `?host=<HOSTNAME>`.
        * (It would also be nice to fallback to checking PWD or somesuch. Intuitively you might look for `/var/www/.../sites/FOO.BAR` and then say `httpHost=FOO.BAR`. However, the `conf_path()` algorithm is a bit rich, and I'm not sure that heuristic is particularly accurate. Better to let that idea marinade a bit more...)
* Make it more realistic to use CMS-first protocol on a day-to-day basis. If you specify boot options in `CIVICRM_BOOT`, then most commands will now respect that. But if you don't, then it continues using the traditional protocol.

For testing, I setup a local multisite with two folders (`sites/default` and `sites/foo.dmaster.bknix`) and ran several permutations of `cv url civicrm/admin`:

```
for BASE in "$HOME/bknix/build/dmaster/web/"{,sites/default,sites/foo.dmaster.bknix} ; do cd "$BASE"; for LVL in full cms-full ; do for OPT in '' '--hostname=foo.dmaster.bknix' '--hostname=dmaster.bknix' ; do echo -n "PWD=$PWD; LEVEL=$LVL OPT=$OPT ... Output: " ; ~/src/cv/bin/cv url civicrm/admin --level=$LVL $OPT ; done ; done ; done
```

Which outputs (*very wide text*):

```
PWD=~/bknix/build/dmaster/web; LEVEL=full OPT=                                                          Output: "http://dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web; LEVEL=full OPT=--hostname=foo.dmaster.bknix                              Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web; LEVEL=full OPT=--hostname=dmaster.bknix                                  Output: "http://dmaster.bknix:8001/civicrm/admin"

PWD=~/bknix/build/dmaster/web; LEVEL=cms-full OPT=                                                      Output: "http://dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web; LEVEL=cms-full OPT=--hostname=foo.dmaster.bknix                          Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web; LEVEL=cms-full OPT=--hostname=dmaster.bknix                              Output: "http://dmaster.bknix:8001/civicrm/admin"

PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=full OPT=                                            Output: "http://dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=full OPT=--hostname=foo.dmaster.bknix                Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=full OPT=--hostname=dmaster.bknix                    Output: "http://dmaster.bknix:8001/civicrm/admin"

PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=cms-full OPT=                                        Output: "http://dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=cms-full OPT=--hostname=foo.dmaster.bknix            Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/default; LEVEL=cms-full OPT=--hostname=dmaster.bknix                Output: "http://dmaster.bknix:8001/civicrm/admin"

PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=full OPT=                                  Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=full OPT=--hostname=foo.dmaster.bknix      Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=full OPT=--hostname=dmaster.bknix          Output: "http://dmaster.bknix:8001/civicrm/admin"

PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=cms-full OPT=                              Output: "http://dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=cms-full OPT=--hostname=foo.dmaster.bknix  Output: "http://foo.dmaster.bknix:8001/civicrm/admin"
PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=cms-full OPT=--hostname=dmaster.bknix      Output: "http://dmaster.bknix:8001/civicrm/admin"

```

All of these look correct except for:

```
PWD=~/bknix/build/dmaster/web/sites/foo.dmaster.bknix; LEVEL=cms-full OPT=                              Output: "http://dmaster.bknix:8001/civicrm/admin"
```

which is because `CmsBootstrap` doesn't support multisite detection from the PWD.