### PR TITLE
Update README to show drupal 8 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A local CiviCRM installation.
 PHP v5.6+.
 
 Support may vary depending on the host environment (CMS type, file-structure, symlinks, etc).
- * *Tested heavily*: Drupal 7 single-site, WordPress single-site, UnitTests
- * *Tested lightly*: Backdrop single-site, WordPress (alternate content root)
- * *Untested*: Drupal 7 multi-site, WordPress multi-site, Joomla, Drupal 6, Drupal 8; any heavy symlinking
+ * *Tested heavily*: Drupal 7/8 single-site, WordPress single-site, UnitTests
+ * *Tested lightly*: Drupal 9 single-site, Backdrop single-site, WordPress (alternate content root)
+ * *Untested*: Drupal 7 multi-site, WordPress multi-site, Joomla, Drupal 6; any heavy symlinking
    * *Tip*: If you use an untested or incompatible host environment, then you may see the error `Failed to locate civicrm.settings.php`. See [StackExchange](http://civicrm.stackexchange.com/questions/12732/civix-reports-failed-to-locate-civicrm-settings-php) to discuss work-arounds.
 
 Download


### PR DESCRIPTION
Drupal 8 is pretty well tested now.

See also https://civicrm.stackexchange.com/questions/38148/how-do-i-access-drush-commands-specific-to-civicrm