### PR TITLE
Fix `php:eval` exit-codes. Fix multiple test issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "platform": {
             "php": "7.2.0"
         },
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "allow-plugins": {
+            "civicrm/composer-downloads-plugin": true
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php"
+         cacheResult="false"
 >
   <testsuites>
     <testsuite name="Cv Test Suite">

--- a/src/Command/EvalCommand.php
+++ b/src/Command/EvalCommand.php
@@ -51,6 +51,7 @@ NOTE: To change the default output format, set CV_OUTPUT.
 
     $value = eval($input->getArgument('code') . ';');
     $this->sendResult($input, $output, $value);
+    return 0;
   }
 
 }

--- a/src/Command/FillCommand.php
+++ b/src/Command/FillCommand.php
@@ -59,8 +59,8 @@ class FillCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->boot($input, $output);
     if (!$input->getOption('file')) {
-      $this->boot($input, $output);
       $reader = new SiteConfigReader(CIVICRM_SETTINGS_PATH);
       $liveData = $reader->compile(array('buildkit', 'home', 'active'));
     }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -1,0 +1,94 @@
+<?php
+namespace Civi\Cv;
+
+/**
+ * This is all so evil. It shouldn't exist. God save ye wretched souls who
+ * seek to reconcile all the error-handlers of all the platforms.
+ */
+class ErrorHandler {
+
+  private static $hasShutdown = FALSE;
+  private static $count = 0;
+  private static $renderer = NULL;
+
+  public static function pushHandler() {
+    static::$count++;
+    if (!static::$hasShutdown) {
+      static::$hasShutdown = TRUE;
+      register_shutdown_function([static::class, 'onShutdown']);
+    }
+    // set_error_handler([static::class, 'onError']);
+    set_error_handler([static::class, 'onError']);
+    set_exception_handler([static::class, 'onException']);
+
+  }
+
+  public static function popHandler() {
+    static::$count--;
+    restore_error_handler();
+    restore_exception_handler();
+  }
+
+  public static function onShutdown() {
+    if (static::$count > 0) {
+      $error = error_get_last();
+      if (($error['type'] & (E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR))) {
+        // Something - like a bad eval() - interrupted normal execution.
+        // Make sure the status code reflects that.
+        exit(255);
+      }
+    }
+  }
+
+  public static function onError($errorLevel, $message, $filename, $line) {
+    if ($errorLevel & error_reporting()) {
+      $errorType = static::getErrorTypes()[$errorLevel] ?: "Unknown[$errorLevel]";
+      fprintf(STDERR, "[%s] %s at %s:%d\n", $errorType, $message, $filename, $line);
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  /**
+   * @param \Throwable $exception
+   */
+  public static function onException($exception) {
+    if (isset(static::$renderer)) {
+      call_user_func(static::$renderer, $exception);
+    }
+    else {
+      fprintf(STDERR, "Exception: %s (%s)\n%s", $exception->getMessage(), get_class($exception), $exception->getTraceAsString());
+    }
+    exit(255);
+  }
+
+  /**
+   * @param callable|null $renderer
+   */
+  public static function setRenderer(?callable $renderer): void {
+    self::$renderer = $renderer;
+  }
+
+  protected static function getErrorTypes(): array {
+    return [
+      E_ERROR => 'PHP Error',
+      E_WARNING => 'PHP Warning',
+      E_PARSE => 'PHP Parse Error',
+      E_NOTICE => 'PHP Notice',
+      E_CORE_ERROR => 'PHP Core Error',
+      E_CORE_WARNING => 'PHP Core Warning',
+      E_COMPILE_ERROR => 'PHP Compile Error',
+      E_COMPILE_WARNING => 'PHP Compile Warning',
+      E_USER_ERROR => 'PHP User Error',
+      E_USER_WARNING => 'PHP User Warning',
+      E_USER_NOTICE => 'PHP User Notice',
+      E_STRICT => 'PHP Strict Warning',
+      E_RECOVERABLE_ERROR => 'PHP Recoverable Fatal Error',
+      E_DEPRECATED => 'PHP Deprecation',
+      E_USER_DEPRECATED => 'PHP User Deprecation',
+    ];
+  }
+
+}

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Util;
 
+use Civi\Cv\ErrorHandler;
 use Civi\Cv\PharOut\PharOut;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -47,6 +48,9 @@ trait BootTrait {
     else {
       throw new \Exception("Unrecognized bootstrap level");
     }
+
+    // CMS may have installed wonky error-handling. Add our own.
+    ErrorHandler::pushHandler();
 
     $output->writeln('<info>[BootTrait]</info> Finished', OutputInterface::VERBOSITY_DEBUG);
   }

--- a/tests/Command/HttpCommandTest.php
+++ b/tests/Command/HttpCommandTest.php
@@ -48,7 +48,7 @@ class HttpCommandTest extends \Civi\Cv\CivilTestCase {
 
     $parsed = json_decode($p->getOutput(), TRUE);
     $this->assertTrue(!empty($parsed['values'][0]['title']) && is_string($parsed['values'][0]['title']),
-      'Response should include a title. Received: ' . $body);
+      'Response should include a title. Received: ' . $p->getOutput());
     $this->assertEquals(1, count($parsed['values']), "Response should have been limited to 1 record.");
 
     $error = $p->getErrorOutput();


### PR DESCRIPTION
This fixes multiple issues in the test-suite. Most of the commits are small the things.

The gnarly part involves "EvalCommand", which had both direct failures (`EvalCommandTest`) and various indirect failures (`ExtensionLifecycleTest`). It seems likely that this was a leftover from the last Symfony upgrade.

Intuitively: if `cv php:eval` encounters an error, then the exit-code should indicate as much. But in some cases, it didn't. This is because of how the various error-handlers (Symfony, Drupal, etc) interacted with each other. Structurally, I'm not keen on the patch -- but functionally, it's what we need, and I can't think of anything else to do the needful. It passes the tests on D7+WP, php73+php81. So it's certainly better.