### PR TITLE
StructuredOutputTrait - Restore filtering of JSON output

### DIFF
--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -133,7 +133,7 @@ trait StructuredOutputTrait {
     // If it's not one of our, then fallback to generic rendering
     if (!in_array($input->getOption('out'), ['table', 'csv', 'list'])) {
       // Use a generic format.
-      $this->sendResult($input, $output, $records);
+      $this->sendResult($input, $output, ArrayUtil::filterColumns($records, $columns));
       return;
     }
 


### PR DESCRIPTION
There is a regression per ExtensionListCommandTest::testGetJson, eg when running:

```
cv ext:list /^cividiscount$/ --out=json --remote --columns=name,version
```

The `--columns` aren't respected when using JSON.

Regression circa v0.3.7 (b0a5023c4ca110499ef0c8dcc1810aca41eacbdd).