### PR TITLE
Make upgrade:db work on windows

### DIFF
--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -192,7 +192,7 @@ Examples:
     }
 
     $id = md5(implode(\CRM_Core_DAO::VALUE_SEPARATOR, array(
-      posix_getuid(),
+      $home,
       CIVICRM_SETTINGS_PATH,
       $GLOBALS['civicrm_root'],
 


### PR DESCRIPTION
It sounds like this line doesn't need to be posix_getuid() and just needs to be something that's the same each time for the same user. There is no posix_getuid() on windows. Since $home is already computed, I've stuck that in.