### PR TITLE
CmsBootstrap::bootDrupal8(): bootstrap Drupal 9 with --user config

### DIFF
--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -272,11 +272,21 @@ class CmsBootstrap {
     }
 
     if ($cmsUser) {
-      $entity_manager = \Drupal::entityManager();
-      $users = $entity_manager->getStorage($entity_manager->getEntityTypeFromClass('Drupal\user\Entity\User'))
-        ->loadByProperties(array(
-          'name' => $cmsUser,
-        ));
+      // Drupal 8
+      if (method_exists('Drupal', 'entityManager')) {
+        $entity_manager = \Drupal::entityManager();
+        $users = $entity_manager->getStorage($entity_manager->getEntityTypeFromClass('Drupal\user\Entity\User'))
+          ->loadByProperties(array(
+            'name' => $cmsUser,
+          ));
+      } else {
+        // Drupal 9
+        $entity_manager = \Drupal::entityTypeManager();
+        $users = $entity_manager->getStorage(\Drupal::service('entity_type.repository')->getEntityTypeFromClass('Drupal\user\Entity\User'))
+          ->loadByProperties([
+            'name' => $cmsUser,
+          ]);
+      }
       if (count($users) == 1) {
         foreach ($users as $uid => $user) {
           user_login_finalize($user);


### PR DESCRIPTION
fix #113 

Adaptive logic added to check if `\Drupal::entityManager()` can be called (D8), if not it calls `\Drupal::entityTypeManager()` and gets users the D9 way.

Note: for some reason (I can't see why) `is_callable` returned `true` for the non-existent method and resulted in an "Call to undefined method" whereas `method_exists` returned `false` correctly.