### PR TITLE
Add "cv pipe" subcommand

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -4,7 +4,6 @@ namespace Civi\Cv;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Debug\ErrorHandler;
 
 class Application extends \Symfony\Component\Console\Application {
 
@@ -83,6 +82,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\FillCommand();
     $commands[] = new \Civi\Cv\Command\FlushCommand();
     $commands[] = new \Civi\Cv\Command\PathCommand();
+    $commands[] = new \Civi\Cv\Command\PipeCommand();
     $commands[] = new \Civi\Cv\Command\SqlCliCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeCommand();

--- a/src/Command/PipeCommand.php
+++ b/src/Command/PipeCommand.php
@@ -1,0 +1,68 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\BootTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PipeCommand extends BaseCommand {
+
+  use BootTrait;
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $this
+      ->setName('pipe')
+      ->setDescription('Start a Civi::pipe session (JSON-RPC 2.0)')
+      ->setHelp('Start a Civi::pipe session (JSON-RPC 2.0)
+
+The Civi::pipe protocol provides a line-oriented session for executing multiple requests in a single CiviCRM instance.
+
+Callers may request *connection flags*, such as:
+
+* v: Show version
+* l: Show login support
+* t: Enable trusted mode
+* u: Enable untrusted mode
+
+Examples:
+
+  $ cv pipe
+  {"Civi::pipe":{"v":"5.47.alpha1","t":"trusted","l":["nologin"]}}
+
+  $ cv pipe uv
+  {"Civi::pipe":{"u":"untrusted","v":"5.47.alpha1"}}
+
+See also: https://docs.civicrm.org/dev/en/latest/framework/pipe
+');
+    $this->addArgument('connection-flags', InputArgument::OPTIONAL, 'List of connection-flags (Default: Determined by civicrm-core)', NULL);
+    // Tempting to add separate CLI flags that map to 'connection-flags', but this seems easier given that:
+    // 1. The existing flags have different meanings (eg (v)erbose vs (v)ersion).
+    // 2. The connection-flags are owned by civicrm-core.git. Don't want to update this whenever there's a new one.
+
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+    if (!is_callable(['Civi', 'pipe'])) {
+      fwrite(STDERR, "This version of CiviCRM does not include Civi::pipe() support.\n");
+      return 1;
+    }
+    if ($flags = $input->getArgument('connection-flags')) {
+      \Civi::pipe($flags);
+    }
+    else {
+      \Civi::pipe();
+    }
+    return 0;
+  }
+
+}


### PR DESCRIPTION
This is just short-hand for `cv ev 'Civi::pipe();' introduced by https://github.com/civicrm/civicrm-core/pull/22262