### PR TITLE
Improve interoperability of `Bootstrap.php`/`CmsBootstrap.php`

### DIFF
--- a/bin/cv
+++ b/bin/cv
@@ -18,6 +18,7 @@ $autoloaders = array(
 foreach ($autoloaders as $autoloader) {
   if (file_exists($autoloader)) {
     require_once $autoloader;
+    define('CV_AUTOLOAD', $autoloader);
     $found = 1;
     break;
   }

--- a/src/BuildkitReader.php
+++ b/src/BuildkitReader.php
@@ -1,6 +1,8 @@
 <?php
 namespace Civi\Cv;
 
+use Civi\Cv\Util\Filesystem;
+
 class BuildkitReader {
 
   /**
@@ -10,6 +12,8 @@ class BuildkitReader {
    * @return null|string
    */
   public static function findShFile($settingsFile) {
+    $fs = new Filesystem();
+    $settingsFile = $fs->toAbsolutePath($settingsFile);
     $parts = explode('/', str_replace('\\', '/', $settingsFile));
     while (!empty($parts)) {
       $last = array_pop($parts);

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -104,6 +104,26 @@ class CmsBootstrap {
   }
 
   /**
+   * Export bootstrap logic.
+   *
+   * @param array $actions
+   *   List of bootstrap actions to include.
+   *   Ex: ['bootCms', 'bootCivi']
+   * @return string
+   *   PHP code to `CmsBootstrap` in a new process
+   */
+  public function generate(array $actions = []): string {
+    $instanceExpr = '\\' . get_class($this) . '::singleton()';
+    $code = '';
+    $code .= sprintf("require_once %s;\n", var_export(CV_AUTOLOAD, TRUE));
+    $code .= sprintf("%s->addOptions(%s);\n", $instanceExpr, var_export($this->getOptions(), TRUE));
+    foreach ($actions as $action) {
+      $code .= sprintf("%s->%s()->bootCivi();\n", $instanceExpr, $action);
+    }
+    return $code;
+  }
+
+  /**
    * Bootstrap the CiviCRM runtime.
    *
    * @return CmsBootstrap

--- a/src/CmsBootstrap.php
+++ b/src/CmsBootstrap.php
@@ -238,7 +238,22 @@ class CmsBootstrap {
       \CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
     }
 
+    $GLOBALS['_CV'] = $this->buildCv();
+
     return $this;
+  }
+
+  protected function buildCv(): array {
+    $settings = constant('CIVICRM_SETTINGS_PATH');
+    if ($settings && class_exists('Civi\Cv\SiteConfigReader')) {
+      $this->writeln("Load supplemental configuration for \"$settings\"", OutputInterface::VERBOSITY_DEBUG);
+      $reader = new SiteConfigReader($settings);
+      return $reader->compile(array('buildkit', 'home'));
+    }
+    else {
+      $this->writeln("Warning: Not loading supplemental configuration for \"$settings\". SiteConfigReader is missing.", OutputInterface::VERBOSITY_DEBUG);
+      return [];
+    }
   }
 
   /**

--- a/src/Command/BootCommand.php
+++ b/src/Command/BootCommand.php
@@ -36,6 +36,10 @@ class BootCommand extends BaseCommand {
           . '\CRM_Utils_System::loadBootStrap(array(), FALSE);';
         break;
 
+      case 'cms-full':
+        $code = \Civi\Cv\CmsBootstrap::singleton()->generate(['bootCms', 'bootCivi']);
+        break;
+
       case 'none':
         break;
 

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -10,18 +10,33 @@ class Filesystem {
   }
 
   /**
+   * @return false|string
+   */
+  public function pwd() {
+    // exec(pwd) works better with symlinked source trees, but it's
+    // probably not portable to Windows.
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+      return getcwd();
+    }
+    else {
+      exec('pwd', $output);
+      return trim(implode("\n", $output));
+    }
+  }
+
+  /**
    * @param string $path
    * @return string updated $path
    */
   public function toAbsolutePath($path) {
     if (empty($path)) {
-      $res = getcwd();
+      $res = $this->pwd();
     }
     elseif ($this->isAbsolutePath($path)) {
       $res = $path;
     }
     else {
-      $res = getcwd() . DIRECTORY_SEPARATOR . $path;
+      $res = $this->pwd() . DIRECTORY_SEPARATOR . $path;
     }
     if (is_dir($res)) {
       return realpath($res);

--- a/tests/Command/BootCommandTest.php
+++ b/tests/Command/BootCommandTest.php
@@ -19,9 +19,11 @@ class BootCommandTest extends \Civi\Cv\CivilTestCase {
 
     $helloPhp = escapeshellarg($phpBoot->getOutput()
       . 'printf("count is %s\n", CRM_Core_DAO::singleValueQuery("select count(*) from civicrm_contact"));'
+      . 'printf("my admin is %s\n", $GLOBALS["_CV"]["ADMIN_USER"]);'
     );
     $phpRun = Process::runOk(new \Symfony\Component\Process\Process("php -r $helloPhp"));
-    $this->assertRegExp('/^count is [0-9]+$/', $phpRun->getOutput());
+    $this->assertRegExp('/^count is [0-9]+\n/', $phpRun->getOutput());
+    $this->assertRegExp('/my admin is \w+\n/', $phpRun->getOutput());
   }
 
   public function testBootCmsFull() {
@@ -31,9 +33,11 @@ class BootCommandTest extends \Civi\Cv\CivilTestCase {
 
     $helloPhp = escapeshellarg($phpBoot->getOutput()
       . 'printf("count is %s\n", CRM_Core_DAO::singleValueQuery("select count(*) from civicrm_contact"));'
+      . 'printf("my admin is %s\n", $GLOBALS["_CV"]["ADMIN_USER"]);'
     );
     $phpRun = Process::runOk(new \Symfony\Component\Process\Process("php -r $helloPhp"));
-    $this->assertRegExp('/^count is [0-9]+$/', $phpRun->getOutput());
+    $this->assertRegExp('/^count is [0-9]+\n/', $phpRun->getOutput());
+    $this->assertRegExp('/my admin is \w+\n/', $phpRun->getOutput());
   }
 
   public function testBootClassLoader() {

--- a/tests/Command/BootCommandTest.php
+++ b/tests/Command/BootCommandTest.php
@@ -13,9 +13,21 @@ class BootCommandTest extends \Civi\Cv\CivilTestCase {
     parent::setUp();
   }
 
-  public function testBootDefault() {
-    $phpBoot = Process::runOk($this->cv("php:boot"));
+  public function testBootFull() {
+    $phpBoot = Process::runOk($this->cv("php:boot --level=full"));
     $this->assertRegExp(';CIVICRM_SETTINGS_PATH;', $phpBoot->getOutput());
+
+    $helloPhp = escapeshellarg($phpBoot->getOutput()
+      . 'printf("count is %s\n", CRM_Core_DAO::singleValueQuery("select count(*) from civicrm_contact"));'
+    );
+    $phpRun = Process::runOk(new \Symfony\Component\Process\Process("php -r $helloPhp"));
+    $this->assertRegExp('/^count is [0-9]+$/', $phpRun->getOutput());
+  }
+
+  public function testBootCmsFull() {
+    $phpBoot = Process::runOk($this->cv("php:boot --level=cms-full"));
+    $this->assertRegExp(';BEGINPHP;', $phpBoot->getOutput());
+    $this->assertRegExp(';ENDPHP;', $phpBoot->getOutput());
 
     $helloPhp = escapeshellarg($phpBoot->getOutput()
       . 'printf("count is %s\n", CRM_Core_DAO::singleValueQuery("select count(*) from civicrm_contact"));'

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -40,6 +40,18 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertEquals(255, $p->getExitCode());
   }
 
+  public function testPhpEval_CvVar_Full() {
+    $helloPhp = escapeshellarg('printf("my admin is %s\n", $GLOBALS["_CV"]["ADMIN_USER"]);');
+    $p = Process::runOk($this->cv("ev --level=full $helloPhp"));
+    $this->assertRegExp('/^my admin is \w+\s*$/', $p->getOutput());
+  }
+
+  public function testPhpEval_CvVar_CmsFull() {
+    $helloPhp = escapeshellarg('printf("my admin is %s\n", $GLOBALS["_CV"]["ADMIN_USER"]);');
+    $p = Process::runOk($this->cv("ev --level=cms-full $helloPhp"));
+    $this->assertRegExp('/^my admin is \w+\s*$/', $p->getOutput());
+  }
+
   public function testBoot() {
     $checkBoot = escapeshellarg('echo (function_exists("drupal_add_js") || function_exists("wp_redirect") || class_exists("JFactory") || class_exists("Drupal")) ? "found" : "not-found";');
 


### PR DESCRIPTION
(Extracted from #145) 

As part of the effort to switch from `Bootstrap.php` to `CmsBootstrap.php`, we need to make sure that it actually works as replacement. This addresses a couple edge-cases:

1. The `php:boot` command should support `--level=cms-full`
2. When using `--level=cms-full`, you should get the same `$_CV` variables (as currently provided by `--level=full`).