### PR TITLE
Drupal 9 - Fix error regarding `AccountProxy::get()` (#148)

### DIFF
--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -456,7 +456,8 @@ class CmsBootstrap {
         break;
 
       case 'Drupal8':
-        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE, CIVICRM_UF, 'Individual');
+        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+        \CRM_Core_BAO_UFMatch::synchronize($user, TRUE, CIVICRM_UF, 'Individual');
         break;
 
       case 'Joomla':

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -207,7 +207,8 @@ trait BootTrait {
         break;
 
       case 'Drupal8':
-        \CRM_Core_BAO_UFMatch::synchronize(\Drupal::currentUser(), TRUE,
+        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+        \CRM_Core_BAO_UFMatch::synchronize($user, TRUE,
           CIVICRM_UF, 'Individual');
         break;
 


### PR DESCRIPTION
This should fix an issue that appears in both #148 and in the test-matrix. It presents as:

```
Error: Call to undefined method Drupal\Core\Session\AccountProxy::get() in
CRM_Utils_System_Drupal8->getUserIDFromUserObject() (line 595 of
/home/jenkins/bknix-max/build/build-1/vendor/civicrm/civicrm-core/CRM/Utils/System/Drupal8.php).
```

And it flows from a call to `\CRM_Core_BAO_UFMatch::synchronize`. There are, in fact, two callers for `synchronize()`, and I believe both need updating.

