### PR TITLE
Fix for issue 95: use STDERR for display_errors

### DIFF
--- a/bin/cv
+++ b/bin/cv
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-ini_set('display_errors', 1);
+ini_set('display_errors', 'stderr');
 if (PHP_SAPI !== 'cli') {
   printf("cv is a command-line tool. It is designed to run with PHP_SAPI \"%s\". The active PHP_SAPI is \"%s\".\n", 'cli', PHP_SAPI);
   printf("TIP: In a typical shell environment, the \"php\" command should execute php-cli - not php-cgi or similar.\n");

--- a/bin/cv2
+++ b/bin/cv2
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-ini_set('display_errors', 1);
+ini_set('display_errors', 'stderr');
 if (PHP_SAPI !== 'cli') {
   echo "cv is a command-line tool\n";
   exit(1);

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -213,7 +213,7 @@ trait BootTrait {
     $output->writeln('[BootTrait] Attempting to set verbose error reporting', OutputInterface::VERBOSITY_DEBUG);
     // standard php debug chat settings
     error_reporting(E_ALL | E_STRICT);
-    ini_set('display_errors', TRUE);
+    ini_set('display_errors', 'stderr');
     ini_set('display_startup_errors', TRUE);
   }
 


### PR DESCRIPTION
This swaps out setting `display_errors = 1` for `display_errors = 'stderr'` as documented to mean, unsurprisingly, that errors get pumped out on STDERR.

This means command line users can get rid of errors easily, e.g. for the sake of being able to  boot civi - see #95 

I've tried to run the unit tests, but they're hanging when they get to a certain place, bu thtat happens before this change too?
