### PR TITLE
Bootstrap, CmsBootstrap - No external deps

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @endcode
  *
  * This class is intended to be run *before* the classloader is available. Therefore, it
- * must be self-sufficient.
+ * must be self-sufficient - do not rely on other classes, even in the same package.
  *
  * A key issue is locating the civicrm.settings.php file -- this is complicated because
  * each CMS has a different structure, because some CMS's have multisite features, and
@@ -175,7 +175,7 @@ class Bootstrap {
     if (!defined('CIVICRM_SETTINGS_PATH')) {
 
       $this->options = $options = array_merge($this->options, $options);
-      $this->writeln("Options: " . Encoder::encode($options, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+      $this->writeln("Options: " . json_encode($options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), OutputInterface::VERBOSITY_DEBUG);
 
       $this->writeln("Find settings file", OutputInterface::VERBOSITY_DEBUG);
       $settings = $this->getCivicrmSettingsPhp($options);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -186,9 +186,15 @@ class Bootstrap {
           . " To customize, set variable CIVICRM_SETTINGS to point to the preferred civicrm.settings.php.");
       }
 
-      $this->writeln("Load supplemental configuration for \"$settings\"", OutputInterface::VERBOSITY_DEBUG);
-      $reader = new SiteConfigReader($settings);
-      $GLOBALS['_CV'] = $reader->compile(array('buildkit', 'home'));
+      if (class_exists('Civi\Cv\SiteConfigReader')) {
+        $this->writeln("Load supplemental configuration for \"$settings\"", OutputInterface::VERBOSITY_DEBUG);
+        $reader = new SiteConfigReader($settings);
+        $GLOBALS['_CV'] = $reader->compile(array('buildkit', 'home'));
+      }
+      else {
+        $this->writeln("Warning: Not loading supplemental configuration for \"$settings\". SiteConfigReader is missing.", OutputInterface::VERBOSITY_DEBUG);
+        $GLOBALS['_CV'] = [];
+      }
 
       $this->writeln("Load settings file \"" . $settings . "\"", OutputInterface::VERBOSITY_DEBUG);
       define('CIVICRM_SETTINGS_PATH', $settings);

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\Route;
  * @endcode
  *
  * This class is intended to be run *before* the classloader is available. Therefore, it
- * must be self-sufficient.
+ * must be self-sufficient - do not rely on other classes, even in the same package.
  *
  * By default, bootstrap will scan PWD and every ancestor directory to see if it
  * contains a supported CMS. If you have performance considerations, or if the
@@ -102,7 +102,7 @@ class CmsBootstrap {
    * @throws \Exception
    */
   public function bootCms() {
-    $this->writeln("Options: " . Encoder::encode($this->options, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    $this->writeln("Options: " . json_encode($this->options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), OutputInterface::VERBOSITY_DEBUG);
 
     if ($this->options['env'] && getenv($this->options['env'])) {
       $cmsExpr = getenv($this->options['env']);
@@ -121,7 +121,7 @@ class CmsBootstrap {
       $cms = $this->findCmsRoot($this->getSearchDir());
     }
 
-    $this->writeln("CMS: " . Encoder::encode($cms, 'json-pretty'), OutputInterface::VERBOSITY_DEBUG);
+    $this->writeln("CMS: " . json_encode($options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), OutputInterface::VERBOSITY_DEBUG);
     if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
       throw new \Exception("Failed to parse or find a CMS");
     }

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -50,12 +50,13 @@ class CmsBootstrap {
   /**
    * Symphony OutputInterface provide during booting to enable the command-line
    * 'v', 'vv' and 'vvv' options
+   * @var \Symfony\Component\Console\Output\OutputInterface
    * @see http://symfony.com/doc/current/console/verbosity.html
    */
   protected $output = FALSE;
 
   /**
-   * @var array|NULL
+   * @var array|null
    */
   protected $bootedCms = NULL;
 


### PR DESCRIPTION
These files were originally written with the intent to run without any other supporting classes. A few small/non-critical deps have snuck in. Simplify.