### PR TITLE
dev/core#2323 - Avoid confusing error message and don't try to synchronize if --user is an unknown user

### DIFF
--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -101,8 +101,7 @@ trait BootTrait {
     if ($input->getOption('user')) {
       $output->writeln('<info>[BootTrait]</info> Set system user', OutputInterface::VERBOSITY_DEBUG);
       if (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
-        \CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user'));
-        if (!$this->ensureUserContact($output)) {
+        if (!\CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user')) || !$this->ensureUserContact($output)) {
           throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
         }
       }


### PR DESCRIPTION
Overview
----------
https://lab.civicrm.org/dev/core/-/issues/2323

For a call like `cv api --user=admiin job.fetch_activities`, where `admiin` isn't a user, the return value from loadUser is not checked, so if the cms user doesn't exist it still tries to synchronize and can lead to confusing error message instead of the intended one.

Before
-------
* Drupal 8: `Call to undefined method Drupal\Core\Session\AccountProxy::get()`
* Drupal 7: `Trying to get property 'uid' of non-object`

After
-----
* `Failed to determine contactID for user=admiin`
* Avoids possible unintended synchronize consequences.

Technical Details
------------------
Check the return value from loadUser() first, then call ensureUserContact().

Comments
------------
The other cmses appear to also return true/false from loadUser so the check should be valid for all cmses.