### PR TITLE
composer.json - Update to Symfony 4 (filesystem+process). Change PHP minimum (5.6=>7.1).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.6.0",
         "symfony/console": "~2.8|^3",
         "symfony/process": "~2.8|^3",
-        "symfony/filesystem": "~2.8|^3",
+        "symfony/filesystem": "~2.8|^3|^4",
         "psy/psysh": "@stable",
         "civicrm/composer-downloads-plugin": "~2.1|^3"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1.3",
         "symfony/console": "~2.8|^3",
-        "symfony/process": "~2.8|^3",
-        "symfony/filesystem": "~2.8|^3|^4",
+        "symfony/process": "^4",
+        "symfony/filesystem": "^4",
         "psy/psysh": "@stable",
         "civicrm/composer-downloads-plugin": "~2.1|^3"
     },
@@ -26,7 +26,7 @@
     ],
     "config": {
         "platform": {
-            "php": "5.6"
+            "php": "7.1.3"
         },
         "bin-dir": "bin"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81be2359d0ae02fbce851118e3e55931",
+    "content-hash": "dde955d5377b93e9f9102682cd2bc120",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -130,6 +130,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -176,6 +177,7 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
@@ -469,28 +471,24 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.38",
+            "version": "v4.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "0a0d3b4bda11aa3a0464531c40e681e184e75628"
+                "reference": "517fb795794faf29086a77d99eb8f35e457837a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0a0d3b4bda11aa3a0464531c40e681e184e75628",
-                "reference": "0a0d3b4bda11aa3a0464531c40e681e184e75628",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/517fb795794faf29086a77d99eb8f35e457837a7",
+                "reference": "517fb795794faf29086a77d99eb8f35e457837a7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -513,9 +511,23 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Filesystem Component",
+            "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "time": "2020-01-17T08:50:08+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-21T12:19:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -663,28 +675,104 @@
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v3.4.38",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "b03b02dcea26ba4c65c16a73bab4f00c186b13da"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b03b02dcea26ba4c65c16a73bab4f00c186b13da",
-                "reference": "b03b02dcea26ba4c65c16a73bab4f00c186b13da",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.4.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c2098705326addae6e6742151dfade47ac71da1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c2098705326addae6e6742151dfade47ac71da1b",
+                "reference": "c2098705326addae6e6742151dfade47ac71da1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -707,9 +795,23 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Process Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "time": "2020-02-04T08:04:52+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-22T22:36:24+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -837,11 +939,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.0"
+        "php": ">=7.1.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "7.1.3"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Rebased and slightly extended variation on #76. CC @homotechsual @seamuslee001 

Note that Symfony 4 requires PHP 7.1.3. According to docs, CiviCRM has [required PHP 7.1 since 5.25.0](https://docs.civicrm.org/installation/en/latest/general/requirements/), and 5.25 was current [May 2020](https://lab.civicrm.org/dev/release). So I don't see any reason to hold it back.

This does NOT update `symfony/console`. That appears to cause some test-failures - and likely requires its own/more involved change.

Spot-checked tests on a couple local builds


```
### wpmaster+5.39

$ civibuild restore wpmaster && cv flush --cwd=/Users/totten/bknix/build/wpmaster/web && XDEBUG_MODE=off XDEBUG_PORT= CV_TEST_BUILD=/Users/totten/bknix/build/wpmaster/web phpunit7 --group std --debug

Time: 38.39 seconds, Memory: 12.00 MB

OK (118 tests, 283 assertions)

### dmaster+5.44

# Note: this had 1 failure, which was pre-existing and specific to my local build.

$ civibuild restore dmaster && cv flush --cwd=/Users/totten/bknix/build/dmaster/web && XDEBUG_MODE=off XDEBUG_PORT= CV_TEST_BUILD=/Users/totten/bknix/build/dmaster/web phpunit7 --group std --debug


There was 1 failure:

1) Civi\Cv\Command\ShowCommandTest::testShowJson
Failed asserting that '7.83-dev' matches PCRE pattern "/^([0-9\.\-]|alpha|beta|master|x)+$/".

/Users/totten/src/cv/tests/Command/ShowCommandTest.php:18

FAILURES!
Tests: 118, Assertions: 292, Failures: 1.

```