### PR TITLE
#117 - Symfony cmf removed in drupal 10

### DIFF
--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -2,7 +2,6 @@
 namespace Civi\Cv;
 
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -256,8 +255,8 @@ class CmsBootstrap {
     $kernel->preHandle($request);
     $container = $kernel->rebuildContainer();
     // Add our request to the stack and route context.
-    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));
-    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, '<none>');
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
     $container->get('request_stack')->push($request);
     $container->get('router.request_context')->fromRequest($request);
 


### PR DESCRIPTION
Addresses https://github.com/civicrm/cv/issues/117

This patch works in drupal 9 and 10 but doesn't work in drupal 8, but drupal 8 been eol for 6 months and doesn't get security fixes and civi can be run equally as well on drupal 9.

Before
-------
Simple example from within a drupal 10 install (don't try to install civi):
`cv ev --level=cms-only "echo Drupal::VERSION;"`

`Error: Class "Symfony\Cmf\Component\Routing\RouteObjectInterface" not found in ...\src\CmsBootstrap.php on line 259 #0 [internal function]: Civi\Cv\CmsBootstrap->bootDrupal8()`

After
-----
9.3.9 (or whatever)