### PR TITLE
php-scoper - Fix prefixing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ PRJDIR=$(absdirname "$0")
 OUTFILE="$PRJDIR/bin/cv.phar"
 set -e
 
-BOX_VERSION=3.16.0
+BOX_VERSION=4.3.7
 BOX_URL="https://github.com/box-project/box/releases/download/${BOX_VERSION}/box.phar"
 BOX_DIR="$PRJDIR/extern/box-$BOX_VERSION"
 BOX_BIN="$BOX_DIR/box"

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,8 @@ function absdirname() {
 }
 
 PRJDIR=$(absdirname "$0")
-set -ex
+OUTFILE="$PRJDIR/bin/cv.phar"
+set -e
 
 BOX_VERSION=3.16.0
 BOX_URL="https://github.com/box-project/box/releases/download/${BOX_VERSION}/box.phar"
@@ -34,5 +35,7 @@ pushd "$PRJDIR" >> /dev/null
   ## `composer/xdebug-handler`.  (Both have a need to manipulate PHP INI.) The flag `BOX_ALLOW_XDEBUG` is defined by their
   ## upstream.  Setting the flag doesn't actually configure xdebug -- rather, it disables PHP INI automanipulations, so that you
   ## are _allowed_ to set PHP INI options (`xdebug.*`, `phar.*`, etc) on your own.
+
+  php scripts/check-phar.php "$OUTFILE"
 
 popd >> /dev/null

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -2,17 +2,9 @@
 
 return [
   'prefix' => 'Cvphar',
-  'patchers' => [
-      function (string $filePath, string $prefix, string $content) {
-          // In some cases, `cv` references classes provided by civicrm-core or by the UF. Preserve the original names.
-          $content = preg_replace(';Cvphar\(CRM_|HTML_|DB_|Drupal|JFactory|Guzzle|Civi::);', '$1', $content);
-          $content = preg_replace_callback(';Cvphar\Civi\([A-Za-z0-9_\\]*);', function($m) {
-            if (substr($m[1], 0, 3) === 'Cv\\') return $m[0]; // Civi\Cv is mapped.
-            else return 'Civi\\' . $m[1]; // Nothing else is mapped.
-          }, $content);
-          return $content;
-      },
-  ],
+  'exclude-namespaces' => ['Civi', 'Guzzle', 'Drupal'],
+  'exclude-classes' => ['/^(CRM_|HTML_|DB_)/', 'JFactory', 'Civi', 'Drupal'],
+  'exclude-functions' => ['/^civicrm_api/'],
 
   // Do not generate wrappers/aliases for `civicrm_api()` etc or various CMS-booting functions.
   'expose-global-functions' => false,

--- a/scripts/check-phar.php
+++ b/scripts/check-phar.php
@@ -1,0 +1,71 @@
+#!/usr/bin/env php
+<?php
+
+// This is a sniff-test to ensure that the generated PHAR looks the way it
+// should. In particular, we assert that some classes MUST have
+// namespace-prefixes, and other classes MUST NOT.
+
+global $errors, $pharFile;
+
+if (empty($argv[1]) || !file_exists($argv[1])) {
+  die("Missing argument. Ex: check-phar.php /path/to/my.phar");
+}
+
+$pharFile = $argv[1];
+$errors = [];
+
+assertMatch('src/Command/BootCommand.php', ';^namespace Civi;');
+assertNotMatch('src/Command/BootCommand.php', ';^namespace Cvphar;');
+
+assertNotMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace Symfony;');
+assertMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace Cvphar.Symfony;');
+
+assertMatch('src/Util/UrlCommandTrait.php', ';CRM_Utils_System;');
+assertNotMatch('src/Util/UrlCommandTrait.php', ';Cvphar.CRM_Utils_System;');
+
+assertMatch('src/Command/ApiCommand.php', ';civicrm_api;');
+assertNotMatch('src/Command/ApiCommand.php', ';Cvphar.civicrm_api;');
+
+assertMatch('src/CmsBootstrap.php', ';JFactory::;');
+assertMatch('src/CmsBootstrap.php', ';Drupal::;');
+assertNotMatch('src/CmsBootstrap.php', ';Cvphar.JFactory;');
+assertNotMatch('src/CmsBootstrap.php', ';Cvphar.Drupal;');
+
+if (empty($errors)) {
+  echo "OK $pharFile\n";
+}
+else {
+  echo "ERROR $pharFile\n";
+  echo implode("", $errors);
+  exit(empty($errors) ? 0 : 1);
+}
+
+########################################################################################
+
+/**
+ * Construct full name for a file (within the phar).
+ */
+function getFilename(?string $relpath = NULL): string {
+  global $pharFile;
+  $path = 'phar://' . $pharFile;
+  if ($relpath != NULL) {
+    $path .= '/' . $relpath;
+  }
+  return $path;
+}
+
+function assertMatch(string $relpath, string $regex) {
+  global $errors;
+  $content = explode("\n", file_get_contents(getFilename($relpath)));
+  if (!preg_grep($regex, $content)) {
+    $errors[] = sprintf("Failed: assertMatch(%s, %s)\n", var_export($relpath, 1), var_export($regex, 1));
+  }
+}
+
+function assertNotMatch(string $relpath, string $regex) {
+  global $errors;
+  $content = explode("\n", file_get_contents(getFilename($relpath)));
+  if (!empty($x = preg_grep($regex, $content))) {
+    $errors[] = sprintf("Failed: assertNotMatch(%s, %s)\n", var_export($relpath, 1), var_export($regex, 1));
+  }
+}

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
     sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
   };
   pkgs = import pkgSrc {};
-  myphp = pkgs.php74.buildEnv {
+  myphp = pkgs.php81.buildEnv {
     extraConfig = ''
       memory_limit=-1
     '';
@@ -20,5 +20,5 @@ in
 
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    nativeBuildInputs = [ myphp pkgs.php74Packages.composer ];
+    nativeBuildInputs = [ myphp pkgs.php81Packages.composer ];
 }


### PR DESCRIPTION
Per #147, it appears that the prefixing is not currently working for `cv.phar`. This should restore prefixing.

Before
---------

* Rely on `patchers` to enable/disable prefixing for specific symbols
* Nothing will complain about incorrect prefixing
* Compile on box 3.16.0 and php74

After
-------

* Rely on `exclude-classes`, `exclude-namespaces`, etc to enable/disable prefixing for specific symbols
* Build script will spot-check some prefixes and complain if they're wrong.
* Compile on box 4.3.7 and php81

Technical Details
----------------------

I played around with the `scoper.inc.php` rules on 3.16.0, and the problem seemed to be caused by the `patchers` function. This is somewhat fiddly way to enable/disable prefixing, and it's no longer necessary since `exclude-classes` and `exclude-namespaces` can do the needful.

After addressing that, there was another issue where `polyfill-php80` didn't load correctly. This required upgrading `box` and `php`.

I tested the resulting `cv.phar` lightly on `php73` with D7, WP, and D9. They all seemed OK.