### PR TITLE
ErrorHandler - Guard for `$error`

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -32,7 +32,7 @@ class ErrorHandler {
   public static function onShutdown() {
     if (static::$count > 0) {
       $error = error_get_last();
-      if (($error['type'] & (E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR))) {
+      if (isset($error['type']) && ($error['type'] & (E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR))) {
         // Something - like a bad eval() - interrupted normal execution.
         // Make sure the status code reflects that.
         exit(255);


### PR DESCRIPTION
Aims to fix [this](https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=max,CIVIVER=master,SUITES=phpunit-crm,label=bknix-tmp/lastCompletedBuild/testReport/(root)/CRM_Utils_FileTest/testIsDirWithOpenBasedir_with_data_set__0/):

```
CRM_Utils_FileTest::testIsDirWithOpenBasedir with data set #0 ('/etc', false)
doIsDirWithOpenBasedir() should not generate warnings
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''
+'[PHP Warning] Trying to access array offset on value of type null at phar:///home/jenkins/bknix-max/bin/cv/src/ErrorHandler.php:35'

/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CRM/Utils/FileTest.php:354
/home/jenkins/bknix-max/build/build-0/web/sites/all/modules/civicrm/tests/phpunit/CiviTest/CiviUnitTestCase.php:229
```