### PR TITLE
Address php 7.4 deprecation

### DIFF
--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -101,7 +101,7 @@ Examples:
   }
 
   protected function createRegex($filterExpr) {
-    if ($filterExpr{0} === ';') {
+    if ($filterExpr[0] === ';') {
       return $filterExpr;
     }
     // $filterExpr = preg_replace(';^~/;', '', $filterExpr);


### PR DESCRIPTION
https://stackoverflow.com/questions/59158548/array-and-string-offset-access-syntax-with-curly-braces-is-deprecated