### PR TITLE
Add `cv http` command

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -5,7 +5,7 @@ return [
   'patchers' => [
       function (string $filePath, string $prefix, string $content) {
           // In some cases, `cv` references classes provided by civicrm-core or by the UF. Preserve the original names.
-          $content = preg_replace(';Cvphar\(CRM_|HTML_|DB_|Drupal|JFactory|Civi::);', '$1', $content);
+          $content = preg_replace(';Cvphar\(CRM_|HTML_|DB_|Drupal|JFactory|Guzzle|Civi::);', '$1', $content);
           $content = preg_replace_callback(';Cvphar\Civi\([A-Za-z0-9_\\]*);', function($m) {
             if (substr($m[1], 0, 3) === 'Cv\\') return $m[0]; // Civi\Cv is mapped.
             else return 'Civi\\' . $m[1]; // Nothing else is mapped.

--- a/src/Application.php
+++ b/src/Application.php
@@ -117,6 +117,7 @@ class Application extends \Symfony\Component\Console\Application {
     // $commands[] = new \Civi\Cv\Command\UpgradeDlCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeGetCommand(); // FIXME: Revalidate and add UpgradeGetCommandTest to the group "std".
     // $commands[] = new \Civi\Cv\Command\UpgradeReportCommand(); // FIXME: Revalidate and add UpgradeReportCommandTest to the group "std".
+    $commands[] = new \Civi\Cv\Command\HttpCommand();
     $commands[] = new \Civi\Cv\Command\UrlCommand();
     if ($context !== 'repl') {
       $commands[] = new \Civi\Cv\Command\BootCommand();

--- a/src/Command/HttpCommand.php
+++ b/src/Command/HttpCommand.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\StructuredOutputTrait;
+use Civi\Cv\Util\UrlCommandTrait;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HttpCommand extends BaseExtensionCommand {
+
+  use StructuredOutputTrait;
+  use UrlCommandTrait;
+
+  protected function configure() {
+    $this
+      ->setName('http')
+      ->setDescription('Send an HTTP request')
+      ->configureUrlOptions()
+      ->addOption('request', 'X', InputOption::VALUE_REQUIRED, 'HTTP Request Method (GET, POST, etc)')
+      ->addOption('data', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'HTTP Request Data')
+      ->addOption('header', 'H', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'HTTP Request Header')
+      ->addOption('authx-flow', NULL, InputOption::VALUE_REQUIRED, 'How to present authentication credentials [header, login, param, xheader]', 'xheader')
+      ->setHelp('
+Request a page or resource via HTTP.
+
+Examples:
+  cv http get civicrm/dashboard
+  cv http -x get cividiscount/css/example.css
+  cv http post -d \'[civicrm.root]/extern/ipn.php\'
+  cv http get -d \'[civicrm.files]/foo.txt\'
+
+NOTE: For a longer list of example URLs, see `cv url --help`
+
+NOTE: Some defaults change depending the presence of --data:
+      Without --data, the default verb is GET.
+      With --data, the default verb is POST, and the default `Content-Type`
+      is `application/x-www-form-urlencoded`
+
+NOTE: If you use `--login` and do not have `authx`, then it prompts about
+      enabling the extension. The extra I/O may influence some scripted
+      use-cases.
+');
+    $this->configureBootOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
+
+    $method = $input->getOption('request');
+    $data = $this->parseRequestData($input);
+    $headers = $this->parseRequestHeaders($input);
+
+    if ($data) {
+      // TODO: Headers should be case-insensitive.
+      $headers['Content-Length'] = strlen($data);
+      $headers['Content-Type'] = ($headers['Content-Type'] ?? 'application/x-www-form-urlencoded');
+    }
+    if (empty($method)) {
+      $method = ($data === NULL) ? 'GET' : 'POST';
+    }
+
+    $rows = $this->createUrls($input, $output, FALSE);
+    foreach ($rows as $row) {
+      $statusCode = $this->sendRequest($output, $method, $row['value'], array_merge($headers, $row['headers'] ?? []), $data);
+      return ($statusCode >= 200 && $statusCode < 300) ? 0 : $statusCode;
+    }
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param string $method
+   * @param string $url
+   * @param array $headers
+   * @param string|null $body
+   * @return int
+   *   Response code
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  protected function sendRequest(OutputInterface $output, string $method, string $url, array $headers = [], ?string $body = NULL): int {
+    $method = strtoupper($method);
+    $errorOutput = is_callable([$output, 'getErrorOutput']) ? $output->getErrorOutput() : $output;
+    $verbose = function(string $text) use ($errorOutput) {
+      $errorOutput->writeln($text, OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_VERBOSE);
+    };
+
+    $verbose("> $method $url");
+    foreach ($headers as $name => $value) {
+      $verbose("> $name: $value");
+    }
+
+    $c = new Client();
+    $response = $c->request($method, $url, [
+      'http_errors' => FALSE,
+      'headers' => $headers,
+      'body' => $body,
+    ]);
+
+    $verbose('< HTTP/' . $response->getProtocolVersion() . ' ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase());
+    foreach ($response->getHeaders() as $name => $values) {
+      foreach ($values as $value) {
+        $verbose("< $name: $value");
+      }
+    }
+
+    $body = $response->getBody();
+    while (!$body->eof()) {
+      $output->write($body->read(16 * 1024));
+    }
+
+    return $response->getStatusCode();
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return string|null
+   */
+  protected function parseRequestData(InputInterface $input): ?string {
+    $inputData = $input->getOption('data');
+    $data = NULL;
+    if (!empty($inputData)) {
+      foreach ($inputData as $datum) {
+        $data = is_null($data) ? '' : "$data&";
+
+        if ($datum === '-') {
+          $data .= file_get_contents('php://stdin');
+        }
+        elseif ($datum[0] === '@') {
+          $file = substr($datum, 1);
+          if (!file_exists($file) || !is_readable($file)) {
+            throw new \RuntimeException("Cannot read file: $file");
+          }
+          $data .= file_get_contents($file);
+        }
+        else {
+          $data .= $datum;
+        }
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return array
+   */
+  protected function parseRequestHeaders(InputInterface $input): array {
+    $headers = [];
+    foreach ($input->getOption('header') as $str) {
+      [$key, $value] = explode(':', $str, 2);
+      $headers[$key] = ltrim($value, ' ');
+    }
+    return $headers;
+  }
+
+}

--- a/src/Command/UrlCommand.php
+++ b/src/Command/UrlCommand.php
@@ -4,7 +4,7 @@ namespace Civi\Cv\Command;
 use Civi\Cv\Encoder;
 use Civi\Cv\Util\Process;
 use Civi\Cv\Util\StructuredOutputTrait;
-use Symfony\Component\Console\Input\InputArgument;
+use Civi\Cv\Util\UrlCommandTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,23 +12,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 class UrlCommand extends BaseExtensionCommand {
 
   use StructuredOutputTrait;
-
-  const DEFAULT_JWT_TIMEOUT = 300;
+  use UrlCommandTrait;
 
   protected function configure() {
     $this
       ->setName('url')
       ->setAliases(['open'])
       ->setDescription('Compose a URL to a CiviCRM page. (Optionally, open in a browser.)')
-      ->addArgument('path', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Relative path to a CiviCRM page, such as "civicrm/contact/view?reset=1&cid=1"')
       ->configureOutputOptions(['tabular' => TRUE, 'availColumns' => 'type,expr,value', 'shortcuts' => ['table', 'list']])
-      ->addOption('relative', 'r', InputOption::VALUE_NONE, 'Prefer relative URL format. (Default: absolute)')
-      ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Generate a frontend URL (Default: backend)')
-      ->addOption('login', NULL, InputOption::VALUE_NONE, 'Add an authentication code (based on current user; uses authx; expires=' . static::DEFAULT_JWT_TIMEOUT . 's)')
+      ->configureUrlOptions()
       ->addOption('open', 'O', InputOption::VALUE_NONE, 'Open a local web browser')
-      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
-      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
-      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")')
       // The original contract only displayed one URL. We subsequently added support for list/csv/table output which require multi-record orientation.
       // It's ambiguous whether JSON/serialize formats should stick to the old output or multi-record output.
       ->addOption('tabular', NULL, InputOption::VALUE_NONE, 'Force display in multi-record mode. (Enabled by default for list,csv,table formats.)')
@@ -91,60 +84,7 @@ NOTE: If you use `--login` and do not have `authx`, then it prompts about
 
     $this->boot($input, $output);
 
-    $rows = array();
-    if ($input->getOption('ext')) {
-      foreach ($input->getOption('ext') as $extExpr) {
-        $rows[] = $this->resolveExt($extExpr, $output);
-      }
-    }
-    if ($input->getOption('dynamic')) {
-      foreach ($input->getOption('dynamic') as $dynExpr) {
-        $rows[] = $this->resolveDynamic($dynExpr, $output);
-      }
-    }
-    if ($input->getOption('config')) {
-      foreach ($input->getOption('config') as $configExpr) {
-        $rows[] = $this->resolveConfig($configExpr, $output);
-      }
-    }
-    if ($input->getArgument('path')) {
-      foreach ($input->getArgument('path') as $pathExpr) {
-        $rows[] = $this->resolveRoute($pathExpr, $input);
-      }
-    }
-    if (count($rows) === 0) {
-      $rows[] = $this->resolveRoute('', $input);
-    }
-
-    if ($input->getOption('login')) {
-      if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
-        if ($this->getIO()->confirm('Enable authx?')) {
-          // ^^ Does the question go to STDERR or STDOUT?
-          $output->getErrorOutput()->writeln('<info>Enabling extension "authx"</info>');
-          civicrm_api3('Extension', 'enable', ['key' => 'authx']);
-        }
-        else {
-          throw new \RuntimeException('Missing required extension: authx');
-        }
-      }
-      $cid = \CRM_Core_Session::getLoggedInContactID();
-      if (!$cid) {
-        throw new \RuntimeException('The "--login" option requires specifying an active user/contact ("--user=X").');
-      }
-      $token = \Civi::service('crypto.jwt')->encode([
-        'exp' => time() + static::DEFAULT_JWT_TIMEOUT,
-        'sub' => 'cid:' . $cid,
-        'scope' => 'authx',
-      ]);
-      $rows = array_map(
-        function($row) use ($token) {
-          $delim = strpos($row['value'], '?') === FALSE ? '?' : '&';
-          $row['value'] .= $delim . '_authxSes=1&_authx=Bearer+' . urlencode($token);
-          return $row;
-        },
-        $rows
-      );
-    }
+    $rows = $this->createUrls($input, $output);
 
     if ($input->getOption('open')) {
       $cmd = $this->pickCommand();
@@ -189,145 +129,6 @@ NOTE: If you use `--login` and do not have `authx`, then it prompts about
       }
     }
     return NULL;
-  }
-
-  /**
-   * Resolve the "--ext/-x" parameter to a URL.
-   *
-   * @param string $extExpr
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @return array|null
-   *   - type: string
-   *   - expr: string
-   *   - value: string
-   */
-  protected function resolveExt($extExpr, OutputInterface $output) {
-    $mapper = \CRM_Extension_System::singleton()->getMapper();
-
-    list ($keyOrName, $file) = explode('/', $extExpr, 2);
-    if ($keyOrName === '.') {
-      return array(
-        'type' => 'ext',
-        'expr' => $extExpr,
-        'value' => $this->urlJoin(\CRM_Core_Config::singleton()->extensionsURL, $file),
-      );
-    }
-
-    if (strpos($keyOrName, '.') === FALSE) {
-      $shortMap = $this->getShortMap();
-      if (isset($shortMap[$keyOrName]) && count($shortMap[$keyOrName]) === 1) {
-        $keyOrName = $shortMap[$keyOrName][0];
-      }
-    }
-
-    try {
-      return array(
-        'type' => 'ext',
-        'expr' => $extExpr,
-        'value' => $this->urlJoin($mapper->keyToUrl($keyOrName), $file),
-      );
-    }
-    catch (\CRM_Extension_Exception_MissingException $e) {
-      $output->getErrorOutput()
-        ->writeln("<error>Ignoring unrecognized extension \"$keyOrName\"</error>");
-      // $returnValue = 1;
-      return NULL;
-    }
-  }
-
-  /**
-   * Resolve the "--dynamic/-d" parameter to a URL.
-   *
-   * @param string $dynExpr
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @return array|null
-   *   - type: string
-   *   - expr: string
-   *   - value: string
-   */
-  protected function resolveDynamic($dynExpr, OutputInterface $output) {
-    if (!is_callable(array('Civi', 'paths'))) {
-      $output->getErrorOutput()
-        ->writeln("<error>Dynamic path expressions are only available on CiviCRM v4.7+</error>");
-      return NULL;
-    }
-
-    if (preg_match(';^(\[[^\]]+\])([\\/]?)$;', $dynExpr, $matches)) {
-      // getPath() is wonky about "[civicrm.root]" or "[civicrm.root]/",
-      // so we have to trick it.
-      $dyn = \Civi::paths()->getUrl($matches[1] . "/./", 'absolute');
-      $value = preg_replace(';/./$;', '', $dyn) . $matches[2];
-      return array(
-        'type' => 'dynamic',
-        'expr' => $dynExpr,
-        'value' => $value,
-      );
-    }
-    else {
-      // Phew, we can do a normal lookup.
-      return array(
-        'type' => 'dynamic',
-        'expr' => $dynExpr,
-        'value' => \Civi::paths()->getUrl($dynExpr, 'absolute'),
-      );
-    }
-  }
-
-  /**
-   * Resolve the "--config/-c" parameter to a URL.
-   *
-   * @param string $configExpr
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @return array|null
-   *   - type: string
-   *   - expr: string
-   *   - value: string
-   */
-  protected function resolveConfig($configExpr, OutputInterface $output) {
-    list ($configProperty, $file) = explode('/', $configExpr, 2);
-    $dir = \CRM_Core_Config::singleton()->{$configProperty};
-    return array(
-      'type' => 'config',
-      'expr' => $configExpr,
-      'value' => $this->urlJoin($dir, $file),
-    );
-  }
-
-  protected function urlJoin($folder, $file) {
-    if ($folder == NULL || $folder == FALSE) {
-      return $folder;
-    }
-    if ($file !== NULL && $file !== FALSE) {
-      return \CRM_Utils_File::addTrailingSlash($folder, '/') . $file;
-    }
-    else {
-      return rtrim($folder, DIRECTORY_SEPARATOR);
-    }
-  }
-
-  /**
-   * @param string $pathExpr
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @return array
-   */
-  protected function resolveRoute($pathExpr, InputInterface $input) {
-    $path = parse_url($pathExpr, PHP_URL_PATH);
-    $query = parse_url($pathExpr, PHP_URL_QUERY);
-    $fragment = parse_url($pathExpr, PHP_URL_FRAGMENT);
-
-    return array(
-      'type' => 'router',
-      'expr' => $pathExpr,
-      'value' => \CRM_Utils_System::url(
-        $path,
-        $query,
-        !$input->getOption('relative'),
-        $fragment,
-        FALSE,
-        (bool) $input->getOption('frontend'),
-        (bool) !$input->getOption('frontend')
-      ),
-    );
   }
 
 }

--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -1,0 +1,240 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class UrlCommandTrait
+ * @package Civi\Cv\Util
+ */
+trait UrlCommandTrait {
+
+  /**
+   * @var int
+   */
+  protected $defaultJwtTimeout = 300;
+
+  /**
+   * @return $this
+   */
+  protected function configureUrlOptions() {
+    $this
+      ->addArgument('path', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Relative path to a CiviCRM page, such as "civicrm/contact/view?reset=1&cid=1"')
+      ->addOption('relative', 'r', InputOption::VALUE_NONE, 'Prefer relative URL format. (Default: absolute)')
+      ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Generate a frontend URL (Default: backend)')
+      ->addOption('login', NULL, InputOption::VALUE_NONE, 'Add an authentication code (based on current user; uses authx; expires=' . $this->defaultJwtTimeout . 's)')
+      ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
+      ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
+      ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")');
+
+    return $this;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function createUrls(InputInterface $input, OutputInterface $output): array {
+    $rows = [];
+    if ($input->getOption('ext')) {
+      foreach ($input->getOption('ext') as $extExpr) {
+        $rows[] = $this->resolveExt($extExpr, $output);
+      }
+    }
+    if ($input->getOption('dynamic')) {
+      foreach ($input->getOption('dynamic') as $dynExpr) {
+        $rows[] = $this->resolveDynamic($dynExpr, $output);
+      }
+    }
+    if ($input->getOption('config')) {
+      foreach ($input->getOption('config') as $configExpr) {
+        $rows[] = $this->resolveConfig($configExpr, $output);
+      }
+    }
+    if ($input->getArgument('path')) {
+      foreach ($input->getArgument('path') as $pathExpr) {
+        $rows[] = $this->resolveRoute($pathExpr, $input);
+      }
+    }
+    if (count($rows) === 0) {
+      $rows[] = $this->resolveRoute('', $input);
+    }
+
+    if ($input->getOption('login')) {
+      if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
+        if ($this->getIO()->confirm('Enable authx?')) {
+          // ^^ Does the question go to STDERR or STDOUT?
+          $output->getErrorOutput()->writeln('<info>Enabling extension "authx"</info>');
+          civicrm_api3('Extension', 'enable', ['key' => 'authx']);
+        }
+        else {
+          throw new \RuntimeException('Missing required extension: authx');
+        }
+      }
+      $cid = \CRM_Core_Session::getLoggedInContactID();
+      if (!$cid) {
+        throw new \RuntimeException('The "--login" option requires specifying an active user/contact ("--user=X").');
+      }
+      $token = \Civi::service('crypto.jwt')->encode([
+        'exp' => time() + $this->defaultJwtTimeout,
+        'sub' => 'cid:' . $cid,
+        'scope' => 'authx',
+      ]);
+      $rows = array_map(
+        function ($row) use ($token) {
+          $delim = strpos($row['value'], '?') === FALSE ? '?' : '&';
+          $row['value'] .= $delim . '_authxSes=1&_authx=Bearer+' . urlencode($token);
+          return $row;
+        },
+        $rows
+      );
+    }
+    return $rows;
+  }
+
+  /**
+   * Resolve the "--ext/-x" parameter to a URL.
+   *
+   * @param string $extExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveExt($extExpr, OutputInterface $output) {
+    $mapper = \CRM_Extension_System::singleton()->getMapper();
+
+    [$keyOrName, $file] = explode('/', $extExpr, 2);
+    if ($keyOrName === '.') {
+      return array(
+        'type' => 'ext',
+        'expr' => $extExpr,
+        'value' => $this->urlJoin(\CRM_Core_Config::singleton()->extensionsURL, $file),
+      );
+    }
+
+    if (strpos($keyOrName, '.') === FALSE) {
+      $shortMap = $this->getShortMap();
+      if (isset($shortMap[$keyOrName]) && count($shortMap[$keyOrName]) === 1) {
+        $keyOrName = $shortMap[$keyOrName][0];
+      }
+    }
+
+    try {
+      return array(
+        'type' => 'ext',
+        'expr' => $extExpr,
+        'value' => $this->urlJoin($mapper->keyToUrl($keyOrName), $file),
+      );
+    }
+    catch (\CRM_Extension_Exception_MissingException $e) {
+      $output->getErrorOutput()
+        ->writeln("<error>Ignoring unrecognized extension \"$keyOrName\"</error>");
+      // $returnValue = 1;
+      return NULL;
+    }
+  }
+
+  /**
+   * Resolve the "--dynamic/-d" parameter to a URL.
+   *
+   * @param string $dynExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveDynamic($dynExpr, OutputInterface $output) {
+    if (!is_callable(array('Civi', 'paths'))) {
+      $output->getErrorOutput()
+        ->writeln("<error>Dynamic path expressions are only available on CiviCRM v4.7+</error>");
+      return NULL;
+    }
+
+    if (preg_match(';^(\[[^\]]+\])([\\/]?)$;', $dynExpr, $matches)) {
+      // getPath() is wonky about "[civicrm.root]" or "[civicrm.root]/",
+      // so we have to trick it.
+      $dyn = \Civi::paths()->getUrl($matches[1] . "/./", 'absolute');
+      $value = preg_replace(';/./$;', '', $dyn) . $matches[2];
+      return array(
+        'type' => 'dynamic',
+        'expr' => $dynExpr,
+        'value' => $value,
+      );
+    }
+    else {
+      // Phew, we can do a normal lookup.
+      return array(
+        'type' => 'dynamic',
+        'expr' => $dynExpr,
+        'value' => \Civi::paths()->getUrl($dynExpr, 'absolute'),
+      );
+    }
+  }
+
+  /**
+   * Resolve the "--config/-c" parameter to a URL.
+   *
+   * @param string $configExpr
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return array|null
+   *   - type: string
+   *   - expr: string
+   *   - value: string
+   */
+  protected function resolveConfig($configExpr, OutputInterface $output) {
+    [$configProperty, $file] = explode('/', $configExpr, 2);
+    $dir = \CRM_Core_Config::singleton()->{$configProperty};
+    return array(
+      'type' => 'config',
+      'expr' => $configExpr,
+      'value' => $this->urlJoin($dir, $file),
+    );
+  }
+
+  protected function urlJoin($folder, $file) {
+    if ($folder == NULL || $folder == FALSE) {
+      return $folder;
+    }
+    if ($file !== NULL && $file !== FALSE) {
+      return \CRM_Utils_File::addTrailingSlash($folder, '/') . $file;
+    }
+    else {
+      return rtrim($folder, DIRECTORY_SEPARATOR);
+    }
+  }
+
+  /**
+   * @param string $pathExpr
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return array
+   */
+  protected function resolveRoute($pathExpr, InputInterface $input) {
+    $path = parse_url($pathExpr, PHP_URL_PATH);
+    $query = parse_url($pathExpr, PHP_URL_QUERY);
+    $fragment = parse_url($pathExpr, PHP_URL_FRAGMENT);
+
+    return array(
+      'type' => 'router',
+      'expr' => $pathExpr,
+      'value' => \CRM_Utils_System::url(
+        $path,
+        $query,
+        !$input->getOption('relative'),
+        $fragment,
+        FALSE,
+        (bool) $input->getOption('frontend'),
+        (bool) !$input->getOption('frontend')
+      ),
+    );
+  }
+
+}

--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -36,11 +36,11 @@ trait UrlCommandTrait {
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *
+   * @param bool $useDefault
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function createUrls(InputInterface $input, OutputInterface $output): array {
+  protected function createUrls(InputInterface $input, OutputInterface $output, bool $useDefault = TRUE): array {
     $rows = [];
     if ($input->getOption('ext')) {
       foreach ($input->getOption('ext') as $extExpr) {
@@ -63,7 +63,12 @@ trait UrlCommandTrait {
       }
     }
     if (count($rows) === 0) {
-      $rows[] = $this->resolveRoute('', $input);
+      if ($useDefault) {
+        $rows[] = $this->resolveRoute('', $input);
+      }
+      else {
+        throw new \RuntimeException("No paths specified");
+      }
     }
 
     if ($input->getOption('login')) {

--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -24,7 +24,8 @@ trait UrlCommandTrait {
     $this
       ->addArgument('path', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Relative path to a CiviCRM page, such as "civicrm/contact/view?reset=1&cid=1"')
       ->addOption('relative', 'r', InputOption::VALUE_NONE, 'Prefer relative URL format. (Default: absolute)')
-      ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Generate a frontend URL (Default: backend)')
+      ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Equivalent to --entry=frontend')
+      ->addOption('entry', NULL, InputOption::VALUE_REQUIRED, 'Request frontend or backend style URLs', 'default')
       ->addOption('login', 'L', InputOption::VALUE_NONE, 'Add an authentication code (based on current user; uses authx; expires=' . $this->defaultJwtTimeout . 's)')
       ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
       ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
@@ -246,8 +247,9 @@ trait UrlCommandTrait {
     $path = parse_url($pathExpr, PHP_URL_PATH);
     $query = parse_url($pathExpr, PHP_URL_QUERY);
     $fragment = parse_url($pathExpr, PHP_URL_FRAGMENT);
+    $entry = $input->getOption('frontend') ? 'frontend' : $input->getOption('entry');
 
-    return array(
+    return [
       'type' => 'router',
       'expr' => $pathExpr,
       'value' => \CRM_Utils_System::url(
@@ -256,10 +258,10 @@ trait UrlCommandTrait {
         !$input->getOption('relative'),
         $fragment,
         FALSE,
-        (bool) $input->getOption('frontend'),
-        (bool) !$input->getOption('frontend')
+        ($entry === 'frontend'),
+        ($entry === 'backend')
       ),
-    );
+    ];
   }
 
 }

--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -25,7 +25,7 @@ trait UrlCommandTrait {
       ->addArgument('path', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Relative path to a CiviCRM page, such as "civicrm/contact/view?reset=1&cid=1"')
       ->addOption('relative', 'r', InputOption::VALUE_NONE, 'Prefer relative URL format. (Default: absolute)')
       ->addOption('frontend', 'f', InputOption::VALUE_NONE, 'Generate a frontend URL (Default: backend)')
-      ->addOption('login', NULL, InputOption::VALUE_NONE, 'Add an authentication code (based on current user; uses authx; expires=' . $this->defaultJwtTimeout . 's)')
+      ->addOption('login', 'L', InputOption::VALUE_NONE, 'Add an authentication code (based on current user; uses authx; expires=' . $this->defaultJwtTimeout . 's)')
       ->addOption('ext', 'x', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'An extension name. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Use "." for the default extension dir.')
       ->addOption('config', 'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A config property. (Ex: "templateCompileDir/en_US")')
       ->addOption('dynamic', 'd', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A dynamic path expression (v4.7+) (Ex: "[civicrm.root]/packages")');

--- a/tests/Command/HttpCommandTest.php
+++ b/tests/Command/HttpCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\Process;
+
+/**
+ * @group std
+ */
+class HttpCommandTest extends \Civi\Cv\CivilTestCase {
+
+  /**
+   * CLI params to specify the login user for these tests.
+   *
+   * Ex: '--login --user=admin' or '-LU admin'
+   *
+   * @var string
+   */
+  protected $login = '-LU admin';
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  public function testAuthorizedGet() {
+    $body = $this->cvOk("http {$this->login} civicrm/admin");
+    $this->assertRegExp(':<html:', $body);
+    $this->assertRegExp(':Create and edit available tags here:', $body);
+  }
+
+  public function testUnauthorizedGet() {
+    $body = $this->cvFail("http civicrm/admin");
+    $this->assertRegExp(':<html:', $body);
+    $this->assertNotRegExp(':Create and edit available tags here:', $body);
+  }
+
+  public function testGetWebService() {
+    $data = escapeshellarg('params=' . urlencode(json_encode(['limit' => 1])));
+    $body = $this->cvOk("http {$this->login} civicrm/ajax/api4/Group/get --data $data");
+    $parsed = json_decode($body, TRUE);
+    $this->assertTrue(!empty($parsed['values'][0]['title']) && is_string($parsed['values'][0]['title']),
+      'Response should include a title. Received: ' . $body);
+    $this->assertEquals(1, count($parsed['values']), "Response should have been limited to 1 record.");
+  }
+
+  public function testGetWebServiceVerbose() {
+    $data = escapeshellarg('params=' . urlencode(json_encode(['limit' => 1])));
+    $p = Process::runOk($this->cv("http -v {$this->login} civicrm/ajax/api4/Group/get --data $data"));
+
+    $parsed = json_decode($p->getOutput(), TRUE);
+    $this->assertTrue(!empty($parsed['values'][0]['title']) && is_string($parsed['values'][0]['title']),
+      'Response should include a title. Received: ' . $body);
+    $this->assertEquals(1, count($parsed['values']), "Response should have been limited to 1 record.");
+
+    $error = $p->getErrorOutput();
+    $this->assertRegExp(';> POST http;', $error);
+    $this->assertRegExp(';> Content-Type: application/x-www-form-urlencoded;', $error);
+    $this->assertRegExp(';> X-Civi-Auth: Bearer;', $error);
+    $this->assertRegExp(';< Content-Type: application/json;', $error);
+  }
+
+}


### PR DESCRIPTION
The `cv http` command is simillar to `cv url` and `cv open`, except that it actually sends an HTTP request.

Examples
--------------------------

This is useful for doing basic sanity checks on HTTP end-points, e.g.

```bash
cv http --user=admin --login civicrm/admin > /tmp/foo.html

cv http -LU admin civicrm/admin > /tmp/foo.html

if cv http -LU admin civicrm/admin | grep -q 'Create and edit available tags here' ; then
  echo "Page looks right"
else
  echo "Page looks wrong"
fi

cv http -LU admin civicrm/ajax/api4/Group/get --data 'params=%7B%22limit%22%3A1%7D'
```

Comments
--------------------------

In theory, the existing command `cv url` (aka `cv open`) could give a similar benefit:

```bash
curl `cv url --user=admin --login civicrm/admin` > /tmp/foo.html

curl `cv url -LU admin civicrm/ajax/api4/Group/get` --data 'params=%7B%22limit%22%3A1%7D'
```

But this doesn't quite work -- `cv url --login` gives a URL that's tuned for *session login* (e.g. `&_authxSes=1&_authx=...`). So you actually need a more sophisticated series of requests to. It's good for a browser (it's good for `cv open`),  but it's not good for a one-off request to a specific route.
