### PR TITLE
Improve the Typist User Interface

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -9,6 +9,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends \Symfony\Component\Console\Application {
 
+  protected $deprecatedAliases = [
+    'debug:container' => 'service',
+    'debug:event-dispatcher' => 'event',
+  ];
+
   /**
    * Determine the version number.
    *
@@ -138,6 +143,14 @@ class Application extends \Symfony\Component\Console\Application {
     ShellVerbosityIsEvil::doWithoutEvil(function() use ($input, $output) {
       parent::configureIO($input, $output);
     });
+  }
+
+  public function find($name) {
+    if (isset($this->deprecatedAliases[$name])) {
+      fprintf(STDERR, "WARNING: Subcommand \"%s\" has been renamed to \"%s\". In the future, the old name may stop working.\n\n", $name, $this->deprecatedAliases[$name]);
+      $name = $this->deprecatedAliases[$name];
+    }
+    return parent::find($name);
   }
 
 }

--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -29,8 +29,8 @@ class ApiCommand extends BaseCommand {
 
   protected function configure() {
     $this
-      ->setName('api')
-      ->setAliases(['api3'])
+      ->setName('api3')
+      ->setAliases(['api'])
       ->setDescription('Call APIv3')
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
       ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list']])

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -198,20 +198,16 @@ internal services (eg `--all`, `--tag=XXX`, or `-v`).
   }
 
   /**
-   * @param $definition
-   *
+   * @param \Symfony\Component\DependencyInjection\Definition $definition
    * @return array|string
    */
-  protected function getEvents($definition) {
+  protected function getEvents($definition): array {
     if (class_exists('Civi\Core\Event\EventScanner')) {
       if ($definition->getTag('event_subscriber') || $definition->getTag('kernel.event_subscriber')) {
         return \Civi\Core\Event\EventScanner::findListeners($definition->getClass());
       }
-      else {
-        return '';
-      }
     }
-    return '?';
+    return [];
   }
 
   /**

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -19,9 +19,9 @@ class DebugContainerCommand extends BaseCommand {
 
   protected function configure() {
     $this
-      ->setName('debug:container')
-      ->setAliases(['service'])
-      ->setDescription('Dump the container configuration')
+      ->setName('service')
+      ->setAliases(['svc'])
+      ->setDescription('Inspect the service container')
       ->addArgument('name', InputArgument::OPTIONAL, 'An service name or regex')
       ->addOption('concrete', 'C', InputOption::VALUE_NONE, 'Display concrete class names. (This requires activating every matching service.)')
       ->addOption('internal', 'i', InputOption::VALUE_NONE, 'Include internal services')

--- a/src/Command/DebugDispatcherCommand.php
+++ b/src/Command/DebugDispatcherCommand.php
@@ -14,8 +14,8 @@ class DebugDispatcherCommand extends BaseCommand {
 
   protected function configure() {
     $this
-      ->setName('debug:event-dispatcher')
-      ->setDescription('Dump the list of event listeners')
+      ->setName('event')
+      ->setDescription('Inspect events and listeners')
       ->addArgument('event', InputArgument::OPTIONAL, 'An event name or regex')
       // ->addOption('out', NULL, InputArgument::OPTIONAL, 'Specify return format (json,none,php,pretty,shell)', \Civi\Cv\Encoder::getDefaultFormat())
       // ->configureOutputOptions()

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -21,7 +21,7 @@ class ExtensionListCommand extends BaseExtensionCommand {
   protected function configure() {
     $this
       ->setName('ext:list')
-      ->setAliases(array())
+      ->setAliases(['ext'])
       ->setDescription('List extensions')
       ->addOption('local', 'L', InputOption::VALUE_NONE, 'Filter extensions by location (local)')
       ->addOption('remote', 'R', InputOption::VALUE_NONE, 'Filter extensions by location (remote)')


### PR DESCRIPTION
1. Rename `debug:event-dispatcher` to `event`. Leave deprecated alias for long name.
2. Rename `debug:container` to `service` (`svc` ). Leave deprecated alias for long name.
3. Add alias `ext` =~ `ext:list`
4. Swap the names `api` and `api3`. (The main name is now listed as `api3` alongside `api4`. The name `api` is left as a live alias.)
