### PR TITLE
Remove drupal 8 support since using class_exists doesn't work properly in cmsbootstrap

### DIFF
--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -254,11 +254,8 @@ class CmsBootstrap {
     $kernel->preHandle($request);
     $container = $kernel->rebuildContainer();
     // Add our request to the stack and route context.
-    $routeInterface = class_exists('\Drupal\Core\Routing\RouteObjectInterface')
-      ? '\Drupal\Core\Routing\RouteObjectInterface'
-      : '\Symfony\Cmf\Component\Routing\RouteObjectInterface';
-    $request->attributes->set($routeInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
-    $request->attributes->set($routeInterface::ROUTE_NAME, '<none>');
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT, new \Symfony\Component\Routing\Route('<none>'));
+    $request->attributes->set(\Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME, '<none>');
     $container->get('request_stack')->push($request);
     $container->get('router.request_context')->fromRequest($request);
 


### PR DESCRIPTION
It looks like class_exists is always false so while it seems like it works in drupal 8 and 9 because the old class exists anyway, in drupal 10 it fails.

So just remove drupal 8 support.