### PR TITLE
Address php 7.4 deprecation

### DIFF
--- a/src/BuildkitReader.php
+++ b/src/BuildkitReader.php
@@ -35,7 +35,7 @@ class BuildkitReader {
     $lines = explode("\n", file_get_contents($shFile));
     $result = array();
     foreach ($lines as $line) {
-      if (empty($line) || $line{0} == '#') {
+      if (empty($line) || $line[0] == '#') {
         continue;
       }
       if (preg_match('/^([A-Z0-9_]+)=\"(.*)\"$/', $line, $matches)) {


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated 

https://stackoverflow.com/questions/59158548/array-and-string-offset-access-syntax-with-curly-braces-is-deprecated