### PR TITLE
cv upgrade:db - Fix multilingual support by flagging upgrade-mode

### DIFF
--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -143,6 +143,13 @@ Examples:
 
     $output->writeln("<info>Upgrade to <comment>$codeVer</comment> completed.</info>", $niceMsgVerbosity);
 
+    if (version_compare($codeVer, '5.26.alpha', '<')) {
+      // Work-around for bugs like dev/core#1713.
+      // Note that #1713 didn't affect earlier versions of `cv` because they mistakenly omitted CIVICRM_UPGRADE_ACTIVE.
+      $output->writeln('<info>Detected CiviCRM 5.25 or earlier. Force flush.</info>');
+      \Civi\Cv\Util\Cv::passthru("flush");
+    }
+
     $output->writeln("<info>Checking post-upgrade messages...</info>", $niceMsgVerbosity);
     $message = file_get_contents($postUpgradeMessageFile);
     if ($input->getOption('out') === 'pretty') {

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -94,6 +94,10 @@ Examples:
       }
     }
 
+    if (!defined('CIVICRM_UPGRADE_ACTIVE')) {
+      define('CIVICRM_UPGRADE_ACTIVE', 1);
+    }
+
     // Why is dropTriggers() hard-coded? Can't we just enqueue this as part of buildQueue()?
     if ($isFirstTry) {
       $output->writeln("<info>Dropping SQL triggers...</info>", $niceMsgVerbosity);

--- a/src/Util/Cv.php
+++ b/src/Util/Cv.php
@@ -59,4 +59,29 @@ class Cv {
     }
   }
 
+  /**
+   * Call the "cv" command on an interactive "passthru" basis, meaning that output is displayed on our console.
+   *
+   * @param string $cmd
+   *   The rest of the command to send.
+   * @return int
+   *   The exit code
+   * @throws \RuntimeException
+   *   If the command terminates abnormally.
+   */
+  public static function passthru($cmd) {
+    $cmd = 'cv ' . $cmd;
+    $process = proc_open(
+      $cmd,
+      array(
+        // 0 => array('pipe', 'r'),
+        0 => STDIN,
+        1 => STDOUT,
+        2 => STDERR,
+      ),
+      $pipes
+    );
+    return proc_close($process);
+  }
+
 }


### PR DESCRIPTION
…rade to ensure that the correct schema is retrieved

ping @totten 

You can test this by loading up CiviCRM 5.13.x making it a multilingual instance and then using cv to upgrade the database without this it borks