### PR TITLE
quote MySQL password

### DIFF
--- a/src/Util/Datasource.php
+++ b/src/Util/Datasource.php
@@ -137,7 +137,7 @@ class Datasource {
     $data = "[client]\n";
     $data .= "host={$this->host}\n";
     $data .= "user={$this->username}\n";
-    $data .= "password={$this->password}\n";
+    $data .= "password='{$this->password}'\n";
     if ($this->port != NULL) {
       $data .= "port={$this->port}\n";
     }


### PR DESCRIPTION
If you have globbing characters (e.g. `*`) in your MySQL password, `cv` will fail to connect.  Quoting the password in the generated `defaults-file` fixes the problem and seems to have no ill effect.