### PR TITLE
ConsoleQueueRunner - Raise error that are more like core errors

### DIFF
--- a/src/Util/ConsoleQueueRunner.php
+++ b/src/Util/ConsoleQueueRunner.php
@@ -86,7 +86,10 @@ class ConsoleQueueRunner {
 
       if ($action === 'y' && !$this->dryRun) {
         try {
-          $task->run($taskCtx);
+          $isOK = $task->run($taskCtx);
+          if (!$isOK) {
+            throw new \Exception('Task returned false');
+          }
         }
         catch (\Exception $e) {
           // WISHLIST: For interactive mode, perhaps allow retry/skip?


### PR DESCRIPTION
Corollary to https://github.com/civicrm/civicrm-core/pull/23594

Before
---------

* The core runners (headless-runner and web-runner) complain if tasks end with FALSE-ish values.
* `cv`s console-runner does not care if tasks end with FALSE-ish values.

After
-------

* All 3 runners complain if tasks end with FALSE-ish values.
