### PR TITLE
ext:enable (etc) - Fix resolution for non-dotted "key"s

### DIFF
--- a/src/Command/BaseExtensionCommand.php
+++ b/src/Command/BaseExtensionCommand.php
@@ -56,25 +56,20 @@ class BaseExtensionCommand extends BaseCommand {
     $shortMap = NULL;
 
     foreach ($input->getArgument('key-or-name') as $keyOrName) {
-      if (strpos($keyOrName, '.') !== FALSE) {
-        if (in_array($keyOrName, $allKeys)) {
-          $foundKeys[] = $keyOrName;
-        }
-        else {
-          $missingKeys[] = $keyOrName;
-        }
+      if (in_array($keyOrName, $allKeys)) {
+        $foundKeys[] = $keyOrName;
+        continue;
       }
-      else {
-        if ($shortMap === NULL) {
-          $shortMap = $this->getShortMap();
-        }
-        if ($shortMap[$keyOrName]) {
-          $foundKeys = array_merge($foundKeys, $shortMap[$keyOrName]);
-        }
-        else {
-          $missingKeys[] = $keyOrName;
-        }
+
+      if ($shortMap === NULL) {
+        $shortMap = $this->getShortMap();
       }
+      if ($shortMap[$keyOrName]) {
+        $foundKeys = array_merge($foundKeys, $shortMap[$keyOrName]);
+        continue;
+      }
+
+      $missingKeys[] = $keyOrName;
     }
 
     return array($foundKeys, $missingKeys);


### PR DESCRIPTION
When enabling or disabling an extension, one can use the long (`key`) or short (`<file>`) identifiers, eg

```
1a: cv en flexmailer
1b: cv en org.civicrm.flexmailer
```

There is a problem with an extension like this:

```
2a: civix generate:module com.example.foo-bar      // OK
2b: cv en com.example.foo-bar                      // OK
2c: cv en foo_bar                                  // OK

3a: civix generate:module foo-bar                  // OK
3b: cv en foo-bar                                  // Fail
3c: cv en foo_bar                                  // OK
```

In 3a, the module is created (huzzah), but you get a counter-intuitive behavior where (3b) fails and (3c) works. Weird, right?

A couple things are going on. This fixes one of them.

* In (3a), civix translates the long name (`key="foo-bar"`) to a short name (`<file>foo_bar</file>`). This is because the two namespaces have different rules. (`key` originates with reverse-DNS, and `<file>` originates with PHP function-names. The two namespaces disagree about dashes and underscores.)
* In (3b), `cv en foo-bar` should match `key="foo-bar"`, but it doesn't even try because the `key` does not have any dots. (Historically, that was an invalid key.)
* In (3c), `cv en foo_bar` works because it matches the `<file>`.

Of course, it's increasingly common to have `key` identifiers without dots. This fixes `cv en` so that it matches non-dotted keys.