### PR TITLE
"upgrade:db" - Add option to "step through" tasks (--step)

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -6,10 +6,16 @@ use Civi\Cv\Util\OptionCallbackTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class BaseCommand extends Command {
 
   use OptionCallbackTrait;
+
+  /**
+   * @var \Symfony\Component\Console\Style\StyleInterface
+   */
+  private $io;
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -17,7 +23,15 @@ class BaseCommand extends Command {
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
+    $this->io = new SymfonyStyle($input, $output);
     $this->runOptionCallbacks($input, $output);
+  }
+
+  /**
+   * @return \Symfony\Component\Console\Style\StyleInterface
+   */
+  protected function getIO() {
+    return $this->io;
   }
 
   protected function assertBooted() {

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -137,7 +137,7 @@ Examples:
     }
 
     $output->writeln("<info>Executing upgrade...</info>", $niceMsgVerbosity);
-    $runner = new ConsoleQueueRunner($this->getIO(), $output, $queue, $input->getOption('dry-run'), $input->getOption('step'));
+    $runner = new ConsoleQueueRunner($this->getIO(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
     $runner->runAll();
 
     $output->writeln("<info>Finishing upgrade...</info>", $niceMsgVerbosity);

--- a/src/Util/ConsoleQueueRunner.php
+++ b/src/Util/ConsoleQueueRunner.php
@@ -22,11 +22,6 @@ class ConsoleQueueRunner {
   private $io;
 
   /**
-   * @var \Symfony\Component\Console\Output\OutputInterface
-   */
-  private $output;
-
-  /**
    * @var \CRM_Queue_Queue
    */
   private $queue;
@@ -40,14 +35,12 @@ class ConsoleQueueRunner {
    * ConsoleQueueRunner constructor.
    *
    * @param \Symfony\Component\Console\Style\SymfonyStyle $io
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param \CRM_Queue_Queue $queue
    * @param bool $dryRun
    * @param bool $step
    */
-  public function __construct(\Symfony\Component\Console\Style\SymfonyStyle $io, \Symfony\Component\Console\Output\OutputInterface $output, \CRM_Queue_Queue $queue, $dryRun = FALSE, $step = FALSE) {
+  public function __construct(\Symfony\Component\Console\Style\SymfonyStyle $io, \CRM_Queue_Queue $queue, $dryRun = FALSE, $step = FALSE) {
     $this->io = $io;
-    $this->output = $output;
     $this->queue = $queue;
     $this->dryRun = $dryRun;
     $this->step = (bool) $step;
@@ -71,16 +64,16 @@ class ConsoleQueueRunner {
       $item = $this->queue->stealItem();
       $task = $item->data;
 
-      if ($this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
-        // Symfony progress bar would be prettier, but they don't allow
+      if ($io->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
+        // Symfony progress bar would be prettier, but (when last checked) they didn't allow
         // resetting when the queue-length expands dynamically.
-        $this->output->write(".");
+        $io->write(".");
       }
-      elseif ($this->output->getVerbosity() === OutputInterface::VERBOSITY_VERBOSE) {
-        $this->output->writeln(sprintf("<info>%s</info>", $task->title));
+      elseif ($io->getVerbosity() === OutputInterface::VERBOSITY_VERBOSE) {
+        $io->writeln(sprintf("<info>%s</info>", $task->title));
       }
-      elseif ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-        $this->output->writeln(sprintf("<info>%s</info> (<comment>%s</comment>)", $task->title, self::formatTaskCallback($task)));
+      elseif ($io->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
+        $io->writeln(sprintf("<info>%s</info> (<comment>%s</comment>)", $task->title, self::formatTaskCallback($task)));
       }
 
       $action = 'y';
@@ -97,7 +90,7 @@ class ConsoleQueueRunner {
         }
         catch (\Exception $e) {
           // WISHLIST: For interactive mode, perhaps allow retry/skip?
-          $this->output->writeln(sprintf("<error>Error executing task \"%s\"</error>", $task->title));
+          $io->writeln(sprintf("<error>Error executing task \"%s\"</error>", $task->title));
           throw $e;
         }
       }
@@ -105,8 +98,8 @@ class ConsoleQueueRunner {
       $this->queue->deleteItem($item);
     }
 
-    if ($this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
-      $this->output->writeln("");
+    if ($io->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
+      $io->newLine();
     }
   }
 


### PR DESCRIPTION
The command `upgrade:db` prepares a list of upgrade tasks, and then it executes them all.

However, if you want carefully inspect what happens between steps (eg by looking at the database in another window), then it may help to slow-down the execution process.

This adds an option `--step`. This enables verbose output and pause before executing each step:

![Screenshot from 2022-04-12 00-08-54](https://user-images.githubusercontent.com/1336047/162901460-f4e4770d-8ac7-4765-8dab-7c582227625c.png)
