### PR TITLE
Update bootstrapping for drupal 9 and update the url command test and…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,25 +8,25 @@
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
-            "version": "v2.1.1",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-downloads-plugin.git",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269"
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/8722bc7d547315be39397a3078bb51ee053ca269",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
+                "composer-plugin-api": "^1.1 || ^2.0",
                 "php": ">=5.6",
                 "togos/gitignore": "~1.1.1"
             },
             "require-dev": {
-                "composer/composer": "~1.0",
+                "composer/composer": "~1.0 || ~2.0",
                 "friendsofphp/php-cs-fixer": "^2.3",
                 "phpunit/phpunit": "^5.7",
                 "totten/process-helper": "^1.0.1"
@@ -55,7 +55,10 @@
                 }
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
-            "time": "2019-08-28T00:33:51+00:00"
+            "support": {
+                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
+            },
+            "time": "2020-11-02T05:26:23+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -945,5 +948,5 @@
     "platform-overrides": {
         "php": "7.1.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -129,7 +129,6 @@ class CmsBootstrap {
       $this->writeln("Simulate web environment in CLI", OutputInterface::VERBOSITY_DEBUG);
       $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
     }
-
     $func = 'boot' . $cms['type'];
     if (!is_callable([$this, $func])) {
       throw new \Exception("Failed to locate boot function ($func)");
@@ -175,6 +174,10 @@ class CmsBootstrap {
     // PRE-CONDITIONS: CMS has already been booted, and Civi is already installed.
     if (function_exists('civicrm_initialize')) {
       civicrm_initialize();
+    }
+    elseif (class_exists('Drupal')) {
+      //Drupal 8 / 9
+      \Drupal::service('civicrm')->initialize();
     }
     // else if Joomla weirdness, do that
     else {

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -26,7 +26,7 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
   }
 
   public function testBoot() {
-    $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory")) ? "found" : "not-found";');
+    $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory") || class_exists("Drupal")) ? "found" : "not-found";');
 
     $p1 = Process::runOk($this->cv("ev $checkBoot"));
     $this->assertRegExp('/^found$/', $p1->getOutput());

--- a/tests/Command/UrlCommandTest.php
+++ b/tests/Command/UrlCommandTest.php
@@ -53,13 +53,13 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
 
   public function testExtPaths() {
     $plain = rtrim($this->cvJsonOk("url -x civicrm"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm($|/\w+$);', $plain);
+    $this->assertRegExp(';https?://.*/civicrm($|/core$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm(/$|/\w+/$);', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/$|/core/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/packages"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/|/core/)packages$;', $plain);
   }
 
   public function testDynamicExprPaths() {
@@ -75,6 +75,9 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp(';https?://.*/civicrm(/$|/\w+/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/packages'"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm(/|/core/)packages$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -d '[civicrm.packages]'"), "\n");
     $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
   }
 

--- a/tests/Command/UrlCommandTest.php
+++ b/tests/Command/UrlCommandTest.php
@@ -53,10 +53,10 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
 
   public function testExtPaths() {
     $plain = rtrim($this->cvJsonOk("url -x civicrm"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm($|/\w+$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/$|/\w+/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/packages"), "\n");
     $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
@@ -69,10 +69,10 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
     }
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]'"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm($|/\w+$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/'"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/$|/\w+/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/packages'"), "\n");
     $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);


### PR DESCRIPTION
… composer downloads package as well

This updates to fix some test failures when running cv tests using a d9 build but I still get these failures

ping @totten @homotechsual 

```
There were 4 failures:

1) Civi\Cv\Command\EvalCommandTest::testBoot
Failed asserting that 'not-found\n
' matches PCRE pattern "/^found$/".

/home/seamus/cv/tests/Command/EvalCommandTest.php:32

2) Civi\Cv\Command\ShowCommandTest::testShowJson
Failed asserting that 'Unknown' matches PCRE pattern "/^([0-9\.\-]|alpha|beta|master|x)+$/".

/home/seamus/cv/tests/Command/ShowCommandTest.php:18

3) Civi\Cv\Command\UrlCommandTest::testExtPaths
Failed asserting that 'http://d9demo/libraries/civicrm/core/packages' matches PCRE pattern ";https?://.*/civicrm/packages$;".

/home/seamus/cv/tests/Command/UrlCommandTest.php:62

4) Civi\Cv\Command\UrlCommandTest::testDynamicExprPaths
Failed asserting that 'http://d9demo/libraries/civicrm/core/packages' matches PCRE pattern ";https?://.*/civicrm/packages$;".

/home/seamus/cv/tests/Command/UrlCommandTest.php:78
```

3 & 4 look like legit failures because the url should be `http://d9demo/libraries/civicrm/packages` not `http://d9demo/libraries/civicrm/core/packages` 