### PR TITLE
ext:enable - Add an alias for "ext:install"

### DIFF
--- a/src/Command/ExtensionEnableCommand.php
+++ b/src/Command/ExtensionEnableCommand.php
@@ -18,7 +18,7 @@ class ExtensionEnableCommand extends BaseExtensionCommand {
   protected function configure() {
     $this
       ->setName('ext:enable')
-      ->setAliases(array('en'))
+      ->setAliases(['en', 'ext:install'])
       ->setDescription('Enable an extension')
       ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the local list of extensions (Default: Only refresh on cache-miss)')
       ->addOption('ignore-missing', NULL, InputOption::VALUE_NONE, 'If a requested extension is missing, skip it')


### PR DESCRIPTION
I find that I'll sometimes pick `ext:enable` or `ext:install`, depending on the specific focus of my testing -- e.g.

* if attention has turned to an issue with enable or disable processes (or with `hook_enable`/`hook_disable`), then I'm likely to pick `ext:enable`.

* if attention turns to install or uninstall processes (or `hook_install`/`hook_uninstall`), then I'd write `ext:install`.

But `install` and `enable` are literally the same thing, and `ext:install` fails. Additionally, `CRM_Extension_Manager` and APIv3 already have aliases to equate `install` and `enable.` This just makes `cv` do the same.