### PR TITLE
Add commands to view/edit settings

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -86,6 +86,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\PipeCommand();
     $commands[] = new \Civi\Cv\Command\SettingSetCommand();
     $commands[] = new \Civi\Cv\Command\SettingGetCommand();
+    $commands[] = new \Civi\Cv\Command\SettingRevertCommand();
     $commands[] = new \Civi\Cv\Command\SqlCliCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -84,6 +84,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\FlushCommand();
     $commands[] = new \Civi\Cv\Command\PathCommand();
     $commands[] = new \Civi\Cv\Command\PipeCommand();
+    $commands[] = new \Civi\Cv\Command\SettingCommand();
     $commands[] = new \Civi\Cv\Command\SqlCliCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeCommand();

--- a/src/Application.php
+++ b/src/Application.php
@@ -84,7 +84,8 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new \Civi\Cv\Command\FlushCommand();
     $commands[] = new \Civi\Cv\Command\PathCommand();
     $commands[] = new \Civi\Cv\Command\PipeCommand();
-    $commands[] = new \Civi\Cv\Command\SettingCommand();
+    $commands[] = new \Civi\Cv\Command\SettingSetCommand();
+    $commands[] = new \Civi\Cv\Command\SettingGetCommand();
     $commands[] = new \Civi\Cv\Command\SqlCliCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeCommand();

