### PR TITLE
Update to use Symfony Console v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /bin/phpunit
 /bin/php-parse
 /bin/psysh
+/bin/var-dump-server

--- a/README.md
+++ b/README.md
@@ -165,16 +165,15 @@ $ git clone https://github.com/civicrm/cv
 $ cd cv
 $ composer install
 $ export CV_TEST_BUILD=/home/me/buildkit/build/dmaster/web/
-$ phpunit5 --group std
-PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
+$ phpunit7 --group std
+PHPUnit 7.5.15 by Sebastian Bergmann and contributors.
 
-Configuration read from /home/me/src/cv/phpunit.xml.dist
+...............................................................  63 / 118 ( 53%)
+.......................................................         118 / 118 (100%)
 
-.................................................
+Time: 3.13 minutes, Memory: 14.00 MB
 
-Time: 2 seconds, Memory: 6.50Mb
-
-OK (49 tests, 121 assertions)
+OK (118 tests, 295 assertions)
 ```
 
 > We generally choose an existing installation based on `civibuild`
@@ -187,7 +186,7 @@ with various CMS's and file structures).  Prepare these builds separately
 and loop through them, e.g.
 
 ```
-$ for CV_TEST_BUILD in /home/me/buildkit/build/{dmaster,wpmaster,bmaster} ; do export CV_TEST_BUILD; phpunit5 --group std; done
+$ for CV_TEST_BUILD in /home/me/buildkit/build/{dmaster,wpmaster,bmaster} ; do export CV_TEST_BUILD; phpunit7 --group std; done
 ```
 
 Unit-Tests (Installer)
@@ -208,5 +207,5 @@ Given these extra requirements, this test runs as a separate group.
 A typical execution might look like:
 
 ```
-$ env DEBUG=1 OFFLINE=1 CV_SETUP_PATH=$HOME/src/civicrm-setup phpunit5 --group installer
+$ env DEBUG=1 OFFLINE=1 CV_SETUP_PATH=$HOME/src/civicrm-setup phpunit7 --group installer
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/console": "~2.8|^3",
+        "symfony/console": "~2.8|^3|^4",
         "symfony/process": "^4",
         "symfony/filesystem": "^4",
         "psy/psysh": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/console": "~2.8|^3|^4",
+        "symfony/console": "^4",
         "symfony/process": "^4",
         "symfony/filesystem": "^4",
         "psy/psysh": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4d2477055a036a19e56485ba758a5a6",
