### PR TITLE
php:eval - Improve support for non-array outputs

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -73,6 +73,8 @@ class Encoder {
         return serialize($data);
 
       case 'shell':
+        $data = static::preferArray($data);
+
         if (is_scalar($data)) {
           return escapeshellarg($data);
         }
@@ -108,6 +110,15 @@ class Encoder {
       default:
         throw new \RuntimeException('Unknown output format');
     }
+  }
+
+  private static function preferArray($data) {
+    if (is_object($data)) {
+      if ($data instanceof \JsonSerializable || $data instanceof \stdClass) {
+        $data = json_decode(json_encode($data), TRUE);
+      }
+    }
+    return $data;
   }
 
 }

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -41,6 +41,7 @@ class Encoder {
       'none',
       'pretty',
       'php',
+      'php-data',
       'json-pretty',
       'json-strict',
       'serialize',
@@ -58,6 +59,9 @@ class Encoder {
 
       case 'php':
         return var_export($data, 1);
+
+      case 'php-data':
+        return var_export(static::preferArray($data), 1);
 
       case 'json-pretty':
         $jsonOptions = (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0)

--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -104,9 +104,14 @@ trait StructuredOutputTrait {
       $result = ArrayUtil::implodeTree($flat, $result);
     }
     $buf = Encoder::encode($result, $input->getOption('out'));
-    $options = empty($result['is_error'])
-      ? (OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_NORMAL)
-      : (OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_QUIET);
+    $options = OutputInterface::OUTPUT_RAW;
+    if (!is_array($result)) {
+      $options |= OutputInterface::VERBOSITY_NORMAL;
+    }
+    else {
+      $options |= empty($result['is_error']) ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_QUIET;
+      // Why...? Feels weird for `cv php:eval`, but maybe it makes sense in some other commands?
+    }
     $output->writeln($buf, $options);
   }
 

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -19,11 +19,25 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp('/^eval says version is [0-9a-z\.]+\s*$/', $p->getOutput());
   }
 
-  public function testPhpEval_ReturnObj() {
+  public function testPhpEval_ReturnObj_json() {
     $phpCode = escapeshellarg('return (object)["ab"=>"cd"];');
     $p = Process::runOk($this->cv("ev $phpCode --out=json"));
     $this->assertEquals(0, $p->getExitCode());
     $this->assertRegExp(';"ab":\w*"cd\";', $p->getOutput());
+  }
+
+  public function testPhpEval_ReturnObj_shell() {
+    $phpCodes = [
+      'return (object)["ab"=>"cd"];',
+      'return new class implements JsonSerializable { public function jsonSerialize() { return ["ab" => "cd"]; } };',
+    ];
+
+    foreach ($phpCodes as $phpCode) {
+      $escaped = escapeshellarg($phpCode);
+      $p = Process::runOk($this->cv("ev $escaped --out=shell"));
+      $this->assertEquals(0, $p->getExitCode());
+      $this->assertRegExp(';ab=["\']cd;', $p->getOutput());
+    }
   }
 
   public function testPhpEval() {

--- a/tests/Command/EvalCommandTest.php
+++ b/tests/Command/EvalCommandTest.php
@@ -19,6 +19,13 @@ class EvalCommandTest extends \Civi\Cv\CivilTestCase {
     $this->assertRegExp('/^eval says version is [0-9a-z\.]+\s*$/', $p->getOutput());
   }
 
+  public function testPhpEval_ReturnObj() {
+    $phpCode = escapeshellarg('return (object)["ab"=>"cd"];');
+    $p = Process::runOk($this->cv("ev $phpCode --out=json"));
+    $this->assertEquals(0, $p->getExitCode());
+    $this->assertRegExp(';"ab":\w*"cd\";', $p->getOutput());
+  }
+
   public function testPhpEval() {
     $helloPhp = escapeshellarg('printf("eval says version is %s\n", CRM_Utils_System::version());');
     $p = Process::runOk($this->cv("ev $helloPhp"));


### PR DESCRIPTION
The eval command can be used to `return` data with whatever serialization format is active.

However, depending on the data, it can fail. (Ex: regardless of what the serialization mechanism supports, it crashes for non-array output because it's trying to find APIv3-style `is_error` metadata.) This patch improves output options for non-array results.