### PR TITLE
Api4 - Don't crash when displaying an empty table

### DIFF
--- a/src/Command/Api4Command.php
+++ b/src/Command/Api4Command.php
@@ -151,7 +151,12 @@ NOTE: To change the default output format, set CV_OUTPUT.
 
     $out = $input->getOption('out');
     if (!in_array($out, Encoder::getFormats()) && in_array($out, Encoder::getTabularFormats())) {
-      $columns = empty($params['select']) ? array_keys($result->first()) : $params['select'];
+      if (!empty($params['select'])) {
+        $columns = $params['select'];
+      }
+      else {
+        $columns = count($result) ? array_keys($result->first()) : [''];
+      }
       $this->sendTable($input, $output, (array) $result, $columns);
     }
     else {


### PR DESCRIPTION
The `-T` flag requests that results be displayed as a table.  Consider these four commands:

1. cv api4 Route.get +w 'name like %admin%' -T +s path
2. cv api4 Route.get +w 'name like %admin%' -T
3. cv api4 Route.get +w 'name like %zzz%' -T +s path
4. cv api4 Route.get +w 'name like %zzz%' -T

How do they behave?

1. Shows a table (with `path` header) and exits normally
2. Shows a table (with many column headers) and exits normally
3. Shows an empty table (with `path` header) and exits normally
4. Crashes because it cannot pick a header. (At least, on php81 it does.) (`array_keys(): Argument #1 ($array) must be of type array, null given`)

This patch changes (4) to behave more like (3) -- it will show an empty table and exit normally.