### PR TITLE
'cv api4' - Accept short-hand conditions+values using pseudo-constant ":" fields

### DIFF
--- a/src/Util/Api4ArgParser.php
+++ b/src/Util/Api4ArgParser.php
@@ -12,17 +12,21 @@ class Api4ArgParser {
         $this->applyOption($params, $state, $arg);
         $state = '_TOP_';
       }
-      elseif (preg_match('/^([a-zA-Z0-9_]+)=(.*)/', $arg, $matches)) {
+      // Ex: 'foo=bar', 'fo.oo=bar', 'fo:oo=bar'
+      elseif (preg_match('/^([a-zA-Z0-9_:\.]+)=(.*)/', $arg, $matches)) {
         list (, $key, $value) = $matches;
         $params[$key] = $this->parseValueExpr($value);
       }
+      // Ex: '+w', '+where'
       elseif (preg_match('/^\+([a-zA-Z0-9_]+)$/', $arg, $matches)) {
         $state = $matches[1];
       }
+      // Ex: '+l=2', '+l:2'
       elseif (preg_match('/^\+([a-zA-Z0-9_]+)[:=](.*)/', $arg, $matches)) {
         list (, $key, $expr) = $matches;
         $this->applyOption($params, $key, $expr);
       }
+      // Ex: '{"foo": "bar"}'
       elseif (preg_match('/^\{.*\}$/', $arg)) {
         $params = array_merge($params, $this->parseJsonNoisily($arg));
       }
@@ -132,7 +136,7 @@ class Api4ArgParser {
   }
 
   public function parseAssignment($expr) {
-    if (preg_match('/^([a-zA-Z0-9_\.]+)\s*=\s*(.*)$/', $expr, $matches)) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*=\s*(.*)$/', $expr, $matches)) {
       return [$matches[1] => $this->parseValueExpr($matches[2])];
     }
     else {
@@ -141,7 +145,7 @@ class Api4ArgParser {
   }
 
   public function parseWhere($expr) {
-    if (preg_match('/^([a-zA-Z0-9_\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|LIKE|NOT LIKE|IN|NOT IN)\s*(.*)$/i', $expr, $matches)) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|LIKE|NOT LIKE|IN|NOT IN)\s*(.*)$/i', $expr, $matches)) {
       if (!empty($matches[3])) {
         return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
       }

--- a/tests/Util/Api4ArgParserTest.php
+++ b/tests/Util/Api4ArgParserTest.php
@@ -56,6 +56,14 @@ class Api4ArgParserTest extends \PHPUnit\Framework\TestCase {
       ['where' => [['id', 'IS NOT NULL'], ['id', '>=', '234']]],
     ];
     $exs[] = [
+      ['+w', 'foo:bar=apple', '+where', 'whiz.bang=banana'],
+      ['where' => [['foo:bar', '=', 'apple'], ['whiz.bang', '=', 'banana']]],
+    ];
+    $exs[] = [
+      ['+v', 'foo:bar=apple', '+value', 'whiz.bang=banana'],
+      ['values' => ['foo:bar' => 'apple', 'whiz.bang' => 'banana']],
+    ];
+    $exs[] = [
       ['+where:display_name like "alice%"', '+w:id >= 234'],
       [
         'where' => [


### PR DESCRIPTION
This updates the parsing of shorthand `+w/+where` and `+v/+value` to accept pseudo-constant fields (eg `:name` and `:label`).

Some examples:

```
cv api4 OptionValue.get +w option_group_id:name=contribution_recur_status
cv api4 OptionValue.get +w 'option_group_id:label=Recurring Contribution Status'
cv api4 Contact.update +w id=10 +v gender_id:name=Male
```