### PR TITLE
Basic autocomplete support (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ Bootstrap
 > ___NOTE___: In absence of a configuration variable, the __Automatic__ mode will behave like `CIVICRM_SETTINGS="Auto"` (in v0.3.x).
   This is tentatively planned to change in v0.4.x, where it will behave like `CIVICRM_BOOT="Auto://."`
 
+Autocomplete
+============
+
+There is limited/experimental support for shell autocompletion based on [stecman/symfony-console-completion](https://github.com/stecman/symfony-console-completion).
+To enable it:
+
+```sh
+# BASH ~4.x, ZSH
+source <(cv _completion --generate-hook)
+
+# BASH ~3.x, ZSH
+cv _completion --generate-hook | source /dev/stdin
+
+# BASH (any version)
+eval $(cv _completion --generate-hook)
+```
+
 Build
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "symfony/console": "^4",
         "symfony/process": "^4",
         "psr/log": "~1.1 || ~2.0 || ~3.0",
-        "psy/psysh": "@stable"
+        "psy/psysh": "@stable",
+        "stecman/symfony-console-completion": "^0.11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b36e3e71fa4a86a6e2869a98202c4bc",
+    "content-hash": "999d23b37e33d51ac31df8795901a955",
     "packages": [
         {
             "name": "lesser-evil/shell-verbosity-is-evil",
@@ -276,6 +276,55 @@
                 "source": "https://github.com/bobthecow/psysh/tree/v0.11.18"
             },
             "time": "2023-05-23T02:31:11+00:00"
+        },
+        {
+            "name": "stecman/symfony-console-completion",
+            "version": "0.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stecman/symfony-console-completion.git",
+                "reference": "a9502dab59405e275a9f264536c4e1cb61fc3518"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/a9502dab59405e275a9f264536c4e1cb61fc3518",
+                "reference": "a9502dab59405e275a9f264536c4e1cb61fc3518",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.3 || ~3.0 || ~4.0 || ~5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Holdaway",
+                    "email": "stephen@stecman.co.nz"
+                }
+            ],
+            "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "support": {
+                "issues": "https://github.com/stecman/symfony-console-completion/issues",
+                "source": "https://github.com/stecman/symfony-console-completion/tree/0.11.0"
+            },
+            "time": "2019-11-24T17:03:06+00:00"
         },
         {
             "name": "symfony/console",

--- a/shell.nix
+++ b/shell.nix
@@ -20,5 +20,8 @@ in
 
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    nativeBuildInputs = [ myphp pkgs.php81Packages.composer ];
+    nativeBuildInputs = [ myphp pkgs.php81Packages.composer pkgs.bash-completion ];
+    shellHook = ''
+      source ${pkgs.bash-completion}/etc/profile.d/bash_completion.sh
+    '';
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -129,6 +129,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\CoreCheckReqCommand();
       $commands[] = new \Civi\Cv\Command\CoreInstallCommand();
       $commands[] = new \Civi\Cv\Command\CoreUninstallCommand();
+      $commands[] = new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand();
     }
     return $commands;
   }


### PR DESCRIPTION
Quick/experimental support for bash autocomplete:

[![asciicast](https://asciinema.org/a/b7jVdCXqaz18tx2W4MemvL0jW.svg)](https://asciinema.org/a/b7jVdCXqaz18tx2W4MemvL0jW)

Possible issues:

* Needs to spin up `cv` every time you press `Tab`. That might be a bit heavy? The alternative would be a smaller/dedicated script?
* It uses the metadata from Symfony Console -- so it can complete some symbols (e.g. subcommand names and some `--foo` options). But completing other things (such as entity-names, action-names, or extension-keys) would require some more work.