+    "content-hash": "15e8432e08107b85502324825521bde3",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dde955d5377b93e9f9102682cd2bc120",
+    "content-hash": "f4d2477055a036a19e56485ba758a5a6",
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -55,9 +55,6 @@
                 }
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
-            "support": {
-                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
-            },
             "time": "2020-11-02T05:26:23+00:00"
         },
         {
@@ -235,6 +232,55 @@
             "time": "2018-02-28T20:30:58+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -356,39 +402,51 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.15",
+            "version": "v4.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f"
+                "reference": "329b3a75cc6b16d435ba1b1a41df54a53382a3f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d5643cd095e5e37d31e004bb2606b5dd7e96602f",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/329b3a75cc6b16d435ba1b1a41df54a53382a3f0",
+                "reference": "329b3a75cc6b16d435ba1b1a41df54a53382a3f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/debug": "~2.7,>=2.7.2|~3.0.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1|~3.0.0",
-                "symfony/process": "~2.1|~3.0.0"
+                "psr/log": "^1|^2",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -411,9 +469,23 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
-            "time": "2016-12-06T11:59:35+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-04T12:23:33+00:00"
         },
         {
             "name": "symfony/debug",
@@ -678,6 +750,82 @@
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
             "name": "symfony/polyfill-php80",
             "version": "v1.23.1",
             "source": {
@@ -817,6 +965,82 @@
             "time": "2021-11-22T22:36:24+00:00"
         },
         {
+            "name": "symfony/service-contracts",
+            "version": "v1.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "633df678bec3452e04a7b0337c9bcfe7354124b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/633df678bec3452e04a7b0337c9bcfe7354124b3",
+                "reference": "633df678bec3452e04a7b0337c9bcfe7354124b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-04T13:32:43+00:00"
+        },
+        {
             "name": "symfony/var-dumper",
             "version": "v3.4.38",
             "source": {
@@ -948,5 +1172,5 @@
     "platform-overrides": {
         "php": "7.1.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,25 +8,25 @@
     "packages": [
         {
             "name": "civicrm/composer-downloads-plugin",
-            "version": "v2.1.1",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/civicrm/composer-downloads-plugin.git",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269"
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/8722bc7d547315be39397a3078bb51ee053ca269",
-                "reference": "8722bc7d547315be39397a3078bb51ee053ca269",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/3aabb6d259a86158d01829fc2c62a2afb9618877",
+                "reference": "3aabb6d259a86158d01829fc2c62a2afb9618877",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
+                "composer-plugin-api": "^1.1 || ^2.0",
                 "php": ">=5.6",
                 "togos/gitignore": "~1.1.1"
             },
             "require-dev": {
-                "composer/composer": "~1.0",
+                "composer/composer": "~1.0 || ~2.0",
                 "friendsofphp/php-cs-fixer": "^2.3",
                 "phpunit/phpunit": "^5.7",
                 "totten/process-helper": "^1.0.1"
@@ -55,7 +55,10 @@
                 }
             ],
             "description": "Composer plugin for downloading additional files within any composer package.",
-            "time": "2019-08-28T00:33:51+00:00"
+            "support": {
+                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
+            },
+            "time": "2020-11-02T05:26:23+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -945,5 +948,5 @@
     "platform-overrides": {
         "php": "7.1.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ namespace Civi\Cv;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\ErrorHandler;
 
 class Application extends \Symfony\Component\Console\Application {
 
@@ -12,7 +13,19 @@ class Application extends \Symfony\Component\Console\Application {
    */
   public static function main($binDir) {
     $application = new Application('cv', '@package_version@');
-    $application->run();
+
+    $application->setAutoExit(FALSE);
+    $running = TRUE;
+    register_shutdown_function(function () use (&$running) {
+      if ($running) {
+        // Something - like a bad eval() - interrupted normal execution.
+        // Make sure the status code reflects that.
+        exit(255);
+      }
+    });
+    $result = $application->run();
+    $running = FALSE;
+    exit($result);
   }
 
   public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN') {

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -130,7 +130,6 @@ class CmsBootstrap {
       $this->writeln("Simulate web environment in CLI", OutputInterface::VERBOSITY_DEBUG);
       $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
     }
-
     $func = 'boot' . $cms['type'];
     if (!is_callable([$this, $func])) {
       throw new \Exception("Failed to locate boot function ($func)");
@@ -176,6 +175,10 @@ class CmsBootstrap {
     // PRE-CONDITIONS: CMS has already been booted, and Civi is already installed.
     if (function_exists('civicrm_initialize')) {
       civicrm_initialize();
+    }
+    elseif (class_exists('Drupal')) {
+      //Drupal 8 / 9
+      \Drupal::service('civicrm')->initialize();
     }
     // else if Joomla weirdness, do that
     else {

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -26,7 +26,7 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
   }
 
   public function testBoot() {
-    $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory")) ? "found" : "not-found";');
+    $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory") || class_exists("Drupal")) ? "found" : "not-found";');
 
     $p1 = Process::runOk($this->cv("ev $checkBoot"));
     $this->assertRegExp('/^found$/', $p1->getOutput());

--- a/tests/Command/ShowCommandTest.php
+++ b/tests/Command/ShowCommandTest.php
@@ -14,8 +14,8 @@ class ShowCommandTest extends \Civi\Cv\CivilTestCase {
     $p = $this->cv("vars:show");
     $p->run();
     $data = json_decode($p->getOutput(), 1);
-    $this->assertRegExp('/^([0-9\.\-]|alpha|beta|master|x)+$/', $data['CIVI_VERSION']);
-    $this->assertRegExp('/^([0-9\.\-]|alpha|beta|master|x)+$/', $data['CMS_VERSION']);
+    $this->assertRegExp('/^([0-9\.\-]|alpha|beta|dev|master|x)+$/', $data['CIVI_VERSION']);
+    $this->assertRegExp('/^([0-9\.\-]|alpha|beta|dev|master|x)+$/', $data['CMS_VERSION']);
     $this->assertTrue(is_dir($data['CMS_ROOT']));
     $this->assertTrue(is_dir($data['CIVI_CORE']));
   }

--- a/tests/Command/UrlCommandTest.php
+++ b/tests/Command/UrlCommandTest.php
@@ -53,13 +53,13 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
 
   public function testExtPaths() {
     $plain = rtrim($this->cvJsonOk("url -x civicrm"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm($|/core$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/$|/core/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -x civicrm/packages"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/|/core/)packages$;', $plain);
   }
 
   public function testDynamicExprPaths() {
@@ -69,12 +69,15 @@ class UrlCommandTest extends \Civi\Cv\CivilTestCase {
     }
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]'"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm($|/\w+$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/'"), "\n");
-    $this->assertRegExp(';https?://.*/civicrm/$;', $plain);
+    $this->assertRegExp(';https?://.*/civicrm(/$|/\w+/$);', $plain);
 
     $plain = rtrim($this->cvJsonOk("url -d '[civicrm.root]/packages'"), "\n");
+    $this->assertRegExp(';https?://.*/civicrm(/|/core/)packages$;', $plain);
+
+    $plain = rtrim($this->cvJsonOk("url -d '[civicrm.packages]'"), "\n");
     $this->assertRegExp(';https?://.*/civicrm/packages$;', $plain);
   }
 


### PR DESCRIPTION
This applies Tim's trick from #71 to fix issue with exit codes and updates Symfony Console version to be 4.x so that we can install on d9 using composer.