### PR TITLE
ArrayUtil -  Define clearer fallback

### DIFF
--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -83,16 +83,20 @@ class ArrayUtil {
    * @param array $columns
    *   A list of columns.
    *   Ex: array(0 => 'color', 1 => 'length').
+   * @param array $defaults
+   *   Default values for any columns that are missing.
+   *   NULL if omitted.
+   *   Ex: array(0 => 'transparent', 1 => '0 ft')
    * @return array
    *   A list of records. Each one is a numerically indexed array.
    *   Ex: $rows[0] = array(0 => 'red', 1 => 'length')
    */
-  public static function convertAssocToNum($records, $columns) {
+  public static function convertAssocToNum($records, $columns, $defaults = []) {
     $result = array();
     foreach ($records as $k => $oldRow) {
       $newRow = array();
       foreach ($columns as $newKey => $oldKey) {
-        $newRow[$newKey] = $oldRow[$oldKey];
+        $newRow[$newKey] = $oldRow[$oldKey] ?? $defaults[$newKey] ?? NULL;
       }
       $result[$k] = $newRow;
     }


### PR DESCRIPTION
Fixes a warning. This appeared to arise with `api4` calls that tabulate data heterogenous records (eg `Individual`s and `Organization`s).

```
[bknix-max:~/bknix/build/joomla-demo/web] ~/src/cv/bin/cv api4 Contact.get -T
Xdebug: [Step Debug] Could not connect to debugging client. Tried: 127.0.0.1:9003 (through xdebug.client_host/xdebug.client_port) :-(
Notice: Undefined index: legal_name in /Users/totten/src/cv/src/Util/ArrayUtil.php on line 95
Notice: Undefined index: organization_name in /Users/totten/src/cv/src/Util/ArrayUtil.php on line 95
Notice: Undefined index: sic_code in /Users/totten/src/cv/src/Util/ArrayUtil.php on line 95
```