### PR TITLE
BootTrait - Define a preference for URL absolute URLs in `default://`

### DIFF
--- a/lib/src/Util/BootTrait.php
+++ b/lib/src/Util/BootTrait.php
@@ -27,6 +27,12 @@ trait BootTrait {
     $logger = $this->bootLogger($output);
     $logger->debug('Start');
 
+    $GLOBALS['civicrm_url_defaults'] = $GLOBALS['civicrm_url_defaults'] ?? [];
+    array_unshift($GLOBALS['civicrm_url_defaults'], [
+      'format' => 'absolute',
+      'scheme' => 'default',
+    ]);
+
     $this->setupErrorHandling($output);
 
     if ($input->hasOption('test') && $input->getOption('test')) {


### PR DESCRIPTION
This patch (in combination with https://github.com/civicrm/civicrm-core/pull/26861) allows `cv` to pick URLs based on their metadata

Compare:

```
## Link to "civicrm/admin", which is declared as is_public=0
$ cv ev 'return Civi::url("//civicrm/admin");'
"http://wpmaster.127.0.0.1.nip.io:8001/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fadmin"

## Link to "civicrm/user", which is declared as is_public=1
$ cv ev 'return Civi::url("//civicrm/user");'
"http://wpmaster.127.0.0.1.nip.io:8001/civicrm/?civiwp=CiviCRM&q=civicrm%2Fuser"
```

