### PR TITLE
php 7.4 E_NOTICE when checking last_error in bootstrap

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -148,7 +148,7 @@ class Bootstrap {
         return;
       }
       $last_error = error_get_last();
-      switch ($last_error['type']) {
+      switch ($last_error['type'] ?? NULL) {
         case E_ERROR:
         case E_PARSE:
         case E_COMPILE_ERROR:


### PR DESCRIPTION
If there is no last error, then $last_error is NULL so you get `Trying to access array offset on value of type null`