### PR TITLE
Fix recent errors with "core:install" on "cv.phar". Declare "psr/log" requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "lesser-evil/shell-verbosity-is-evil": "~1.0",
         "symfony/console": "^4",
         "symfony/process": "^4",
+        "psr/log": "~1.1 || ~2.0 || ~3.0",
         "psy/psysh": "@stable"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2219c77bab76b61918b16659f5501038",
+    "content-hash": "5b36e3e71fa4a86a6e2869a98202c4bc",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -284,6 +284,56 @@
                 "source": "https://github.com/php-fig/container/tree/master"
             },
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psy/psysh",
@@ -934,5 +984,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -2,8 +2,21 @@
 
 return [
   'prefix' => 'Cvphar',
-  'exclude-namespaces' => ['Civi', 'Guzzle', 'Drupal'],
-  'exclude-classes' => ['/^(CRM_|HTML_|DB_)/', 'JFactory', 'Civi', 'Drupal'],
+  'exclude-namespaces' => [
+    'Civi',
+    'Guzzle',
+    'Drupal',
+
+    // we don't really use these, but CmsBootstrap needs to apply D8+ bootstrap protocol
+    'Symfony\\Component\\HttpFoundation',
+    'Symfony\\Component\\Routing',
+  ],
+  'exclude-classes' => [
+    '/^(CRM_|HTML_|DB_)/',
+    'JFactory',
+    'Civi',
+    'Drupal',
+  ],
   'exclude-functions' => [
     '/^civicrm_/',
     '/^wp_.*/',
@@ -12,5 +25,5 @@ return [
   ],
 
   // Do not generate wrappers/aliases for `civicrm_api()` etc or various CMS-booting functions.
-  'expose-global-functions' => false,
+  'expose-global-functions' => FALSE,
 ];

--- a/scripts/check-phar.php
+++ b/scripts/check-phar.php
@@ -41,6 +41,7 @@ foreach (['src/Bootstrap.php', 'src/CmsBootstrap.php'] as $file) {
 }
 assertNotMatch('src/CmsBootstrap.php', ';Cvphar.JFactory;');
 assertNotMatch('src/CmsBootstrap.php', ';Cvphar.Drupal;');
+assertNotMatch('src/CmsBootstrap.php', ';Cvphar..?Symfony..?Component..?HttpFoundation;');
 
 if (empty($errors)) {
   echo "OK $pharFile\n";


### PR DESCRIPTION
Fixes a recent regression (0.3.35-0.3.36) where "core:install" outputs this:

```
  Found code for civicrm-core in /srv/runner/home/runner-1/buildkit/build/build-1/web/sites/all/modules/civicrm
  Found code for civicrm-setup in /srv/runner/home/runner-1/buildkit/build/build-1/web/sites/all/modules/civicrm/setup
  Error: Class &#039;Cvphar\Psr\Log\AbstractLogger&#039; not found in include() (line 10 of phar:///srv/runner/home/runner-1/buildkit/bin/cv/vendor/composer/../symfony/console/Logger/ConsoleLogger.php).
```

In non-prefixed environments, this worked because `psr/log` was generally provided by some other means.

But now that `cv.phar` prefixing has been restored, it's looking for an isolated version of "AbstractLogger". That seems good in terms of avoiding future conflicts. The problem is that "AbstractLogger" actually needs to be available to "cv".