### PR TITLE
Allow arguments to be passed to the script command 'cv scr'

### DIFF
--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -52,10 +52,10 @@ class ScriptCommand extends BaseCommand {
 
   /**
    * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @param $script
-   * @param array
+   * @param string $script
+   * @param array $scriptArguments
    */
-  protected function runScript(OutputInterface $output, $script, $scriptArguments) {
+  protected function runScript(OutputInterface $output, string $script, array $scriptArguments = []) {
     $output->writeln("<info>[ScriptCommand]</info> Start \"$script\"", OutputInterface::VERBOSITY_DEBUG);
     // This puts the script arguments in the same variable scope as the script
     // so scripts can access arguments using $argv $argc

--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -60,6 +60,7 @@ class ScriptCommand extends BaseCommand {
     // This puts the script arguments in the same variable scope as the script
     // so scripts can access arguments using $argv $argc
     $argv = $scriptArguments;
+    array_unshift($argv, $script);
     $argc = count($argv);
     require $script;
     $output->writeln("<info>[ScriptCommand]</info> Finish \"$script\"", OutputInterface::VERBOSITY_DEBUG);

--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -16,13 +16,15 @@ class ScriptCommand extends BaseCommand {
       ->setName('php:script')
       ->setAliases(array('scr'))
       ->setDescription('Execute a PHP script')
-      ->addArgument('script', InputArgument::REQUIRED);
+      ->addArgument('script', InputArgument::REQUIRED)
+      ->addArgument('scriptArguments', InputArgument::IS_ARRAY, 'Optional arguments to pass to the script as $argv');
     $this->configureBootOptions();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     $fs = new Filesystem();
     $origScript = $fs->toAbsolutePath($input->getArgument('script'));
+    $scriptArguments = $input->getArgument('scriptArguments');
 
     $origCwd = getcwd();
     $this->boot($input, $output);
@@ -31,7 +33,7 @@ class ScriptCommand extends BaseCommand {
     // Normal operation: Use the script path provided at input.
     if (file_exists($origScript)) {
       chdir($origCwd);
-      $this->runScript($output, $origScript);
+      $this->runScript($output, $origScript, $scriptArguments);
       return 0;
     }
 
@@ -40,7 +42,7 @@ class ScriptCommand extends BaseCommand {
     if (file_exists($postScript)) {
       $output->getErrorOutput()->writeln("<comment>WARNING: Loaded script relative to CMS root -- which is deprecated. Script path should be (a) absolute or (b) relative to CWD.</comment>");
       chdir($postCwd);
-      $this->runScript($output, $postScript);
+      $this->runScript($output, $postScript, $scriptArguments);
       return 0;
     }
 
@@ -51,9 +53,14 @@ class ScriptCommand extends BaseCommand {
   /**
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param $script
+   * @param array
    */
-  protected function runScript(OutputInterface $output, $script) {
+  protected function runScript(OutputInterface $output, $script, $scriptArguments) {
     $output->writeln("<info>[ScriptCommand]</info> Start \"$script\"", OutputInterface::VERBOSITY_DEBUG);
+    // This puts the script arguments in the same variable scope as the script
+    // so scripts can access arguments using $argv $argc
+    $argv = $scriptArguments;
+    $argc = count($argv);
     require $script;
     $output->writeln("<info>[ScriptCommand]</info> Finish \"$script\"", OutputInterface::VERBOSITY_DEBUG);
   }

--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -62,7 +62,11 @@ class ScriptCommand extends BaseCommand {
     $argv = $scriptArguments;
     array_unshift($argv, $script);
     $argc = count($argv);
-    require $script;
+    // This prevents the script stomping on any variables it shouldn't - like $output
+    $run = function () use ($argv, $argc, $script) {
+      require $script;
+    };
+    $run();
     $output->writeln("<info>[ScriptCommand]</info> Finish \"$script\"", OutputInterface::VERBOSITY_DEBUG);
   }
 

--- a/tests/Command/ScriptCommandTest.php
+++ b/tests/Command/ScriptCommandTest.php
@@ -26,15 +26,17 @@ class ScriptCommandTest extends \Civi\Cv\CivilTestCase {
   }
 
   public function testScrNoArg() {
-    $helloPhp = escapeshellarg(__DIR__ . '/hello-args.php');
-    $p = Process::runOk($this->cv("scr $helloPhp"));
-    $this->assertEquals("No arguments passed.\n", $p->getOutput());
+    $helloPhpFile = __DIR__ . '/hello-args.php';
+    $helloPhpEsc = escapeshellarg(__DIR__ . '/hello-args.php');
+    $p = Process::runOk($this->cv("scr $helloPhpEsc"));
+    $this->assertEquals("Count: 1\n0: $helloPhpFile\n", $p->getOutput());
   }
 
   public function testScrArgs() {
-    $helloPhp = escapeshellarg(__DIR__ . '/hello-args.php');
-    $p = Process::runOk($this->cv("scr $helloPhp one 'two and' three"));
-    $this->assertEquals("0: one\n1: two and\n2: three\n", $p->getOutput());
+    $helloPhpFile = __DIR__ . '/hello-args.php';
+    $helloPhpEsc = escapeshellarg(__DIR__ . '/hello-args.php');
+    $p = Process::runOk($this->cv("scr $helloPhpEsc one 'two and' three"));
+    $this->assertEquals("Count: 4\n0: $helloPhpFile\n1: one\n2: two and\n3: three\n", $p->getOutput());
   }
 
 }

--- a/tests/Command/ScriptCommandTest.php
+++ b/tests/Command/ScriptCommandTest.php
@@ -25,4 +25,16 @@ class ScriptCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp('/^version [0-9a-z\.]+$/', $p->getOutput());
   }
 
+  public function testScrNoArg() {
+    $helloPhp = escapeshellarg(__DIR__ . '/hello-args.php');
+    $p = Process::runOk($this->cv("scr $helloPhp"));
+    $this->assertEquals("No arguments passed.\n", $p->getOutput());
+  }
+
+  public function testScrArgs() {
+    $helloPhp = escapeshellarg(__DIR__ . '/hello-args.php');
+    $p = Process::runOk($this->cv("scr $helloPhp one 'two and' three"));
+    $this->assertEquals("0: one\n1: two and\n2: three\n", $p->getOutput());
+  }
+
 }

--- a/tests/Command/hello-args.php
+++ b/tests/Command/hello-args.php
@@ -1,4 +1,5 @@
 <?php
+print "Count: $argc\n";
 if (!$argc) {
   print "No arguments passed.\n";
 }

--- a/tests/Command/hello-args.php
+++ b/tests/Command/hello-args.php
@@ -1,0 +1,9 @@
+<?php
+if (!$argc) {
+  print "No arguments passed.\n";
+}
+else {
+  foreach ($argv as $key => $val) {
+    print "$key: $val\n";
+  }
+}


### PR DESCRIPTION
If `cv scr` is called with arguments like this:

`cv scr myscript.php arg1 arg2 ...`

`myscript.php` will have `$argv = ['arg1', 'arg2']`  

Quoted args are passed through correctly:

  `cv scr myscript.php one 'two and' three`  => `$argv = ['one', 'two and', 'three']`

Options starting with a hyphen can also be passed to the script if `--` is used:
  
  `cv scr myscript.php -- -a b`  => `$argv = ['-a', 'b']`

The superglobal `$GLOBAL['argv']` is also available with the full command line but `$argv` will usually be easier to work with.
