### PR TITLE
BootTrait - Update ensureUserContact() for standalone

### DIFF
--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -226,6 +226,10 @@ trait BootTrait {
         \CRM_Core_BAO_UFMatch::synchronize(\JFactory::getUser(), TRUE, CIVICRM_UF, 'Individual');
         break;
 
+      case 'Standalone':
+        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['loggedInUser'], TRUE, CIVICRM_UF, 'Individual');
+        break;
+
       case 'WordPress':
         \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['current_user'], TRUE, CIVICRM_UF, 'Individual');
         break;

--- a/src/Util/BootTrait.php
+++ b/src/Util/BootTrait.php
@@ -227,7 +227,13 @@ trait BootTrait {
         break;
 
       case 'Standalone':
-        \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['loggedInUser'], TRUE, CIVICRM_UF, 'Individual');
+        // At time of writing, support for 'loggedInUser' is in a PR. Once the functionality is merged, we can update/simplify this.
+        if (empty($GLOBALS['loggedInUser'])) {
+          $output->writeln("<error>Failed to sync user/contact. You may be running a pre-release of civicrm-standalone.</error>");
+        }
+        else {
+          \CRM_Core_BAO_UFMatch::synchronize($GLOBALS['loggedInUser'], TRUE, CIVICRM_UF, 'Individual');
+        }
         break;
 
       case 'WordPress':


### PR DESCRIPTION
This is a partial solution for running `E2E_Extern_CliRunnerTest::testPermissionLookup()` on Standalone. The test calls:

```
cv ev --user='admin' 'echo json_encode(CRM_Core_Config::singleton()->userPermissionClass->check("administer CiviCRM", 0));'
```

For a full solution to running `E2E_Extern_CliRunnerTest::testPermissionLookup()`, this needs a corresponding update for civicrm-core.
