### PR TITLE
PHP8 breaks passing blank values in api4

### DIFF
--- a/src/Util/AbstractPlusParser.php
+++ b/src/Util/AbstractPlusParser.php
@@ -75,7 +75,7 @@ abstract class AbstractPlusParser {
    * @return mixed
    */
   protected function parseValueExpr($expr) {
-    if (strpos('{["\'', $expr[0]) !== FALSE) {
+    if ($expr !== '' && strpos('{["\'', $expr[0]) !== FALSE) {
       return $this->parseJsonNoisily($expr);
     }
     else {

--- a/src/Util/SettingArgParser.php
+++ b/src/Util/SettingArgParser.php
@@ -109,7 +109,7 @@ class SettingArgParser extends AbstractPlusParser {
   }
 
   protected function parseValueExpr($expr) {
-    if (strpos('{["\'', $expr[0]) !== FALSE) {
+    if ($expr !== '' && strpos('{["\'', $expr[0]) !== FALSE) {
       return $this->parseJsonNoisily($expr);
     }
     else {

--- a/tests/Command/SettingLifecycleTest.php
+++ b/tests/Command/SettingLifecycleTest.php
@@ -14,9 +14,11 @@ class SettingLifecycleTest extends \Civi\Cv\CivilTestCase {
   }
 
   public function testScalar() {
-    $vset = $this->cvOk('vset dummy_scalar_1=100 dummy_scalar_2="More text"');
+    $vset = $this->cvOk('vset dummy_scalar_1=100 dummy_scalar_2="More text" dummy_blank= dummy_zero=0');
     $this->assertTableHasRow(['domain', 'dummy_scalar_1', 100, 'explicit'], $vset);
     $this->assertTableHasRow(['domain', 'dummy_scalar_2', '"More text"', 'explicit'], $vset);
+    $this->assertTableHasRow(['domain', 'dummy_blank', '""', 'explicit'], $vset);
+    $this->assertTableHasRow(['domain', 'dummy_zero', 0, 'explicit'], $vset);
 
     $vget = $this->cvOk('vget dummy_scalar_1 dummy_scalar_2');
     $this->assertTableHasRow(['domain', 'dummy_scalar_1', 100, 'explicit'], $vget);

--- a/tests/Util/Api4ArgParserTest.php
+++ b/tests/Util/Api4ArgParserTest.php
@@ -106,6 +106,10 @@ class Api4ArgParserTest extends \PHPUnit\Framework\TestCase {
       ['version=4', 'limit=10', '{"version":44,"select":["foo"]}'],
       ['version' => 44, 'limit' => 10, 'select' => ['foo']],
     ];
+    $exs[] = [
+      ['+v:blank=', '+v:zero=0'],
+      ['values' => ['blank' => '', 'zero' => '0']],
+    ];
     return $exs;
   }
 


### PR DESCRIPTION
Previously, I used this to fix AuthX for sites behind basic auth:
```shell
cv api4 Setting.set +v authx_header_cred=
```

However, in PHP8, this throws an error:
```
In AbstractPlusParser.php line 68:
                         
  Failed to parse JSON:  
```

That is because in PHP8, [every string is considered to have an empty string at every position in a string](https://php.watch/versions/8.0/string-function-empty-needles).

This checks explicitly for an empty string.

That said - aren't `needle` and `haystack` reversed here?