### PR TITLE
PHPUnit - Minor maintenance updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ installation and put it in `CV_TEST_BUILD`, as in:
 $ git clone https://github.com/civicrm/cv
 $ cd cv
 $ composer install
-$ export CV_TEST_BUILD=/home/me/buildkit/build/dmaster/
+$ export CV_TEST_BUILD=/home/me/buildkit/build/dmaster/web/
 $ phpunit5 --group std
 PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
   <testsuites>

--- a/tests/CivilTestCase.php
+++ b/tests/CivilTestCase.php
@@ -3,7 +3,7 @@ namespace Civi\Cv;
 
 use Symfony\Component\Console\Tester\CommandTester;
 
-class CivilTestCase extends \PHPUnit_Framework_TestCase {
+class CivilTestCase extends \PHPUnit\Framework\TestCase {
 
   use CvTestTrait;
 

--- a/tests/Command/CoreLifecycleTest.php
+++ b/tests/Command/CoreLifecycleTest.php
@@ -9,7 +9,7 @@ use Civi\Cv\Util\Process;
  *
  * @group installer
  */
-class CoreLifecycleTest extends \PHPUnit_Framework_TestCase {
+class CoreLifecycleTest extends \PHPUnit\Framework\TestCase {
 
   use CvTestTrait;
 

--- a/tests/Util/Api4ArgParserTest.php
+++ b/tests/Util/Api4ArgParserTest.php
@@ -5,7 +5,7 @@ namespace Civi\Cv\Util;
  * @group std
  * @group util
  */
-class Api4ArgParserTest extends \PHPUnit_Framework_TestCase {
+class Api4ArgParserTest extends \PHPUnit\Framework\TestCase {
 
   public function getGoodExamples() {
     $exs = [];

--- a/tests/Util/FilesystemTest.php
+++ b/tests/Util/FilesystemTest.php
@@ -5,7 +5,7 @@ namespace Civi\Cv\Util;
  * @group std
  * @group util
  */
-class FilesystemTest extends \PHPUnit_Framework_TestCase {
+class FilesystemTest extends \PHPUnit\Framework\TestCase {
 
   public function dataIsDescendent() {
     return array(

--- a/tests/Util/ProcessTest.php
+++ b/tests/Util/ProcessTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Process\Process;
  * @group std
  * @group util
  */
-class ProcessTest extends \PHPUnit_Framework_TestCase {
+class ProcessTest extends \PHPUnit\Framework\TestCase {
 
   public function testSprintf() {
     $this->assertEquals(


### PR DESCRIPTION
Note that the updated tests are passing on phpunit5+php70 and phpunit7+php74.

I also took a stab at phpunit5+php56. Some tests passed, and `cv` didn't suffer any syntax issues, but several failed because my target build (`civicrm-core`@`5.24`) doesn't work with php56. But `php56` was dropped from `civicrm-core` last year, so I'm not too worried about maintaining `cv` support there much longer.