### PR TITLE
cv api4 - Add support for more `where` operators

### DIFF
--- a/src/Util/AbstractPlusParser.php
+++ b/src/Util/AbstractPlusParser.php
@@ -106,18 +106,4 @@ abstract class AbstractPlusParser {
     }
   }
 
-  public function parseWhere($expr) {
-    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN|CONTAINS|NOT CONTAINS|REGEXP|NOT REGEXP|REGEXP BINARY|NOT REGEXP BINARY)\s*(.*)$/i', $expr, $matches)) {
-      if (!empty($matches[3])) {
-        return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
-      }
-      else {
-        return [$matches[1], strtoupper($matches[2])];
-      }
-    }
-    else {
-      throw new \RuntimeException("Error parsing \"where\": $expr");
-    }
-  }
-
 }

--- a/src/Util/AbstractPlusParser.php
+++ b/src/Util/AbstractPlusParser.php
@@ -107,7 +107,7 @@ abstract class AbstractPlusParser {
   }
 
   public function parseWhere($expr) {
-    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN)\s*(.*)$/i', $expr, $matches)) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN|CONTAINS|NOT CONTAINS|REGEXP|NOT REGEXP|REGEXP BINARY|NOT REGEXP BINARY)\s*(.*)$/i', $expr, $matches)) {
       if (!empty($matches[3])) {
         return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
       }

--- a/src/Util/Api4ArgParser.php
+++ b/src/Util/Api4ArgParser.php
@@ -5,6 +5,15 @@ namespace Civi\Cv\Util;
 class Api4ArgParser extends AbstractPlusParser {
 
   /**
+   * @var string
+   */
+  private $operators;
+
+  public function __construct() {
+    $this->operators = '\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN|CONTAINS|NOT CONTAINS|REGEXP|NOT REGEXP|REGEXP BINARY|NOT REGEXP BINARY';
+  }
+
+  /**
    * @param array $params
    * @param string $type
    * @param string $expr
@@ -61,6 +70,20 @@ class Api4ArgParser extends AbstractPlusParser {
 
       default:
         throw new \RuntimeException("Unrecognized option: +$type");
+    }
+  }
+
+  public function parseWhere($expr) {
+    if (preg_match('/^([a-zA-Z0-9_:\.]+)\s*(' . $this->operators . ')\s*(.*)$/i', $expr, $matches)) {
+      if (!empty($matches[3])) {
+        return [$matches[1], strtoupper(trim($matches[2])), $this->parseValueExpr(trim($matches[3]))];
+      }
+      else {
+        return [$matches[1], strtoupper($matches[2])];
+      }
+    }
+    else {
+      throw new \RuntimeException("Error parsing \"where\": $expr");
     }
   }
 

--- a/src/Util/Api4ArgParser.php
+++ b/src/Util/Api4ArgParser.php
@@ -10,7 +10,15 @@ class Api4ArgParser extends AbstractPlusParser {
   private $operators;
 
   public function __construct() {
-    $this->operators = '\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN|CONTAINS|NOT CONTAINS|REGEXP|NOT REGEXP|REGEXP BINARY|NOT REGEXP BINARY';
+    if (is_callable(['\Civi\Api4\Utils\CoreUtil', 'getOperators'])) {
+      // 5.30+
+      $this->operators = implode('|', ArrayUtil::map(\Civi\Api4\Utils\CoreUtil::getOperators(), function($op) {
+        return preg_quote($op, '/');
+      }));
+    }
+    else {
+      $this->operators = '\<=|\>=|=|!=|\<|\>|IS NULL|IS NOT NULL|IS EMPTY|IS NOT EMPTY|LIKE|NOT LIKE|IN|NOT IN|CONTAINS|NOT CONTAINS|REGEXP|NOT REGEXP|REGEXP BINARY|NOT REGEXP BINARY';
+    }
   }
 
   /**


### PR DESCRIPTION
# Before:

The `where` shorthand (`+w`) supports some operators, like `LIKE`:

```bash
cv api4 Entity.get -T +w 'name LIKE Opti%' +s name
```

# After:

The `where` shorthand (`+w`) supports more operators, like `CONTAINS` or `REGEXP`:

```bash
cv api4 Entity.get -T +w 'type CONTAINS ManagedEntity' +s name

cv api4 Entity.get -T +w 'name NOT REGEXP .*Field' +s name
```
