### PR TITLE
Fix handling of `exit(0)` (#114)

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -16,7 +16,8 @@ class Application extends \Symfony\Component\Console\Application {
     $application->setAutoExit(FALSE);
     $running = TRUE;
     register_shutdown_function(function () use (&$running) {
-      if ($running) {
+      $error = error_get_last();
+      if ($running && $error) {
         // Something - like a bad eval() - interrupted normal execution.
         // Make sure the status code reflects that.
         exit(255);

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -25,6 +25,21 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp('/^eval says version is [0-9a-z\.]+\s*$/', $p->getOutput());
   }
 
+  public function testPhpEval_Exit0() {
+    $p = Process::runDebug($this->cv("ev 'exit(0);'"));
+    $this->assertEquals(0, $p->getExitCode());
+  }
+
+  public function testPhpEval_Exit1() {
+    $p = Process::runDebug($this->cv("ev 'exit(1);'"));
+    $this->assertEquals(1, $p->getExitCode());
+  }
+
+  public function testPhpEval_ExitCodeError() {
+    $p = Process::runDebug($this->cv("ev 'invalid();'"));
+    $this->assertEquals(255, $p->getExitCode());
+  }
+
   public function testBoot() {
     $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory") || class_exists("Drupal")) ? "found" : "not-found";');
 


### PR DESCRIPTION
Before:

```
$ ./bin/cv ev --level=none 'exit(0);' ; echo $?
255

$ ./bin/cv ev --level=none 'exit(1);' ; echo $?
1

$ ./bin/cv ev --level=none 'invalid();' ; echo $?
255
```

After:

```
$ ./bin/cv ev --level=none 'exit(0);' ; echo $?
0

$ ./bin/cv ev --level=none 'exit(1);' ; echo $?
1

$ ./bin/cv ev --level=none 'invalid();' ; echo $?
255
```