### PR TITLE
Allow Symfony 4 filesystem components. Unblocks composer install on Drupal >= 8.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 
 A local CiviCRM installation.
 
-PHP v5.4+.
+PHP v5.6+.
 
 Support may vary depending on the host environment (CMS type, file-structure, symlinks, etc).
  * *Tested heavily*: Drupal 7 single-site, WordPress single-site, UnitTests

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A local CiviCRM installation.
 PHP v5.6+.
 
 Support may vary depending on the host environment (CMS type, file-structure, symlinks, etc).
- * *Tested heavily*: Drupal 7 single-site, WordPress single-site, UnitTests
- * *Tested lightly*: Backdrop single-site, WordPress (alternate content root)
- * *Untested*: Drupal 7 multi-site, WordPress multi-site, Joomla, Drupal 6, Drupal 8; any heavy symlinking
+ * *Tested heavily*: Drupal 7/8 single-site, WordPress single-site, UnitTests
+ * *Tested lightly*: Drupal 9 single-site, Backdrop single-site, WordPress (alternate content root)
+ * *Untested*: Drupal 7 multi-site, WordPress multi-site, Joomla, Drupal 6; any heavy symlinking
    * *Tip*: If you use an untested or incompatible host environment, then you may see the error `Failed to locate civicrm.settings.php`. See [StackExchange](http://civicrm.stackexchange.com/questions/12732/civix-reports-failed-to-locate-civicrm-settings-php) to discuss work-arounds.
 
 Download

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/process": "~2.8|^3",
         "symfony/filesystem": "~2.8|^3",
         "psy/psysh": "@stable",
-        "civicrm/composer-downloads-plugin": "~2.1"
+        "civicrm/composer-downloads-plugin": "~2.1|^3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.6.0",
         "symfony/console": "~2.8|^3",
         "symfony/process": "~2.8|^3",
-        "symfony/filesystem": "~2.8|^3",
+        "symfony/filesystem": "~2.8|^3|^4",
         "psy/psysh": "@stable",
         "civicrm/composer-downloads-plugin": "~2.1|^3"
     },

--- a/src/Command/BaseExtensionCommand.php
+++ b/src/Command/BaseExtensionCommand.php
@@ -56,25 +56,20 @@ class BaseExtensionCommand extends BaseCommand {
     $shortMap = NULL;
 
     foreach ($input->getArgument('key-or-name') as $keyOrName) {
-      if (strpos($keyOrName, '.') !== FALSE) {
-        if (in_array($keyOrName, $allKeys)) {
-          $foundKeys[] = $keyOrName;
-        }
-        else {
-          $missingKeys[] = $keyOrName;
-        }
+      if (in_array($keyOrName, $allKeys)) {
+        $foundKeys[] = $keyOrName;
+        continue;
       }
-      else {
-        if ($shortMap === NULL) {
-          $shortMap = $this->getShortMap();
-        }
-        if ($shortMap[$keyOrName]) {
-          $foundKeys = array_merge($foundKeys, $shortMap[$keyOrName]);
-        }
-        else {
-          $missingKeys[] = $keyOrName;
-        }
+
+      if ($shortMap === NULL) {
+        $shortMap = $this->getShortMap();
       }
+      if ($shortMap[$keyOrName]) {
+        $foundKeys = array_merge($foundKeys, $shortMap[$keyOrName]);
+        continue;
+      }
+
+      $missingKeys[] = $keyOrName;
     }
 
     return array($foundKeys, $missingKeys);

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -94,6 +94,10 @@ Examples:
       }
     }
 
+    if (!defined('CIVICRM_UPGRADE_ACTIVE')) {
+      define('CIVICRM_UPGRADE_ACTIVE', 1);
+    }
+
     // Why is dropTriggers() hard-coded? Can't we just enqueue this as part of buildQueue()?
     if ($isFirstTry) {
       $output->writeln("<info>Dropping SQL triggers...</info>", $niceMsgVerbosity);
@@ -138,6 +142,13 @@ Examples:
     }
 
     $output->writeln("<info>Upgrade to <comment>$codeVer</comment> completed.</info>", $niceMsgVerbosity);
+
+    if (version_compare($codeVer, '5.26.alpha', '<')) {
+      // Work-around for bugs like dev/core#1713.
+      // Note that #1713 didn't affect earlier versions of `cv` because they mistakenly omitted CIVICRM_UPGRADE_ACTIVE.
+      $output->writeln('<info>Detected CiviCRM 5.25 or earlier. Force flush.</info>');
+      \Civi\Cv\Util\Cv::passthru("flush");
+    }
 
     $output->writeln("<info>Checking post-upgrade messages...</info>", $niceMsgVerbosity);
     $message = file_get_contents($postUpgradeMessageFile);

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -36,6 +36,9 @@ Examples:
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    if (!defined('CIVICRM_UPGRADE_ACTIVE')) {
+      define('CIVICRM_UPGRADE_ACTIVE', 1);
+    }
     $this->boot($input, $output);
 
     if (!ini_get('safe_mode')) {
@@ -92,10 +95,6 @@ Examples:
       else {
         $output->writeln("(No messages)", $niceMsgVerbosity);
       }
-    }
-
-    if (!defined('CIVICRM_UPGRADE_ACTIVE')) {
-      define('CIVICRM_UPGRADE_ACTIVE', 1);
     }
 
     // Why is dropTriggers() hard-coded? Can't we just enqueue this as part of buildQueue()?

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -101,8 +101,7 @@ trait BootTrait {
     if ($input->getOption('user')) {
       $output->writeln('<info>[BootTrait]</info> Set system user', OutputInterface::VERBOSITY_DEBUG);
       if (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
-        \CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user'));
-        if (!$this->ensureUserContact($output)) {
+        if (!\CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user')) || !$this->ensureUserContact($output)) {
           throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
         }
       }

--- a/src/Util/Cv.php
+++ b/src/Util/Cv.php
@@ -59,4 +59,29 @@ class Cv {
     }
   }
 
+  /**
+   * Call the "cv" command on an interactive "passthru" basis, meaning that output is displayed on our console.
+   *
+   * @param string $cmd
+   *   The rest of the command to send.
+   * @return int
+   *   The exit code
+   * @throws \RuntimeException
+   *   If the command terminates abnormally.
+   */
+  public static function passthru($cmd) {
+    $cmd = 'cv ' . $cmd;
+    $process = proc_open(
+      $cmd,
+      array(
+        // 0 => array('pipe', 'r'),
+        0 => STDIN,
+        1 => STDOUT,
+        2 => STDERR,
+      ),
+      $pipes
+    );
+    return proc_close($process);
+  }
+
 }


### PR DESCRIPTION
Allow Symfony 4 filesystem components for installation on Drupal 8.9.*/9.*.* via Composer.