### PR TITLE
Address php 7.4 deprecation notice

### DIFF
--- a/src/Util/DebugDispatcherTrait.php
+++ b/src/Util/DebugDispatcherTrait.php
@@ -21,7 +21,7 @@ trait DebugDispatcherTrait {
     if (!$eventFilter) {
       $listenersByEvent = $dispatcher->getListeners();
     }
-    elseif ($eventFilter{0} === '/') {
+    elseif ($eventFilter[0] === '/') {
       $listenersByEvent = array();
       foreach ($dispatcher->getListeners() as $e => $ls) {
         if (preg_match($eventFilter, $e)) {


### PR DESCRIPTION
https://stackoverflow.com/questions/59158548/array-and-string-offset-access-syntax-with-curly-braces-is-deprecated