### PR TITLE
Include the CMS Composer project's autoloader

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -232,13 +232,13 @@ class Bootstrap {
     require_once $civicrm_root . '/CRM/Core/ClassLoader.php';
     \CRM_Core_ClassLoader::singleton()->register();
 
-    // Include the project autoloader.
+    // Include the UF's autoloader. Should this be tuned based on UF type?
     if (!isset($cmsBasePath)) {
       list (, $cmsBasePath) = $this->findCmsRoot($this->getSearchDir());
     }
-    $project_autoloader = dirname($cmsBasePath) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
-    if (file_exists($project_autoloader)) {
-      require_once($project_autoloader);
+    $cmsAutoloader = dirname($cmsBasePath) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
+    if (file_exists($cmsAutoloader)) {
+      require_once $cmsAutoloader;
     }
 
     if (!empty($options['prefetch'])) {
@@ -294,6 +294,13 @@ class Bootstrap {
 
     $code[] = 'require_once $GLOBALS["civicrm_root"] . "/CRM/Core/ClassLoader.php";';
     $code[] = '\CRM_Core_ClassLoader::singleton()->register();';
+
+    // Include the UF's autoloader. Should this be tuned based on UF type?
+    list (, $cmsBasePath) = $this->findCmsRoot($this->getSearchDir());
+    $cmsAutoloader = dirname($cmsBasePath) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
+    if (file_exists($cmsAutoloader)) {
+      $code[] = sprintf('require_once %s;', var_export($cmsAutoloader, 1));
+    }
 
     return implode("\n", $code);
   }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -232,6 +232,15 @@ class Bootstrap {
     require_once $civicrm_root . '/CRM/Core/ClassLoader.php';
     \CRM_Core_ClassLoader::singleton()->register();
 
+    // Include the project autoloader.
+    if (!isset($cmsBasePath)) {
+      list (, $cmsBasePath) = $this->findCmsRoot($this->getSearchDir());
+    }
+    $project_autoloader = dirname($cmsBasePath) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
+    if (file_exists($project_autoloader)) {
+      require_once($project_autoloader);
+    }
+
     if (!empty($options['prefetch'])) {
       $this->writeln("Call core bootstrap", OutputInterface::VERBOSITY_VERBOSE);
       // I'm not sure why this is called explicitly during bootstrap


### PR DESCRIPTION
This avoids errors including e. g. PEAR's `Log.php` while loading `CRM_Core_Config` when using CiviCRM Core as symlinked Composer dependency in dev environments.

I'm not sure, however, whether this makes sense in all environments, but if that addition is trying to include the same autoloader again, `require_once` will take care of it, so it won't hurt. I'm not able to run certain cv or civix commands without it, but I'd be happy to explain my setup, if there's doubt it's necessary.