### PR TITLE
"debug:container" - Multiple updates

### DIFF
--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -145,7 +145,7 @@ internal services (eg `--all`, `--tag=XXX`, or `-v`).
         $row[] = ['key' => 'factory', 'value' => $this->toPrintableData($factory)];
       }
       foreach ($definition->getMethodCalls() as $n => $call) {
-        $row[] = ['key' => "call[$n]", 'value' => $this->toPrintableData($call)];
+        $row[] = ['key' => "call", 'value' => $this->toPrintableData($call)];
       }
 
       $this->sendTable($input, $output, $row);

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -21,7 +21,8 @@ class DebugContainerCommand extends BaseCommand {
       ->setDescription('Dump the container configuration')
       ->addArgument('name', InputArgument::OPTIONAL, 'An service name or regex')
       ->addOption('concrete', 'C', InputOption::VALUE_NONE, 'Display concrete class names. (This requires activating every matching service.)')
-      ->addOption('all', 'a', InputOption::VALUE_NONE, 'Display all services. (Disable container-optimizations which hide internal services.)')
+      ->addOption('all', 'a', InputOption::VALUE_NONE, 'Display all services, including private/internal.')
+      ->addOption('tag', NULL, InputOption::VALUE_REQUIRED, 'Find services by tag, including private/internal.')
       ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table'])
       ->setHelp('
 Dump the container configuration
@@ -50,6 +51,13 @@ Dump the container configuration
     else {
       $filter = function (Definition $definition, string $name) use ($filterPat) {
         return $name === $filterPat;
+      };
+    }
+
+    if ($input->getOption('tag')) {
+      $input->setOption('all', TRUE);
+      $filter = function (Definition $definition, string $name) use ($filter, $input) {
+        return $definition->getTag($input->getOption('tag')) && $filter($definition, $name);
       };
     }
 

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -17,6 +17,7 @@ class DebugContainerCommand extends BaseCommand {
   protected function configure() {
     $this
       ->setName('debug:container')
+      ->setAliases(['service'])
       ->setDescription('Dump the container configuration')
       ->addArgument('name', InputArgument::OPTIONAL, 'An service name or regex')
       ->addOption('concrete', 'C', InputOption::VALUE_NONE, 'Display concrete class names. (This requires activating every matching service.)')

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -66,6 +66,16 @@ Dump the container configuration
         continue;
       }
 
+      $events = '?';
+      if (class_exists('Civi\Core\Event\EventScanner')) {
+        if ($definition->getTag('event_subscriber') || $definition->getTag('kernel.event_subscriber')) {
+          $events = \Civi\Core\Event\EventScanner::findListeners($definition->getClass());
+        }
+        else {
+          $events = '';
+        }
+      }
+
       $extras = array();
       foreach (['getFactoryClass', 'getFactoryMethod', 'getFactoryService', 'getFactory'] as $factoryCheck) {
         if (is_callable([$definition, $factoryCheck]) && $definition->$factoryCheck()) {
@@ -75,15 +85,15 @@ Dump the container configuration
       if ($definition->getMethodCalls()) {
         $extras[] = sprintf("calls[%s]", count($definition->getMethodCalls()));
       }
-      if ($definition->getTags()) {
-        $extras[] = sprintf("tags[%s]", count($definition->getTags()));
+      foreach ($definition->getTags() as $tag => $tagData) {
+        $extras[] = sprintf("tag[%s]", $tag);
       }
       $class = $input->getOption('concrete') ? get_class(\Civi::service($name)) : $definition->getClass();
 
-      $rows[] = array('service' => $name, 'class' => $class, 'extras' => implode(' ', $extras));
+      $rows[] = array('service' => $name, 'class' => $class, 'events' => $events ? count($events) : '', 'extras' => implode(' ', $extras));
     }
 
-    $this->sendTable($input, $output, $rows, array('service', 'class', 'extras'));
+    $this->sendTable($input, $output, $rows, array('service', 'class', 'events', 'extras'));
   }
 
   /**

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -37,50 +37,48 @@ Dump the container configuration
 
     $filterPat = $input->getArgument('name');
     if (empty($filterPat)) {
-      $filter = function ($name, $definition) {
+      $filter = function (Definition $definition, string $name) {
         return TRUE;
       };
     }
     elseif ($filterPat[0] === '/') {
-      $filter = function ($name, $definition) use ($filterPat) {
+      $filter = function (Definition $definition, string $name) use ($filterPat) {
         return (bool) preg_match($filterPat, $name);
       };
     }
     else {
-      $filter = function ($name, $definition) use ($filterPat) {
+      $filter = function (Definition $definition, string $name) use ($filterPat) {
         return $name === $filterPat;
       };
     }
 
     if (!$input->getOption('all')) {
-      $filter = function ($name, Definition $definition) use ($filter) {
-        return $definition->isPublic() && $filter($name, $definition);
+      $filter = function (Definition $definition, string $name) use ($filter) {
+        return $definition->isPublic() && $filter($definition, $name);
       };
     }
 
-    $rows = array();
     $definitions = $c->getDefinitions();
+    $definitions = array_filter($definitions, $filter, ARRAY_FILTER_USE_BOTH);
     ksort($definitions);
-    foreach ($definitions as $name => $definition) {
-      if (!$filter($name, $definition)) {
-        continue;
-      }
 
-      $events = '?';
-      if (class_exists('Civi\Core\Event\EventScanner')) {
-        if ($definition->getTag('event_subscriber') || $definition->getTag('kernel.event_subscriber')) {
-          $events = \Civi\Core\Event\EventScanner::findListeners($definition->getClass());
-        }
-        else {
-          $events = '';
-        }
-      }
+    if ($output->isVerbose()) {
+      $this->showVerboseReport($input, $output, $definitions);
+    }
+    else {
+      $this->showBasicReport($input, $output, $definitions);
+    }
+  }
+
+  public function showBasicReport(InputInterface $input, OutputInterface $output, array $definitions): void {
+    $rows = [];
+
+    foreach ($definitions as $name => $definition) {
+      $events = $this->getEvents($definition);
 
       $extras = array();
-      foreach (['getFactoryClass', 'getFactoryMethod', 'getFactoryService', 'getFactory'] as $factoryCheck) {
-        if (is_callable([$definition, $factoryCheck]) && $definition->$factoryCheck()) {
-          $extras[] = 'factory';
-        }
+      if ($this->getFactory($definition) !== NULL) {
+        $extras[] = 'factory';
       }
       if ($definition->getMethodCalls()) {
         $extras[] = sprintf("calls[%s]", count($definition->getMethodCalls()));
@@ -94,6 +92,29 @@ Dump the container configuration
     }
 
     $this->sendTable($input, $output, $rows, array('service', 'class', 'events', 'extras'));
+  }
+
+  public function showVerboseReport(InputInterface $input, OutputInterface $output, array $definitions): void {
+    foreach ($definitions as $name => $definition) {
+      $row = [];
+      $row[] = ['key' => 'service', 'value' => $name];
+      $row[] = ['key' => 'class', 'value' => $input->getOption('concrete') ? get_class(\Civi::service($name)) : $definition->getClass()];
+      foreach ($definition->getTags() as $tag => $tagData) {
+        $row[] = ['key' => "tag[$tag]", 'value' => $tagData];
+      }
+
+      foreach ($this->getEvents($definition) as $eventName => $eventValue) {
+        $row[] = ['key' => "event[$eventName]", 'value' => $eventValue];
+      }
+      if ($factory = $this->getFactory($definition)) {
+        $row[] = ['key' => 'factory', 'value' => $factory];
+      }
+      foreach ($definition->getMethodCalls() as $n => $call) {
+        $row[] = ['key' => "call[$n]", 'value' => $call];
+      }
+
+      $this->sendTable($input, $output, $row);
+    }
   }
 
   /**
@@ -118,6 +139,40 @@ Dump the container configuration
 
     $container->compile();
     return $container;
+  }
+
+  /**
+   * @param $definition
+   *
+   * @return array|string
+   */
+  protected function getEvents($definition) {
+    if (class_exists('Civi\Core\Event\EventScanner')) {
+      if ($definition->getTag('event_subscriber') || $definition->getTag('kernel.event_subscriber')) {
+        return \Civi\Core\Event\EventScanner::findListeners($definition->getClass());
+      }
+      else {
+        return '';
+      }
+    }
+    return '?';
+  }
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\Definition $definition
+   * @return array|string|null
+   *   A value describing the factory, or NULL if there is none.
+   */
+  protected function getFactory(Definition $definition) {
+    if (is_callable([$definition, 'getFactory'])) {
+      return $definition->getFactory();
+    }
+    foreach (['getFactoryClass', 'getFactoryMethod', 'getFactoryService'] as $factoryCheck) {
+      if (is_callable([$definition, $factoryCheck]) && $definition->$factoryCheck()) {
+        return 'yes';
+      }
+    }
+    return NULL;
   }
 
 }

--- a/src/Util/Relativizer.php
+++ b/src/Util/Relativizer.php
@@ -1,0 +1,35 @@
+<?php
+namespace Civi\Cv\Util;
+
+class Relativizer {
+
+  /**
+   * @var array
+   */
+  protected $prefixes;
+
+  public function __construct() {
+    $this->prefixes = [
+      '[civicrm.root]/' => \Civi::paths()->getPath('[civicrm.root]/'),
+      '[civicrm.packages]/' => \Civi::paths()->getPath('[civicrm.packages]/'),
+      '[civicrm.files]/' => \Civi::paths()->getPath('[civicrm.files]/'),
+      '[cms.root]/' => \Civi::paths()->getPath('[cms.root]/'),
+    ];
+  }
+
+  /**
+   * @param string $path
+   *   Ex: '/var/www/sites/all/modules/civicrm/CRM/Foo.php
+   * @return string
+   *   Ex: '[civicrm.root]/CRM/Foo.php''
+   */
+  public function filter(string $path): string {
+    foreach ($this->prefixes as $prefix => $prefixPath) {
+      if (\CRM_Utils_File::isChildPath($prefixPath, $path)) {
+        return $prefix . mb_substr($path, mb_strlen($prefixPath));
+      }
+    }
+    return $path;
+  }
+
+}


### PR DESCRIPTION
* Add a shorter command alias `cv service`
* Add more options for finding/selecting services:
    * Allow showing private/internal services (`--internal`, `-i`)
    * Allow filtering by tag name (`--tag=NAME`)
* Add more info for the default report
    * Show actual tag-names
    * Report #registered event listeners (for each service)
* Add verbose (`-v`) output mode with more details about tags, listeners, method-calls, etc