### PR TITLE
$line{0} is deprecated in php 7.4 - replaced it with $line[0] does the same.

### DIFF
--- a/src/BuildkitReader.php
+++ b/src/BuildkitReader.php
@@ -35,7 +35,7 @@ class BuildkitReader {
     $lines = explode("\n", file_get_contents($shFile));
     $result = array();
     foreach ($lines as $line) {
-      if (empty($line) || $line{0} == '#') {
+      if (empty($line) || $line[0] == '#') {
         continue;
       }
       if (preg_match('/^([A-Z0-9_]+)=\"(.*)\"$/', $line, $matches)) {


### PR DESCRIPTION
$line{0} gives a deprecated warning when used with PHP 7.4.  

civix is dependent on the cv libraries, so it shows the same errors. Complete stacktrace

    civix generate:module some.module

     PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /opt/civix/vendor/civicrm/cv/src/BuildkitReader.php on line 38
     PHP Stack trace:
     PHP   1. {main}() /opt/civix/bin/civix:0
     PHP   2. CRM\CivixBundle\Application::main() /opt/civix/bin/civix:23
     PHP   3. CRM\CivixBundle\Application->run() /opt/civix/src/CRM/CivixBundle/Application.php:36
     PHP   4. CRM\CivixBundle\Application->doRun() /opt/civix/vendor/symfony/console/Application.php:124
     PHP   5. CRM\CivixBundle\Application->doRunCommand() /opt/civix/vendor/symfony/console/Application.php:193
     PHP   6. CRM\CivixBundle\Command\InitCommand->run() /opt/civix/vendor/symfony/console/Application.php:850
     PHP   7. CRM\CivixBundle\Command\InitCommand->execute() /opt/civix/vendor/symfony/console/Command/Command.php:257
     PHP   8. CRM\CivixBundle\Command\InitCommand->tryEnable() /opt/civix/src/CRM/CivixBundle/Command/InitCommand.php:124
     PHP   9. CRM\CivixBundle\Services::boot() /opt/civix/src/CRM/CivixBundle/Command/InitCommand.php:133
     PHP  10. Civi\Cv\Bootstrap->boot() /opt/civix/src/CRM/CivixBundle/Services.php:21
     PHP  11. Civi\Cv\SiteConfigReader->compile() /opt/civix/vendor/civicrm/cv/src/Bootstrap.php:155
     PHP  12. Civi\Cv\SiteConfigReader->readBuildkitConfig() /opt/civix/vendor/civicrm/cv/src/SiteConfigReader.php:34
     PHP  13. spl_autoload_call() /opt/civix/vendor/civicrm/cv/src/SiteConfigReader.php:57
     PHP  14. Composer\Autoload\ClassLoader->loadClass() /opt/civix/vendor/civicrm/cv/src/SiteConfigReader.php:57
     PHP  15. Composer\Autoload\includeFile() /opt/civix/vendor/composer/ClassLoader.php:322
     
     Deprecated: Array and string offset access syntax with curly braces is deprecated in /opt/civix/vendor/civicrm/cv/src/BuildkitReader.php on line 38