--- a/src/Command/SettingCommand.php
+++ b/src/Command/SettingCommand.php
@@ -1,0 +1,111 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\BootTrait;
+use Civi\Cv\Util\SettingTrait;
+use Civi\Cv\Util\StructuredOutputTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SettingCommand extends BaseCommand {
+
+  use BootTrait;
+  use StructuredOutputTrait;
+  use SettingTrait;
+
+  /**
+   * @param string|null $name
+   */
+  public function __construct($name = NULL) {
+    parent::__construct($name);
+  }
+
+  protected function configure() {
+    $C = '<comment>';
+    $_C = '</comment>';
+    $I = '<info>';
+    $_I = '</info>';
+
+    $this
+      ->setName('setting:set')
+      ->setAliases(['setting'])
+      ->setDescription('Update CiviCRM settings')
+      ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
+      ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list'], 'fallback' => 'table'])
+      ->addOption('dry-run', 'N', InputOption::VALUE_NONE, 'Preview the API call. Do not execute.')
+      ->addOption('scope', NULL, InputOption::VALUE_REQUIRED, 'Domain to configure', 'domain')
+      ->addArgument('key=value', InputArgument::IS_ARRAY)
+      ->setHelp("Update CiviCRM settings
+
+If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_I} ({$I}-N{$_I}).
+
+{$C}Specification: Piped JSON${_C}
+
+    {$C}echo{$_C} {$I}JSON{$_I} | {$C}cv setting${_C} {$C}--in=json${_C}
+
+{$C}Specification: JSON-ish Key-Value${_C}
+
+    {$C}cv setting${_C} [{$I}KEY{$_I}={$I}VALUE{$_I}]... [{$I}JSON-OBJECT{$_I}]...
+
+    Use ${I}KEY{$_I}={$I}VALUE{$_I} to set an input to a specific value. The value may be a bare string
+    or it may be JSON (beginning with '[' or '{' or '\"').
+
+    Use {$I}JSON-OBJECT{$_I} if you want to pass several fields as one pure JSON string.
+    A parameter which begins with '{' will be interpreted as a JSON expression.
+
+{$C}Setting Scope{$_C}
+
+    All CiviCRM settings are formally attached to a scope, such as a {$I}Contact{$_I} or {$I}Domain{$_I}.
+    For most tasks in most deployments, there is only one important scope ({$I}domain #1{$_I}).
+    In some edge-cases, you may need to target a specific scope Here are some example scopes:
+
+    {$C}cv setting --scope={$_C}{$I}domain{$_I}                (default domain)
+    {$C}cv setting --scope={$_C}{$I}domain:*{$_I}              (all domains)
+    {$C}cv setting --scope={$_C}{$I}domain:12{$_I}             (domain #12)
+    {$C}cv setting --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}  (admin's contact)
+    {$C}cv setting --scope={$_C}{$I}contact:201{$_I}           (contact #201)
+");
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $C = '<comment>';
+    $_C = '</comment>';
+    $I = '<info>';
+    $_I = '</info>';
+
+    $this->boot($input, $output);
+
+    $params = $this->parseSettingParams($input);
+    if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+      $output->writeln("{$I}Params{$_I}: " . json_encode($params, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    $result = [];
+    $useExtraEscape = in_array($input->getOption('out'), ['table']);
+    foreach ($this->findSettings($input->getOption('scope')) as $settingScope => $settingBag) {
+      /** @var \Civi\Core\SettingsBag $settingBag */
+      foreach ($params as $settingKey => $settingValue) {
+        if ($settingBag->getMandatory($settingKey) !== NULL) {
+          $output->writeln("<comment>WARNING: \"$settingKey\" has a mandatory override. Stored settings may be inoperative.</comment>");
+        }
+        if (!$input->getOption('dry-run')) {
+          $settingBag->set($settingKey, $settingValue);
+        }
+
+        $row = [
+          'scope' => $settingScope,
+          'key' => $settingKey,
+          'value' => $useExtraEscape ? json_encode($settingValue, JSON_UNESCAPED_SLASHES) : $settingValue,
+        ];
+        $result[] = $row;
+      }
+    }
+
+    $this->sendTable($input, $output, (array) $result);
+    return 0;
+  }
+
+}

--- a/src/Command/SettingGetCommand.php
+++ b/src/Command/SettingGetCommand.php
@@ -32,6 +32,7 @@ class SettingGetCommand extends BaseCommand {
         'fallback' => 'table',
         'availColumns' => 'scope,key,value,default,explicit,mandatory,layer',
         'defaultColumns' => 'scope,key,value,layer',
+        'specialFormats' => ['civicrm.settings.php'],
       ])
       ->addOption('scope', NULL, InputOption::VALUE_REQUIRED, 'Domain to configure', 'domain')
       ->addArgument('name', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'An setting name or regex')
@@ -46,13 +47,14 @@ class SettingGetCommand extends BaseCommand {
     {$C}cv setting:get {$_C}{$I}mailerJobSize mailerJobsMax{$_I}      (specific settings)
     {$C}cv setting:get /{$_C}{$I}mail{$_I}{$C}/{$_C}                           (any settings that involve \"mail\")
 
-{$C}Verbosity{$_C}
+{$C}Output Modes{$_C}
 
     By default, display settings and their current values in a summary table.
     For more detailed information, you may mix {$C}-v{$_C}, {$C}--columns{$_C}, and/or {$C}-out{$_C}.
 
     {$C}cv setting:get -v{$_C}                               (detailed report, console)
     {$C}cv setting:get --out={$_C}{$I}json-pretty{$_I}{$C} --columns={$_C}{$I}*{$_I}    (detailed report, json)
+    {$C}cv setting:get --out={$_C}{$I}civicrm.settings.php{$_I}       (export for use in civicrm.settings.php)
 
 {$C}Setting Scope{$_C}
 

--- a/src/Command/SettingGetCommand.php
+++ b/src/Command/SettingGetCommand.php
@@ -42,17 +42,17 @@ class SettingGetCommand extends BaseCommand {
     By default, display all settings. You may optionally lookup specific settings by name
     or by regular expression.
 
-    {$C}cv setting:get {$_C}{$I}mailerJobSize{$_I}                 (specific settings)
-    {$C}cv setting:get {$_C}{$I}mailerJobSize mailerJobsMax{$_I}   (specific settings)
-    {$C}cv setting:get /{$_C}{$I}mail{$_I}{$C}/{$_C}                        (any settings that involve \"mail\")
+    {$C}cv setting:get {$_C}{$I}mailerJobSize{$_I}                    (specific settings)
+    {$C}cv setting:get {$_C}{$I}mailerJobSize mailerJobsMax{$_I}      (specific settings)
+    {$C}cv setting:get /{$_C}{$I}mail{$_I}{$C}/{$_C}                           (any settings that involve \"mail\")
 
 {$C}Verbosity{$_C}
 
     By default, display settings and their current values in a summary table.
     For more detailed information, you may mix {$C}-v{$_C}, {$C}--columns{$_C}, and/or {$C}-out{$_C}.
 
-     {$C}cv setting:get -v{$_C}
-     {$C}cv setting:get --out={$_C}{$I}json-pretty{$_I}{$C} --columns={$_C}{$I}*{$_I}
+    {$C}cv setting:get -v{$_C}                               (detailed report, console)
+    {$C}cv setting:get --out={$_C}{$I}json-pretty{$_I}{$C} --columns={$_C}{$I}*{$_I}    (detailed report, json)
 
 {$C}Setting Scope{$_C}
 
@@ -60,11 +60,11 @@ class SettingGetCommand extends BaseCommand {
     For most tasks in most deployments, there is only one important scope ({$I}domain #1{$_I}).
     In some edge-cases, you may need to target a specific scope Here are some example scopes:
 
-    {$C}cv setting:get --scope={$_C}{$I}domain{$_I}                (default domain)
-    {$C}cv setting:get --scope={$_C}{$I}domain:*{$_I}              (all domains)
-    {$C}cv setting:get --scope={$_C}{$I}domain:12{$_I}             (domain #12)
-    {$C}cv setting:get --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}  (admin's contact)
-    {$C}cv setting:get --scope={$_C}{$I}contact:201{$_I}           (contact #201)
+    {$C}cv setting:get --scope={$_C}{$I}domain{$_I}                   (default domain)
+    {$C}cv setting:get --scope={$_C}{$I}domain:*{$_I}                 (all domains)
+    {$C}cv setting:get --scope={$_C}{$I}domain:12{$_I}                (domain #12)
+    {$C}cv setting:get --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}     (admin's contact)
+    {$C}cv setting:get --scope={$_C}{$I}contact:201{$_I}              (contact #201)
 ");
     $this->configureBootOptions();
   }

--- a/src/Command/SettingGetCommand.php
+++ b/src/Command/SettingGetCommand.php
@@ -1,0 +1,110 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\BootTrait;
+use Civi\Cv\Util\SettingTrait;
+use Civi\Cv\Util\StructuredOutputTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SettingGetCommand extends BaseCommand {
+
+  use BootTrait;
+  use StructuredOutputTrait;
+  use SettingTrait;
+
+  protected function configure() {
+    $C = '<comment>';
+    $_C = '</comment>';
+    $I = '<info>';
+    $_I = '</info>';
+
+    $this
+      ->setName('setting:get')
+      ->setAliases(['vget'])
+      ->setDescription('Read CiviCRM settings')
+      ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
+      ->configureOutputOptions([
+        'tabular' => TRUE,
+        'shortcuts' => ['table', 'list'],
+        'fallback' => 'table',
+        'availColumns' => 'scope,key,value,default,explicit,mandatory,layer',
+        'defaultColumns' => 'scope,key,value,layer',
+      ])
+      ->addOption('scope', NULL, InputOption::VALUE_REQUIRED, 'Domain to configure', 'domain')
+      ->addArgument('name', InputArgument::OPTIONAL, 'An setting name or regex')
+      ->setHelp("Read CiviCRM settings
+
+{$C}Name Filter{$_C}
+
+    By default, display all settings. You may optionally lookup specific settings by name
+    or by regular expression.
+
+    {$C}cv setting:get {$_C}{$I}mailerJobSize{$_I}                 (specific setting)
+    {$C}cv setting:get /{$_C}{$I}mail{$_I}{$C}/{$_C}                        (any settings that involve \"mail\")
+
+{$C}Setting Scope{$_C}
+
+    All CiviCRM settings are formally attached to a scope, such as a {$I}Contact{$_I} or {$I}Domain{$_I}.
+    For most tasks in most deployments, there is only one important scope ({$I}domain #1{$_I}).
+    In some edge-cases, you may need to target a specific scope Here are some example scopes:
+
+    {$C}cv setting:get --scope={$_C}{$I}domain{$_I}                (default domain)
+    {$C}cv setting:get --scope={$_C}{$I}domain:*{$_I}              (all domains)
+    {$C}cv setting:get --scope={$_C}{$I}domain:12{$_I}             (domain #12)
+    {$C}cv setting:get --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}  (admin's contact)
+    {$C}cv setting:get --scope={$_C}{$I}contact:201{$_I}           (contact #201)
+");
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+
+    $filterPat = $input->getArgument('name');
+    if (empty($filterPat)) {
+      $filter = function (string $name) {
+        return TRUE;
+      };
+    }
+    elseif ($filterPat[0] === '/') {
+      $filter = function (string $name) use ($filterPat) {
+        return (bool) preg_match($filterPat, $name);
+      };
+    }
+    else {
+      $filter = function (string $name) use ($filterPat) {
+        return $name === $filterPat;
+      };
+    }
+
+    $result = [];
+    foreach ($this->findSettings($input->getOption('scope')) as $settingScope => $settingBag) {
+      /** @var \Civi\Core\SettingsBag $settingBag */
+      $meta = $this->getMetadata($settingScope);
+
+      foreach ($settingBag->all() as $settingKey => $settingValue) {
+        if (!$filter($settingKey)) {
+          continue;
+        }
+        [$encode, $decode] = $this->codec($meta, $settingKey);
+        $row = [
+          'scope' => $settingScope,
+          'key' => $settingKey,
+          'value' => $decode($settingBag->get($settingKey)),
+          'default' => $decode($settingBag->getDefault($settingKey)),
+          'explicit' => $decode($settingBag->getExplicit($settingKey)),
+          'mandatory' => $decode($settingBag->getMandatory($settingKey)),
+          'layer' => $settingBag->getMandatory($settingKey) !== NULL ? 'mandatory' : ($settingBag->hasExplict($settingKey) ? 'explicit' : 'default'),
+        ];
+        $result[] = $row;
+      }
+    }
+
+    $this->sendSettings($input, $output, $result);
+    return 0;
+  }
+
+}

--- a/src/Command/SettingSetCommand.php
+++ b/src/Command/SettingSetCommand.php
@@ -58,18 +58,17 @@ If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_
 
     {$C}cv setting:set {$_C}[{$C}+{$_C}{$I}OP{$_I}{$C} {$_C}{$I}EXPR{$_I}]...
 
-    Each \"+Option\" is an instruction for how to perform an update.
-    These are useful for manipulating arrays, as in:
+    If you have a setting that includes structured data (e.g. objects and lists),
+    then use a \"+Option\" to manipulate the data within it.
 
     Option         Examples
-    {$C}+d{$_C}|{$C}+delete{$_C}     +d contact_reference_options.0
-    {$C}+m{$_C}|{$C}+merge{$_C}      +m contact_reference_options.0=3
-    {$C}+m{$_C}|{$C}+merge{$_C}      +m contact_reference_options[]=3
-
-    They are also useful for manipulating objects, as in:
-
-    {$C}+d{$_C}|{$C}+delete{$_C}     +d mailing_backend.outBound_option
-    {$C}+m{$_C}|{$C}+merge{$_C}      +m mailing_backend.outBound_option=3
+    {$C}+o{$_C}|{$C}+object{$_C}     +o mailing_backend.outBound_option=3     (modify \"outBound_option\")
+                   +o !mailing_backend.outBound_option      (remove \"outBound_option\")
+    {$C}+l{$_C}|{$C}+list{$_C}       +l contact_reference_options[]=3         (append value \"3\")
+                   +l contact_reference_options+=3          (append value \"3\")
+                   +l contact_reference_options-=3          (remove value \"3\")
+                   +l contact_reference_options.0=3         (modify 0th value)
+                   +l !contact_reference_options.0          (remove 0th value)
 
 {$C}Setting Scope{$_C}
 

--- a/src/Command/SettingSetCommand.php
+++ b/src/Command/SettingSetCommand.php
@@ -58,17 +58,17 @@ If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_
 
     {$C}cv setting:set {$_C}[{$C}+{$_C}{$I}OP{$_I}{$C} {$_C}{$I}EXPR{$_I}]...
 
-    If you have a setting that includes structured data (e.g. objects and lists),
-    then use a \"+Option\" to manipulate the data within it.
+    If you have a setting that includes structured data (e.g. objects or lists),
+    then you may wish to update individual elements within the setting. Use a \"+Option\".
 
     Option         Examples
-    {$C}+o{$_C}|{$C}+object{$_C}     +o mailing_backend.outBound_option=3     (modify \"outBound_option\")
-                   +o !mailing_backend.outBound_option      (remove \"outBound_option\")
-    {$C}+l{$_C}|{$C}+list{$_C}       +l contact_reference_options[]=3         (append value \"3\")
-                   +l contact_reference_options+=3          (append value \"3\")
-                   +l contact_reference_options-=3          (remove value \"3\")
-                   +l contact_reference_options.0=3         (modify 0th value)
-                   +l !contact_reference_options.0          (remove 0th value)
+    {$C}+o{$_C}|{$C}+object{$_C}     {$C}+o{$_C} {$I}mailing_backend.smtpServer{$_I}{$C}={$_C}{$I}example.com{$_I}  (modify \"smtpServer\")
+                   {$C}+o{$_C} {$C}!{$_C}{$I}mailing_backend.smtpServer{$_I}             (remove \"smtpServer\")
+    {$C}+l{$_C}|{$C}+list{$_C}       {$C}+l{$_C} {$I}contact_reference_options{$_I}{$C}[]={$_C}{$I}3{$_I}           (append value \"3\")
+                   {$C}+l{$_C} {$I}contact_reference_options{$_I}{$C}+={$_C}{$I}3{$_I}            (append value \"3\")
+                   {$C}+l{$_C} {$I}contact_reference_options{$_I}{$C}-={$_C}{$I}3{$_I}            (remove value \"3\")
+                   {$C}+l{$_C} {$I}contact_reference_options.0{$_I}{$C}={$_C}{$I}3{$_I}           (modify 0th value)
+                   {$C}+l{$_C} {$C}!{$_C}{$I}contact_reference_options.0{$_I}            (remove 0th value)
 
 {$C}Setting Scope{$_C}
 
@@ -76,11 +76,11 @@ If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_
     For most tasks in most deployments, there is only one important scope ({$I}domain #1{$_I}).
     In some edge-cases, you may need to target a specific scope Here are some example scopes:
 
-    {$C}cv setting --scope={$_C}{$I}domain{$_I}                (default domain)
-    {$C}cv setting --scope={$_C}{$I}domain:*{$_I}              (all domains)
-    {$C}cv setting --scope={$_C}{$I}domain:12{$_I}             (domain #12)
-    {$C}cv setting --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}  (admin's contact)
-    {$C}cv setting --scope={$_C}{$I}contact:201{$_I}           (contact #201)
+    {$C}cv setting:set --scope={$_C}{$I}domain{$_I}                             (default domain)
+    {$C}cv setting:set --scope={$_C}{$I}domain:*{$_I}                           (all domains)
+    {$C}cv setting:set --scope={$_C}{$I}domain:12{$_I}                          (domain #12)
+    {$C}cv setting:set --scope={$_C}{$I}contact{$_I}{$C} --user={$_C}{$I}admin{$_I}               (admin's contact)
+    {$C}cv setting:set --scope={$_C}{$I}contact:201{$_I}                        (contact #201)
 ");
     $this->configureBootOptions();
   }

--- a/src/Command/SettingSetCommand.php
+++ b/src/Command/SettingSetCommand.php
@@ -105,7 +105,7 @@ If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_
           'default' => $decode($settingBag->getDefault($settingKey)),
           'explicit' => $input->getOption('dry-run') ? $settingValue : $decode($settingBag->getExplicit($settingKey)),
           'mandatory' => $decode($settingBag->getMandatory($settingKey)),
-          'layer' => $settingBag->getMandatory($settingKey) !== NULL ? 'php' : ($settingBag->hasExplict($settingKey) ? 'database' : 'default'),
+          'layer' => $settingBag->getMandatory($settingKey) !== NULL ? 'mandatory' : ($settingBag->hasExplict($settingKey) ? 'explicit' : 'default'),
         ];
         $result[] = $row;
       }

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -89,6 +89,22 @@ class Encoder {
           return gettype($data);
         }
 
+      case 'civicrm.settings.php':
+        // SpecialFormat: Blurbs for civicrm.settings.php. Used by `setting:get` command.
+        $buf = '';
+        foreach ($data as $row) {
+          if (!isset($row['scope']) || !isset($row['key']) || !isset($row['value'])) {
+            throw new \RuntimeException("Cannot format result for civicrm.settings.php. Must have columns: scope,key,value");
+          }
+          $scope = strpos($row['scope'], 'contact') !== FALSE ? 'contact' : 'domain';
+          $buf .= sprintf("\$civicrm_setting[%s][%s] = %s;\n",
+            var_export($scope, TRUE),
+            var_export($row['key'], TRUE),
+            var_export($row['value'], TRUE)
+          );
+        }
+        return $buf;
+
       default:
         throw new \RuntimeException('Unknown output format');
     }

--- a/src/Util/AbstractPlusParser.php
+++ b/src/Util/AbstractPlusParser.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+/**
+ * Some cv commands allow two dimensions of parameters -- the dash parameters
+ * (`-f`, `--force`) are instructions for how to process the command-line request.
+ * The plus parameters (`+s foo`, `+select foo`) are shorthand for data updates.
+ *
+ * This is a base-class for separating out the plus parameters.
+ */
+abstract class AbstractPlusParser {
+
+  public function parse($args, $defaults = []) {
+    $state = '_TOP_';
+    $params = $defaults;
+    foreach ($args as $arg) {
+      if ($state !== '_TOP_') {
+        $this->applyOption($params, $state, $arg);
+        $state = '_TOP_';
+      }
+      // Ex: 'foo=bar', 'fo.oo=bar', 'fo:oo=bar'
+      elseif (preg_match('/^([a-zA-Z0-9_:\.]+)=(.*)/', $arg, $matches)) {
+        [, $key, $value] = $matches;
+        $params[$key] = $this->parseValueExpr($value);
+      }
+      // Ex: '+w', '+where'
+      elseif (preg_match('/^\+([a-zA-Z0-9_]+)$/', $arg, $matches)) {
+        $state = $matches[1];
+      }
+      // Ex: '+l=2', '+l:2'
+      elseif (preg_match('/^\+([a-zA-Z0-9_]+)[:=](.*)/', $arg, $matches)) {
+        [, $key, $expr] = $matches;
+        $this->applyOption($params, $key, $expr);
+      }
+      // Ex: '{"foo": "bar"}'
+      elseif (preg_match('/^\{.*\}$/', $arg)) {
+        $params = array_merge($params, $this->parseJsonNoisily($arg));
+      }
+      else {
+        throw new \RuntimeException("Unrecognized option format: $arg");
+      }
+    }
+    return $params;
+  }
+
+  protected static function mergeInto(&$params, $key, $values) {
+    if (!isset($params[$key])) {
+      $params[$key] = [];
+    }
+    $params[$key] = array_merge($params[$key], $values);
+  }
+
+  protected static function appendInto(&$params, $key, $values) {
+    if (!isset($params[$key])) {
+      $params[$key] = [];
+    }
+    $params[$key][] = $values;
+  }
+
+  /**
+   * @param string $arg
+   * @return mixed
+   */
+  protected function parseJsonNoisily($arg) {
+    $values = json_decode($arg, 1);
+    if ($values === NULL) {
+      throw new \RuntimeException("Failed to parse JSON: $values");
+    }
+    return $values;
+  }
+
+  /**
+   * @param $expr
+   * @return mixed
+   */
+  protected function parseValueExpr($expr) {
+    if (strpos('{["\'', $expr[0]) !== FALSE) {
+      return $this->parseJsonNoisily($expr);
+    }
+    else {
+      return $expr;
+    }
+  }
+
+  /**
+   * @param array $params
+   * @param string $type
+   *   The name of the plus parameter.
+   *   Ex: "+s foo" ==> "s"
+   *   Ex: "+where foo=bar" ==> "where"
+   * @param string $expr
+   *   Ex: "+s foo" ==> "foo"
+   *   Ex: "+where foo=bar" ==> "foo=bar"
+   *
+   * @return mixed
+   */
+  abstract protected function applyOption(array &$params, string $type, string $expr): void;
+
+  public function parseAssignment($expr) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*=\s*(.*)$/', $expr, $matches)) {
+      return [$matches[1] => $this->parseValueExpr($matches[2])];
+    }
+    else {
+      throw new \RuntimeException("Error parsing \"value\": $expr");
+    }
+  }
+
+  public function parseWhere($expr) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN)\s*(.*)$/i', $expr, $matches)) {
+      if (!empty($matches[3])) {
+        return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
+      }
+      else {
+        return [$matches[1], strtoupper($matches[2])];
+      }
+    }
+    else {
+      throw new \RuntimeException("Error parsing \"where\": $expr");
+    }
+  }
+
+}

--- a/src/Util/Api4ArgParser.php
+++ b/src/Util/Api4ArgParser.php
@@ -2,87 +2,16 @@
 
 namespace Civi\Cv\Util;
 
-class Api4ArgParser {
-
-  public function parse($args, $defaults = []) {
-    $state = '_TOP_';
-    $params = $defaults;
-    foreach ($args as $arg) {
-      if ($state !== '_TOP_') {
-        $this->applyOption($params, $state, $arg);
-        $state = '_TOP_';
-      }
-      // Ex: 'foo=bar', 'fo.oo=bar', 'fo:oo=bar'
-      elseif (preg_match('/^([a-zA-Z0-9_:\.]+)=(.*)/', $arg, $matches)) {
-        list (, $key, $value) = $matches;
-        $params[$key] = $this->parseValueExpr($value);
-      }
-      // Ex: '+w', '+where'
-      elseif (preg_match('/^\+([a-zA-Z0-9_]+)$/', $arg, $matches)) {
-        $state = $matches[1];
-      }
-      // Ex: '+l=2', '+l:2'
-      elseif (preg_match('/^\+([a-zA-Z0-9_]+)[:=](.*)/', $arg, $matches)) {
-        list (, $key, $expr) = $matches;
-        $this->applyOption($params, $key, $expr);
-      }
-      // Ex: '{"foo": "bar"}'
-      elseif (preg_match('/^\{.*\}$/', $arg)) {
-        $params = array_merge($params, $this->parseJsonNoisily($arg));
-      }
-      else {
-        throw new \RuntimeException("Unrecognized option format: $arg");
-      }
-    }
-    return $params;
-  }
-
-  protected static function mergeInto(&$params, $key, $values) {
-    if (!isset($params[$key])) {
-      $params[$key] = [];
-    }
-    $params[$key] = array_merge($params[$key], $values);
-  }
-
-  protected static function appendInto(&$params, $key, $values) {
-    if (!isset($params[$key])) {
-      $params[$key] = [];
-    }
-    $params[$key][] = $values;
-  }
+class Api4ArgParser extends AbstractPlusParser {
 
   /**
-   * @param string $arg
+   * @param array $params
+   * @param string $type
+   * @param string $expr
+   *
    * @return mixed
    */
-  protected function parseJsonNoisily($arg) {
-    $values = json_decode($arg, 1);
-    if ($values === NULL) {
-      throw new \RuntimeException("Failed to parse JSON: $values");
-    }
-    return $values;
-  }
-
-  /**
-   * @param $expr
-   * @return mixed
-   */
-  protected function parseValueExpr($expr) {
-    if (strpos('{["\'', $expr[0]) !== FALSE) {
-      return $this->parseJsonNoisily($expr);
-    }
-    else {
-      return $expr;
-    }
-  }
-
-  /**
-   * @param $params
-   * @param $key
-   * @param $expr
-   * @return mixed
-   */
-  protected function applyOption(&$params, $key, $expr) {
+  protected function applyOption(array &$params, string $type, string $expr): void {
     $aliases = [
       's' => 'select',
       'w' => 'where',
@@ -91,18 +20,18 @@ class Api4ArgParser {
       'v' => 'values',
       'value' => 'values',
     ];
-    $key = isset($aliases[$key]) ? $aliases[$key] : $key;
+    $type = $aliases[$type] ?? $type;
 
-    switch ($key) {
+    switch ($type) {
       case 'select':
-        self::mergeInto($params, $key, array_map([
+        self::mergeInto($params, $type, array_map([
           $this,
           'parseValueExpr',
         ], preg_split('/[, ]/', $expr)));
         break;
 
       case 'where':
-        self::appendInto($params, $key, $this->parseWhere($expr));
+        self::appendInto($params, $type, $this->parseWhere($expr));
         break;
 
       case 'orderBy':
@@ -111,13 +40,13 @@ class Api4ArgParser {
           $keyOrderPair = explode(' ', trim($keyOrderPair));
           $sortKey = $keyOrderPair[0];
           $sortOrder = isset($keyOrderPair[1]) ? strtoupper($keyOrderPair[1]) : 'ASC';
-          $params[$key][$sortKey] = $sortOrder;
+          $params[$type][$sortKey] = $sortOrder;
         }
         break;
 
       case 'limit':
         if (strpos($expr, '@') !== FALSE) {
-          list ($limit, $offset) = explode('@', $expr);
+          [$limit, $offset] = explode('@', $expr);
           $params['limit'] = (int) $limit;
           $params['offset'] = (int) $offset;
         }
@@ -127,34 +56,11 @@ class Api4ArgParser {
         break;
 
       case 'values':
-        self::mergeInto($params, $key, $this->parseAssignment($expr));
+        self::mergeInto($params, $type, $this->parseAssignment($expr));
         break;
 
       default:
-        throw new \RuntimeException("Unrecognized option: +$key");
-    }
-  }
-
-  public function parseAssignment($expr) {
-    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*=\s*(.*)$/', $expr, $matches)) {
-      return [$matches[1] => $this->parseValueExpr($matches[2])];
-    }
-    else {
-      throw new \RuntimeException("Error parsing \"value\": $expr");
-    }
-  }
-
-  public function parseWhere($expr) {
-    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN)\s*(.*)$/i', $expr, $matches)) {
-      if (!empty($matches[3])) {
-        return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
-      }
-      else {
-        return [$matches[1], strtoupper($matches[2])];
-      }
-    }
-    else {
-      throw new \RuntimeException("Error parsing \"where\": $expr");
+        throw new \RuntimeException("Unrecognized option: +$type");
     }
   }
 

--- a/src/Util/SettingArgParser.php
+++ b/src/Util/SettingArgParser.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+class SettingArgParser extends AbstractPlusParser {
+
+  /**
+   * @var \Civi\Core\SettingsBag
+   */
+  protected $settingsBag;
+
+  /**
+   * @var array
+   */
+  protected $settingsMeta;
+
+  protected $pathDelimiter = '.';
+
+  /**
+   * @param \Civi\Core\SettingsBag $settingsBag
+   * @param array $settingsMeta
+   *   List of fields supported by this settings bag.
+   */
+  public function __construct(\Civi\Core\SettingsBag $settingsBag, array $settingsMeta) {
+    $this->settingsBag = $settingsBag;
+    $this->settingsMeta = $settingsMeta;
+  }
+
+  /**
+   * @param array $params
+   * @param string $type
+   * @param string $expr
+   *
+   * @return mixed
+   */
+  protected function applyOption(array &$params, string $type, string $expr): void {
+    $aliases = [
+      // 'a' => 'append',
+      // 'm' => 'update',
+      'm' => 'merge',
+      'd' => 'delete',
+    ];
+    $type = $aliases[$type] ?? $type;
+
+    switch ($type) {
+      // // +a some_rows={"new":"row"}
+      // case 'append':
+      //   [$key, $value] = $this->parseAssignment($expr);
+      //   $keyParts = explode($this->pathDelimiter, $key);
+      //   $this->includeBaseSetting($params, $keyParts[0]);
+      //
+      //   $fullValue = \CRM_Utils_Array::pathGet($params, $keyParts, []);
+      //   if (!in_array($value, $fullValue)) {
+      //     $fullValue[] = $value;
+      //   }
+      //   ArrayUtil::pathSet($params, $keyParts, $fullValue);
+      //   break;
+
+      // // +u mailing_backend.outBoundOption=2
+      // case 'update':
+      //   [$key, $value] = $this->parseAssignment($expr);
+      //   $keyParts = explode($this->pathDelimiter, $key);
+      //   $this->includeBaseSetting($params, $keyParts[0]);
+      //
+      //   ArrayUtil::pathSet($params, $keyParts, $value);
+      //   break;
+
+      // +m mailing_backend.outBoundOption=2
+      // +m some_list[]=100
+      // +m some_rows[]={"field1":"value1","field2":"value2"}
+      case 'merge':
+        [$key, $op, $value] = $this->parseValueUpdate($expr);
+        $keyParts = explode($this->pathDelimiter, $key);
+        $this->includeBaseSetting($params, $keyParts[0]);
+
+        if ($op === '=') {
+          \CRM_Utils_Array::pathSet($params, $keyParts, $value);
+        }
+        elseif ($op === '[]=') {
+          $fullValue = \CRM_Utils_Array::pathGet($params, $keyParts, []);
+          $fullValue[] = $value;
+          \CRM_Utils_Array::pathSet($params, $keyParts, $fullValue);
+        }
+        else {
+          throw new \RuntimeException("Unrecognized value operator: $op");
+        }
+        break;
+
+      // +d mailing_backend
+      // +d mailing_backend.outBound_option
+      case 'delete':
+        $keyParts = explode($this->pathDelimiter, $expr);
+        if (count($keyParts) === 1) {
+          $params[$expr] = NULL;
+        }
+        else {
+          \CRM_Utils_Array::pathUnset($params, $keyParts);
+        }
+        break;
+
+      default:
+        throw new \RuntimeException("Unrecognized option: +$type");
+    }
+  }
+
+  protected function includeBaseSetting(array &$params, string $settingKey) {
+    [$encode, $decode] = SettingCodec::codec($this->settingsMeta, $settingKey);
+    if (!isset($params[$settingKey])) {
+      $params[$settingKey] = $decode($this->settingsBag->get($settingKey));
+    }
+  }
+
+  /**
+   * @param string $expr
+   *   Ex: a=b
+   *   Ex: a[]=b
+   * @return array
+   *   Ex: ['a', '=', 'b']
+   *   Ex: ['a', '[]=', 'b']
+   */
+  public function parseValueUpdate($expr) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(=|\[\]=)\s*(.*)$/', $expr, $matches)) {
+      return [$matches[1], $matches[2], $this->parseValueExpr($matches[3])];
+    }
+    else {
+      throw new \RuntimeException("Error parsing \"value\": $expr");
+    }
+  }
+
+  protected function parseValueExpr($expr) {
+    if (strpos('{["\'', $expr[0]) !== FALSE) {
+      return $this->parseJsonNoisily($expr);
+    }
+    else {
+      return $this->castNumberSoftly($expr);
+    }
+  }
+
+  private function castNumberSoftly($value) {
+    if (is_string($value) && preg_match(';^\d+$;', $value)) {
+      return (int) $value;
+    }
+    elseif (is_string($value) && preg_match(';^\d+\.\d+$;', $value)) {
+      return (float) $value;
+    }
+    return $value;
+  }
+
+}

--- a/src/Util/SettingArgParser.php
+++ b/src/Util/SettingArgParser.php
@@ -69,7 +69,7 @@ class SettingArgParser extends AbstractPlusParser {
       // +list contact_reference_options-=3
       case 'list -=':
         $fullValue = \CRM_Utils_Array::pathGet($params, $keyParts, []);
-        $fullValue = array_diff($fullValue, [$value]);
+        $fullValue = array_values(array_diff($fullValue, [$value]));
         ArrayUtil::pathSet($params, $keyParts, $fullValue);
         break;
 

--- a/src/Util/SettingCodec.php
+++ b/src/Util/SettingCodec.php
@@ -1,0 +1,31 @@
+<?php
+namespace Civi\Cv\Util;
+
+class SettingCodec {
+
+  /**
+   * @param array $meta
+   *   All setting metadata (for given context).
+   * @param string $field
+   *   Name of the field.
+   * @return array
+   *   Pair of callables: [$encode, $decode]
+   */
+  public static function codec(array $meta, string $field) {
+    // There are a handful of  settings with a secondary/nested encoding.
+    $encode = function($value) use ($meta, $field) {
+      if (isset($value) && !empty($meta[$field]['serialize'])) {
+        return \CRM_Core_DAO::serializeField($value, $meta[$field]['serialize']);
+      }
+      return $value;
+    };
+    $decode = function($value) use ($meta, $field) {
+      if (isset($value) && !empty($meta[$field]['serialize'])) {
+        return \CRM_Core_DAO::unSerializeField($value, $meta[$field]['serialize']);
+      }
+      return $value;
+    };
+    return [$encode, $decode];
+  }
+
+}

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -9,16 +9,16 @@ trait SettingTrait {
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param $matches
+   * @param \Civi\Core\SettingsBag $settingsBag
+   * @param array $meta
    * @return array
    */
-  protected function parseSettingParams(InputInterface $input) {
+  protected function parseSettingParams(InputInterface $input, \Civi\Core\SettingsBag $settingsBag, array $meta): array {
     $args = $input->getArgument('key=value');
     switch ($input->getOption('in')) {
       case 'args':
-        $p = new Api4ArgParser();
+        $p = new SettingArgParser($settingsBag, $meta);
         $params = $p->parse($args);
-        $params = $this->castNumbers($params);
         break;
 
       case 'json':
@@ -30,18 +30,6 @@ trait SettingTrait {
         throw new \RuntimeException('Unknown input format');
     }
 
-    return $params;
-  }
-
-  private function castNumbers(array $params): array {
-    foreach ($params as $key => &$value) {
-      if (is_string($value) && preg_match(';^\d+$;', $value)) {
-        $value = (int) $value;
-      }
-      elseif (is_string($value) && preg_match(';^\d+\.\d+$;', $value)) {
-        $value = (float) $value;
-      }
-    }
     return $params;
   }
 

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -195,7 +195,7 @@ trait SettingTrait {
       };
     }
     else {
-      $filterExpr = '/' . implode('|', $filterList) . '/i';
+      $filterExpr = '/' . implode('|', $filterList) . '/';
       $filter = function (string $name) use ($filterExpr) {
         return (bool) preg_match($filterExpr, $name);
       };

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -137,20 +137,7 @@ trait SettingTrait {
    *   Pair of callables: [$encode, $decode]
    */
   protected function codec(array $meta, string $field) {
-    // There are a handful of  settings with a secondary/nested encoding.
-    $encode = function($value) use ($meta, $field) {
-      if (isset($value) && !empty($meta[$field]['serialize'])) {
-        return \CRM_Core_DAO::serializeField($value, $meta[$field]['serialize']);
-      }
-      return $value;
-    };
-    $decode = function($value) use ($meta, $field) {
-      if (isset($value) && !empty($meta[$field]['serialize'])) {
-        return \CRM_Core_DAO::unSerializeField($value, $meta[$field]['serialize']);
-      }
-      return $value;
-    };
-    return [$encode, $decode];
+    return SettingCodec::codec($meta, $field);
   }
 
   protected function fillMeta(array $result): array {

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -182,6 +182,9 @@ trait SettingTrait {
     $filterList = [];
     foreach ($names as $filterPat) {
       if ($filterPat[0] === '/') {
+        if (!\CRM_Utils_String::endsWith($filterPat, '/')) {
+          throw new \RuntimeException('Malformed regular expression. (Modifiers are not supported.)');
+        }
         $filterList[] = substr($filterPat, 1, -1);
       }
       else {

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -173,4 +173,34 @@ trait SettingTrait {
     }
   }
 
+  /**
+   * @param $names
+   *
+   * @return \Closure
+   */
+  protected function createSettingFilter($names): \Closure {
+    $filterList = [];
+    foreach ($names as $filterPat) {
+      if ($filterPat[0] === '/') {
+        $filterList[] = substr($filterPat, 1, -1);
+      }
+      else {
+        $filterList[] = '^' . preg_quote($filterPat, '/') . '$';
+      }
+    }
+
+    if (empty($filterList)) {
+      $filter = function (string $name) {
+        return TRUE;
+      };
+    }
+    else {
+      $filterExpr = '/' . implode('|', $filterList) . '/i';
+      $filter = function (string $name) use ($filterExpr) {
+        return (bool) preg_match($filterExpr, $name);
+      };
+    }
+    return $filter;
+  }
+
 }

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -83,6 +83,8 @@ trait SettingTrait {
   public function sendSettings(InputInterface $input, OutputInterface $output, array $result): void {
     $errorOutput = is_callable([$output, 'getErrorOutput']) ? $output->getErrorOutput() : $output;
 
+    $result = $this->fillMeta($result);
+
     usort($result, function ($a, $b) {
       return strcmp($a['key'], $b['key']);
     });
@@ -151,15 +153,21 @@ trait SettingTrait {
     return [$encode, $decode];
   }
 
+  protected function fillMeta(array $result): array {
+    foreach ($result as &$row) {
+      $meta = $this->getMetadata($row['scope'])[$row['key']] ?? [];
+      foreach ($meta as $key => $value) {
+        $row["meta.$key"] = $value;
+      }
+    }
+    return $result;
+  }
+
   protected function showVerboseReport(InputInterface $input, OutputInterface $output, array $result): void {
     foreach ($result as $row) {
-      $meta = $this->getMetadata($row['scope'])[$row['key']] ?? [];
       $verboseTable = [];
       foreach ($row as $key => $value) {
         $verboseTable[] = ['key' => $key, 'value' => $value];
-      }
-      foreach ($meta as $key => $value) {
-        $verboseTable[] = ['key' => "meta.$key", 'value' => $value];
       }
       $this->sendTable($input, $output, $verboseTable);
     }

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+trait SettingTrait {
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param $matches
+   * @return array
+   */
+  protected function parseSettingParams(InputInterface $input) {
+    $args = $input->getArgument('key=value');
+    switch ($input->getOption('in')) {
+      case 'args':
+        $p = new Api4ArgParser();
+        $params = $p->parse($args);
+        $params = $this->castNumbers($params);
+        break;
+
+      case 'json':
+        $json = stream_get_contents(STDIN);
+        $params = empty($json) ? [] : json_decode($json, TRUE);
+        break;
+
+      default:
+        throw new \RuntimeException('Unknown input format');
+    }
+
+    return $params;
+  }
+
+  private function castNumbers(array $params): array {
+    foreach ($params as $key => &$value) {
+      if (is_string($value) && preg_match(';^\d+$;', $value)) {
+        $value = (int) $value;
+      }
+      elseif (is_string($value) && preg_match(';^\d+\.\d+$;', $value)) {
+        $value = (float) $value;
+      }
+    }
+    return $params;
+  }
+
+  /**
+   * Find the settings-bag(s) for the given scope.
+   *
+   * @param string $scope
+   *   Ex: 'domain', 'contact', 'domain:123', 'contact:123', 'domain:*'
+   * @return \Civi\Core\SettingsBag[]
+   * @throws \CRM_Core_Exception
+   */
+  protected function findSettings(string $scope): array {
+    if ($scope === 'domain') {
+      return [$scope => \Civi::settings()];
+    }
+    if ($scope === 'contact') {
+      return [$scope => \Civi::contactSettings()];
+    }
+
+    $parts = explode(':', $scope);
+    if ($parts[0] === 'contact' && is_numeric($parts[1])) {
+      return [$scope => \Civi::contactSettings($parts[1])];
+    }
+    if ($parts[0] === 'domain' && is_numeric($parts[1])) {
+      return [$scope => \Civi::settings($parts[1])];
+    }
+    if ($parts[0] === 'domain' && $parts[1] === '*') {
+      $domainIds = \CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_domain')->fetchMap('id', 'id');
+      $result = [];
+      foreach ($domainIds as $domainId) {
+        $result["domain:$domainId"] = \Civi::settings($domainId);
+      }
+      return $result;
+    }
+
+    throw new \RuntimeException("Malformed scope");
+  }
+
+}

--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -48,6 +48,7 @@ trait StructuredOutputTrait {
    *     specify a format. (Default: json-pretty)
    *   - defaultColumns: string|NULL, a comma-separated list of default columns to display
    *   - availColumns: string|NULL, a comma-separated list of columns which may be displayed
+   *   - specialFormats: array, list of specialized output formats to enable. (By default, hese are not available on most commands.)
    *
    * NOTE: The --columns option will only defined if 'defaultColumns' or/and 'availColumns'
    * is passed.
@@ -58,6 +59,9 @@ trait StructuredOutputTrait {
     $fallback = !empty($config['fallback']) ? $config['fallback'] : 'json-pretty';
 
     $formats = !empty($config['tabular']) ? Encoder::getTabularFormats() : Encoder::getFormats();
+    if (!empty($config['specialFormats'])) {
+      $formats = array_unique(array_merge($formats, $config['specialFormats']));
+    }
     sort($formats);
 
     $this->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Output format (' . implode(',', $formats) . ')', Encoder::getDefaultFormat($fallback));

--- a/tests/Command/SettingLifecycleTest.php
+++ b/tests/Command/SettingLifecycleTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\Process;
+
+/**
+ * @group std
+ */
+class SettingLifecycleTest extends \Civi\Cv\CivilTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  public function testScalar() {
+    $vset = $this->cvOk('vset dummy_scalar_1=100 dummy_scalar_2="More text"');
+    $this->assertTableHasRow(['domain', 'dummy_scalar_1', 100, 'explicit'], $vset);
+    $this->assertTableHasRow(['domain', 'dummy_scalar_2', '"More text"', 'explicit'], $vset);
+
+    $vget = $this->cvOk('vget dummy_scalar_1 dummy_scalar_2');
+    $this->assertTableHasRow(['domain', 'dummy_scalar_1', 100, 'explicit'], $vget);
+    $this->assertTableHasRow(['domain', 'dummy_scalar_2', '"More text"', 'explicit'], $vget);
+
+    $vgetRegex = $this->cvOk('vget /^dummy/');
+    $this->assertTableHasRow(['domain', 'dummy_scalar_1', 100, 'explicit'], $vgetRegex);
+    $this->assertTableHasRow(['domain', 'dummy_scalar_2', '"More text"', 'explicit'], $vgetRegex);
+
+    $this->cvOk('vdel dummy_scalar_1 dummy_scalar_2');
+    $this->assertNotRegExp('/dummy_scalar/', $this->cvOk('vget /dummy/'));
+  }
+
+  public function testArray() {
+    $vset = $this->cvOk('vset dummy_array=\'[1, 2, 3]\'');
+    $this->assertTableHasRow(['domain', 'dummy_array', '\[1,2,3\]', 'explicit'], $vset);
+
+    $vget = $this->cvOk('vget dummy_array');
+    $this->assertTableHasRow(['domain', 'dummy_array', '\[1,2,3\]', 'explicit'], $vget);
+
+    $vgetRegex = $this->cvOk('vget /^dummy/');
+    $this->assertTableHasRow(['domain', 'dummy_array', '\[1,2,3\]', 'explicit'], $vgetRegex);
+
+    $vsetMerge = $this->cvOk('vset +m dummy_array[]=4 +m "dummy_array[]=foo bar"');
+    $this->assertTableHasRow(['domain', 'dummy_array', '\[1,2,3,4,"foo bar"\]', 'explicit'], $vsetMerge);
+
+    $vgetFinal = $this->cvOk('vget dummy_array');
+    $this->assertTableHasRow(['domain', 'dummy_array', '\[1,2,3,4,"foo bar"\]', 'explicit'], $vgetFinal);
+
+    Process::runOk($this->cv('vdel dummy_array'));
+
+    $this->assertNotRegExp('/dummy_array/', $this->cvOk('vget /dummy/'));
+  }
+
+  public function testObject() {
+    $vset = $this->cvOk('vset dummy_obj=\'{"a": 10}\'');
+    $this->assertTableHasRow(['domain', 'dummy_obj', '\{"a":10\}', 'explicit'], $vset);
+
+    $vget = $this->cvOk('vget dummy_obj');
+    $this->assertTableHasRow(['domain', 'dummy_obj', '\{"a":10\}', 'explicit'], $vget);
+
+    $vgetRegex = $this->cvOk('vget /^dummy/');
+    $this->assertTableHasRow(['domain', 'dummy_obj', '\{"a":10\}', 'explicit'], $vgetRegex);
+
+    $vsetMerge = $this->cvOk('vset +m dummy_obj.b=20 +m dummy_obj.de.ep=30');
+    $this->assertTableHasRow(['domain', 'dummy_obj', '\{"a":10,"b":20,"de":\{"ep":30\}\}', 'explicit'], $vsetMerge);
+
+    $vgetFinal = $this->cvOk('vget /^dummy/');
+    $this->assertTableHasRow(['domain', 'dummy_obj', '\{"a":10,"b":20,"de":\{"ep":30\}\}', 'explicit'], $vgetFinal);
+
+    Process::runOk($this->cv('vdel dummy_obj'));
+    $this->assertNotRegExp('/dummy_obj/', $this->cvOk('vget /dummy/'));
+  }
+
+  protected function assertTableHasRow($expectRow, $actualTable) {
+    $vr = '\s*\|\s*';
+    $regex = '/' . $vr . implode($vr, $expectRow) . $vr . '/';
+    $this->assertRegExp($regex, $actualTable);
+  }
+
+}


### PR DESCRIPTION
Add new helper commands for managing settings.

| Command name | Alias | Description |
| -- | -- | -- |
| `cv setting:get` | `cv vget` | Read the values of some settings |
| `cv setting:set` | `cv vset` | Update the values of some settings |
| `cv setting:revert` | `cv vdel` | Revert/undo/delete the values of some settings |

## Reading the settings

The basic command (`setting:get` aka `vget`) shows the effective value of all settings:

```bash
## Show all
$ cv vget
+--------+-----------------------------------------------+---------------------------------------------+-----------+
| scope  | key                                           | value                                       | layer     |
+--------+-----------------------------------------------+---------------------------------------------+-----------+
| domain | acl_cache_refresh_mode                        | "opportunistic"                             | default   |
| domain | acl_financial_type                            | 0                                           | default   |
| domain | activity_assignee_notification                | "1"                                         | default   |
| domain | activity_assignee_notification_ics            | "0"                                         | default   |
```

The `value` is the live/effective value, and the `layer` indicates the origin of the value. Values may originate in these layers:

* `mandatory`: Settings which are hardcoded into `civicrm.settings.php`.
* `explicit`: Settings which been explicitly edited in the web UI or CLI.
* `default`: Settings which have no particular value - they inherit a default defined by the application.

The list is long. You can narrow down by exact name or by regex:

```bash
## Lookup by name
$ cv vget mailerJobSize
+--------+---------------+-------+---------+
| scope  | key           | value | layer   |
+--------+---------------+-------+---------+
| domain | mailerJobSize | 0     | default |
+--------+---------------+-------+---------+

## Lookup by regex
$ cv vget /mail/
+--------+-----------------------------------+---------------------------------------------+-----------+
| scope  | key                               | value                                       | layer     |
+--------+-----------------------------------+---------------------------------------------+-----------+
| domain | civimail_sync_interval            | 10                                          | default   |
| domain | civimail_workflow                 | "0"                                         | default   |
| domain | mailing_backend                   | {"outBound_option":0,"smtpServer":"local... | mandatory |
| domain | mailing_format                    | "{contact.addressee}\n{contact.street_ad... | default   |
```

There is a lot of information available for debugging -- e.g. with verbose mode (`-v`), it will present every configuration layer (`default`, `explicit`, `mandatory`) as well the metadata for the setting.

```
$ cv vget /debug/ -v
+----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
| key                  | value                                                                                                                               |
+----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
| scope                | domain                                                                                                                              |
| key                  | debug_enabled                                                                                                                       |
| value                | 1                                                                                                                                   |
| default              | 0                                                                                                                                   |
| explicit             | 1                                                                                                                                   |
| mandatory            | 1                                                                                                                                   |
| layer                | mandatory                                                                                                                           |
| meta.group_name      | Developer Preferences                                                                                                               |
| meta.group           | developer                                                                                                                           |
| meta.name            | debug_enabled                                                                                                                       |
| meta.config_key      | debug                                                                                                                               |
| meta.type            | Boolean                                                                                                                             |
| meta.quick_form_type | YesNo                                                                                                                               |
| meta.default         | 0                                                                                                                                   |
| meta.add             | 4.3                                                                                                                                 |
| meta.title           | Enable Debugging                                                                                                                    |
| meta.is_domain       | 1                                                                                                                                   |
| meta.is_contact      | 0                                                                                                                                   |
| meta.description     | Set this value to Yes if you want to use one of CiviCRM's debugging tools. This feature should NOT be enabled for production sites. |
| meta.help_text       | Do not turn this on on production sites                                                                                             |
+----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
```

## Writing the settings

The `setting:set` (aka `vset`) command will update the settings. It accepts key-value pairs:

```bash
## Pass key=value (basic number)
cv vset track_civimail_replies=1

## Pass key=value (basic string)
cv vset petition_contacts='Petition People'

## Pass key=value (JSON array or JSON object)
cv vset authx_guards='["perm"]'
```

For precise handling of complex settings, you can supply values as pure JSON:

```bash
## Pass key+value as JSON (command line parameter)
cv vset '{"authx_guards": ["perm"]}'

## Pass key+value as JSON (standard input)
echo '{"authx_guards": ["perm"]}'  | cv vset --in=json
```

The above operations will replace the setting. For complex settings, it may be more convenient to target the change at a specific property, but this requires some additional hints. For example, `mailing_backend` is an object with nested keys, and you may edit it with the `+object`/`+o` helper:

```bash
## Modify an object's property
cv vset +object mailing_backend.smtpServer=mail.example.com
cv vset +o mailing_backend.smtpServer=mail.example.com

## Remove an object's property
cv vset +object !mailing_backend.smtpServer
cv vset +o !mailing_backend.smtpServer
```

Similarly, `authx_guards` is a list with multiple values. You may add and remove values with the `+list`/`+l` helper:

```bash
## Add to list
cv vset +list authx_guards+=site_key
cv vset +l authx_guards+=site_key

## Remove from a list
cv vset +list authx_guards-=site_key
cv vset +l authx_guards-=site_key
```

## Details: Scope

The commands manage settings for the default `Domain`. This can be changed with `--scope=domain:123`, `--scope=domain:*`, or `--scope=contact:123`.

## Details: Serialized

For settings that have a `serialize=>XYZ` option, it will behave like APIv4 "Setting" - e.g. `contact_edit_options` will look like an array (`["1","2","3"...]`) rather than `^1^2^3...^`. This interpretation applies when displaying any/all configuration layers (ie `default`, `explicit`, `mandatory`).
