### PR TITLE
Allow explicit-automatic flags

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -61,7 +61,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     type of CMS is being used.
  *     (Default: NULL)
  *   - env: string|NULL. The environment variable which may contain the path to
- *     civicrm.settings.php. Set NULL to disable.
+ *     civicrm.settings.php (or the token "Auto"). Set NULL to disable environment-checking.
  *     (Default: CIVICRM_SETTINGS)
  *   - httpHost: string|NULL. For multisite, the HTTP hostname.
  *   - prefetch: bool. Whether to load various caches.
@@ -324,7 +324,7 @@ class Bootstrap {
     if (defined('CIVICRM_CONFDIR') && file_exists(CIVICRM_CONFDIR . '/civicrm.settings.php')) {
       $settings = CIVICRM_CONFDIR . '/civicrm.settings.php';
     }
-    elseif (!empty($options['env']) && getenv($options['env']) && file_exists(getenv($options['env']))) {
+    elseif (!empty($options['env']) && getenv($options['env']) && getenv($options['env']) !== 'Auto' && file_exists(getenv($options['env']))) {
       $settings = getenv($options['env']);
     }
     elseif (!empty($options['settingsFile']) && file_exists($options['settingsFile'])) {

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -130,7 +130,7 @@ class CmsBootstrap {
       $cms = $this->findCmsRoot($this->getSearchDir());
     }
 
-    $this->writeln("CMS: " . json_encode($this->options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), OutputInterface::VERBOSITY_DEBUG);
+    $this->writeln("CMS: " . json_encode($cms, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), OutputInterface::VERBOSITY_DEBUG);
     if (empty($cms['path']) || empty($cms['type']) || !file_exists($cms['path'])) {
       $cmsJson = json_encode($cms, JSON_UNESCAPED_SLASHES);
       throw new \Exception("Failed to parse or find a CMS $cmsJson");

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -111,6 +111,10 @@ class CmsBootstrap {
         'path' => '/' . parse_url($cmsExpr, PHP_URL_HOST) . parse_url($cmsExpr, PHP_URL_PATH),
       );
       $cms['path'] = preg_replace(';^//+;', '/', $cms['path']);
+      if ($cms['type'] === 'Auto') {
+        $isAutoPath = (trim($cms['path'], '/') === '.');
+        $cms = $this->findCmsRoot($isAutoPath ? $this->getSearchDir() : $cms['path']);
+      }
       if (!isset($this->options['user']) && parse_url($cmsExpr, PHP_URL_USER)) {
         $this->options['user'] = parse_url($cmsExpr, PHP_URL_USER);
       }


### PR DESCRIPTION
(This is extracted from the bigger #145, which needs some additional work before reaching its policy goal of flipping the defaults.)

Both `Bootstrap.php` and `CmsBootstrap.php` can be customized by environment variables (`CIVICRM_SETTINGS` and `CIVICRM_BOOT`, respectively). This patch adds a couple more options:

__Before__: The values must concretely define the exact location of the `civicrm.settings.php` or of the CMS (respectively).

* For `Bootstrap`, set `CIVICRM_SETTINGS=/var/www/sites/default/civicrm.settings.php`
* For `CmsBootstrap`, set `CIVICRM_BOOT=Drupal://var/www`

__After__: The old values still work. Additionally, you can specifically indicate a preference for _the default/automatic search behavior_, i.e.

* For `Bootstrap`, set `CIVICRM_SETTINGS=Auto` (literally, "automatically find the settings file")
* For `CmsBootstrap`, set `CIVICRM_BOOT=Auto://.` (literally, "automatically choose the CMS based on the current folder")

The two notations are slightly because the two variables are already different. They aim to feel "ok" when compared to their other regular values.