### PR TITLE
Add support for cv plugins

### DIFF
--- a/bin/cv
+++ b/bin/cv
@@ -26,4 +26,5 @@ foreach ($autoloaders as $autoloader) {
 if (!$found) {
   die("Failed to find autoloader");
 }
+\Civi\Cv\ClassAliases::register();
 \Civi\Cv\Application::main('cv', __DIR__, $argv);

--- a/bin/cv
+++ b/bin/cv
@@ -26,4 +26,4 @@ foreach ($autoloaders as $autoloader) {
 if (!$found) {
   die("Failed to find autoloader");
 }
-\Civi\Cv\Application::main(__DIR__, $argv);
+\Civi\Cv\Application::main('cv', __DIR__, $argv);

--- a/bin/cv
+++ b/bin/cv
@@ -26,4 +26,4 @@ foreach ($autoloaders as $autoloader) {
 if (!$found) {
   die("Failed to find autoloader");
 }
-\Civi\Cv\Application::main(__DIR__);
+\Civi\Cv\Application::main(__DIR__, $argv);

--- a/bin/cv
+++ b/bin/cv
@@ -6,8 +6,8 @@ if (PHP_SAPI !== 'cli') {
   printf("TIP: In a typical shell environment, the \"php\" command should execute php-cli - not php-cgi or similar.\n");
   exit(1);
 }
-if (version_compare(PHP_VERSION, '5.4', '<')) {
-  echo "cv requires PHP 5.4+\n";
+if (version_compare(PHP_VERSION, '7.3', '<')) {
+  echo "cv requires PHP 7.3+\n";
   exit(2);
 }
 $found = 0;

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -46,7 +46,19 @@ This sequencing meaning that some early events (e.g.  `cv.app.boot` or `cv.confi
 
 ## Events
 
-* `cv.app.boot` (*global-only*): Fires immediately when the application starts
-* `cv.app.run` (*global-only*): Fires when the application begins executing a command
-* `cv.app.commands` (*global-only*): Fires when the application builds a list of available commands
+* `cv.app.boot`: Fires immediately when the application starts
+   * __Argument__: `$e['app']`: Reference to the `Application` object
+* `cv.app.commands`: Fires when the application builds a list of available commands
    * __Argument__: `$e['commands`]`: alterable list of commands
+* `cv.app.run`: Fires when the application begins executing a command
+   * __Argument__: `$e['app']`: Reference to the `Application` object
+* `cv.app.site-alias`: Fires if the command is called with an alias (eg `cv @mysite ext:list`)
+   * __Argument__: `$e['alias']`: The name of the alias
+   * __Argument__: `$e['app']`: Reference to the `Application` object
+   * __Argument__: `$e['input']`: Reference to the `InputInterface`
+   * __Argument__: `$e['output']`: Reference to the `OutputInterface`
+   * __Argument__: `$e['argv']`: Raw/original arguments passed to the current command
+   * __Argument__: `$e['transport']`: Alternable callback (output). Fill in a value to specify how to forward the command to the referenced site.
+   * __Argument__: `$e['exec']`: Non-alterable callback (input). Use this if you need to immediately call the action within the current process. 
+
+(Note: When subscribing to an event like `cv.app.site-alias`, you may alternatively subscribe to the wildcard `*.app.site-alias`. In the future, this should allow you hook into adjacent commands like civix and coworker.)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -49,13 +49,12 @@ This sequencing meaning that some early events (e.g.  `cv.app.boot` or `cv.confi
 
 The plugin itself may live in a global namespace or its own namespace.
 
-When a plugin refers to another class, it will be affected by `cv`'s namespace-prefixing:
+Plugins execute within `cv`'s process, so they are affected by `cv`'s namespace-prefixing rules:
 
-* Classes provided by CiviCRM and the user-framework (eg `Civi\*`, `CRM_*`, `Drupal\*`) are referenced by their original names.
-* Classes provided by `cv`'s internal dependencies (eg `Symfony\Component\Console\*`)  should be accessed with the prefix `CvDeps\*` (eg `CvDeps\Symfony\Component\Console\*`).
-
-(Technically, `cv`'s internal dependencies may have different concrete names depending on how `cv` is installed. The prefix `CvDeps\` is a logical alias that will work in
-more environments.)
+* External dependencies (eg CiviCRM, Drupal, WordPress) are not provided by `cv`. They do not have prefixing.
+  Access these with their canonical names (eg `Civi\*`, `CRM_*`, `Drupal\*`).
+* Internal dependencies (eg Symfony Console) are bundled with `cv`. They are generally prefixed, though the
+  concrete names vary. To maximize portability, access these classes with the logical alias `CvDeps\*` (eg `CvDeps\Symfony\Component\Console\*`).
 
 ## Events
 
@@ -76,7 +75,7 @@ more environments.)
 
 (Note: When subscribing to an event like `cv.app.site-alias`, you may alternatively subscribe to the wildcard `*.app.site-alias`. In the future, this should allow you hook into adjacent commands like civix and coworker.)
 
-## Global helpers
+## `Cv` helpers
 
 The `\Civi\Cv\Cv` facade provides some helpers for implementing functionality:
 
@@ -88,3 +87,12 @@ The `\Civi\Cv\Cv` facade provides some helpers for implementing functionality:
     * __`Cv::input()`__: Get the Symfony "Input" interface for current subcommand
     * __`Cv::output()`__: Get the Symfony "Output" interface for current subcommand
     * (*During cv's initial bootstrap, there is no active subcommand. These return stubs.*)
+
+## `$CV_PLUGIN` data
+
+When loading a plugin, the variable `$CV_PLUGIN` is prepopulated with information about the plugin and its environment.
+
+* __Property__: `$CV_PLUGIN['appName']`: Logical name of the CLI application
+* __Property__: `$CV_PLUGIN['appVersion']`: Version of the main application
+* __Property__: `$CV_PLUGIN['name']`: Logical name of the plugin
+* __Property__: `$CV_PLUGIN['file']`: Full path to the plugin-file

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -7,13 +7,14 @@ Cv plugins are PHP files which register event listeners.
 ```php
 // FILE: /etc/cv/plugin/hello-command.php
 use Civi\Cv\Cv;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use CvDeps\Symfony\Component\Console\Input\InputInterface;
+use CvDeps\Symfony\Component\Console\Output\OutputInterface;
+use CvDeps\Symfony\Component\Console\Command\Command;
 
 if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) die("Expect CV_PLUGIN API v1");
 
 Cv::dispatcher()->addListener('cv.app.commands', function($e) {
-  $e['commands'][] = new class extends \Symfony\Component\Console\Command\Command {
+  $e['commands'][] = new class extends Command {
     protected function configure() {
       $this->setName('hello')->setDescription('Say a greeting');
     }
@@ -43,6 +44,18 @@ After loading the global plugins, `cv` reads the the `cv.yml` and then loads any
 
 This sequencing meaning that some early events (e.g.  `cv.app.boot` or `cv.config.find`) are only available to *global plugins*.
 -->
+
+## Namespacing
+
+The plugin itself may live in a global namespace or its own namespace.
+
+When a plugin refers to another class, it will be affected by `cv`'s namespace-prefixing:
+
+* Classes provided by CiviCRM and the user-framework (eg `Civi\*`, `CRM_*`, `Drupal\*`) are referenced by their original names.
+* Classes provided by `cv`'s internal dependencies (eg `Symfony\Component\Console\*`)  should be accessed with the prefix `CvDeps\*` (eg `CvDeps\Symfony\Component\Console\*`).
+
+(Technically, `cv`'s internal dependencies may have different concrete names depending on how `cv` is installed. The prefix `CvDeps\` is a logical alias that will work in
+more environments.)
 
 ## Events
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -18,8 +18,9 @@ Cv::dispatcher()->addListener('cv.app.commands', function($e) {
     protected function configure() {
       $this->setName('hello')->setDescription('Say a greeting');
     }
-    protected function execute(InputInterface $input, OutputInterface $output) {
+    protected function execute(InputInterface $input, OutputInterface $output): int {
       $output->writeln('Hello there!');
+      return 0;
     }
   };
 });

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -75,3 +75,16 @@ more environments.)
    * __Argument__: `$e['exec']`: Non-alterable callback (input). Use this if you need to immediately call the action within the current process. 
 
 (Note: When subscribing to an event like `cv.app.site-alias`, you may alternatively subscribe to the wildcard `*.app.site-alias`. In the future, this should allow you hook into adjacent commands like civix and coworker.)
+
+## Global helpers
+
+The `\Civi\Cv\Cv` facade provides some helpers for implementing functionality:
+
+* Event helpers
+    * __`Cv::dispatcher()`__: Get a reference to the dispatcher service. Add listeners and/or fire events.
+    * __`Cv::filter(string $eventName, array $eventData)`__: Fire a basic event to modify `$eventData`.
+* I/O helpers
+    * __`Cv::io()`__: Get the Symfony "Style" interface for current subcommand
+    * __`Cv::input()`__: Get the Symfony "Input" interface for current subcommand
+    * __`Cv::output()`__: Get the Symfony "Output" interface for current subcommand
+    * (*During cv's initial bootstrap, there is no active subcommand. These return stubs.*)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,52 @@
+# Plugins
+
+Cv plugins are PHP files which register event listeners.
+
+## Example: Add command
+
+```php
+// FILE: /etc/cv/plugin/hello-command.php
+use Civi\Cv\Cv;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) die("Expect CV_PLUGIN API v1");
+
+Cv::dispatcher()->addListener('cv.app.commands', function($e) {
+  $e['commands'][] = new class extends \Symfony\Component\Console\Command\Command {
+    protected function configure() {
+      $this->setName('hello')->setDescription('Say a greeting');
+    }
+    protected function execute(InputInterface $input, OutputInterface $output) {
+      $output->writeln('Hello there!');
+    }
+  };
+});
+```
+
+## Plugin loading
+
+*Global plugins* are loaded from the `CV_PLUGIN_PATH`.  All `*.php` files in
+`CV_PLUGIN_PATH` will be loaded automatically during startup.  Plugins are
+deduped by name (with earlier folders having higher precedence).
+
+If otherwise unspecified, the default value of `CV_PLUGIN_PATH` is:
+
+```bash
+CV_PLUGIN_PATH=$HOME/.config/cv/plugin/:/etc/cv/plugin:/usr/share/cv/plugin:/usr/local/share/cv/plugin
+```
+
+<!--
+Doesn't currently support project-specific plugins. This may be trickier.
+
+After loading the global plugins, `cv` reads the the `cv.yml` and then loads any *local plugins* (i.e. *project-specific* plugins).
+
+This sequencing meaning that some early events (e.g.  `cv.app.boot` or `cv.config.find`) are only available to *global plugins*.
+-->
+
+## Events
+
+* `cv.app.boot` (*global-only*): Fires immediately when the application starts
+* `cv.app.run` (*global-only*): Fires when the application begins executing a command
+* `cv.app.commands` (*global-only*): Fires when the application builds a list of available commands
+   * __Argument__: `$e['commands`]`: alterable list of commands

--- a/lib/src/BaseApplication.php
+++ b/lib/src/BaseApplication.php
@@ -1,0 +1,91 @@
+<?php
+namespace Civi\Cv;
+
+use LesserEvil\ShellVerbosityIsEvil;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BaseApplication extends \Symfony\Component\Console\Application {
+
+  /**
+   * Primary entry point for execution of the standalone command.
+   */
+  public static function main(string $name, ?string $binDir, array $argv) {
+    $class = static::class;
+
+    Cv::plugins()->init();
+    $application = Cv::filter("${name}.app.boot", [
+      'app' => new $class($name, static::version() ?? 'UNKNOWN'),
+    ])['app'];
+
+    $input = new ArgvInput($argv);
+    $output = new ConsoleOutput();
+
+    $application->setAutoExit(FALSE);
+    ErrorHandler::pushHandler();
+    try {
+      $result = $application->run($input, $output);
+    }
+    finally {
+      ErrorHandler::popHandler();
+    }
+    exit($result);
+  }
+
+  public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN') {
+    parent::__construct($name, $version);
+    $this->setCatchExceptions(TRUE);
+
+    $commands = Cv::filter($this->getName() . '.app.commands', [
+      'commands' => $this->createCommands(),
+    ])['commands'];
+    $this->addCommands($commands);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDefaultInputDefinition() {
+    $definition = parent::getDefaultInputDefinition();
+    $definition->addOption(new InputOption('cwd', NULL, InputOption::VALUE_REQUIRED, 'If specified, use the given directory as working directory.'));
+    $definition->addOption(new InputOption('site-alias', NULL, InputOption::VALUE_REQUIRED, 'Load site connection data based on its alias'));
+    return $definition;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function doRun(InputInterface $input, OutputInterface $output) {
+    ErrorHandler::setRenderer(function($e) use ($output) {
+      if ($output instanceof ConsoleOutputInterface) {
+        $this->renderThrowable($e, $output->getErrorOutput());
+      }
+      else {
+        $this->renderThrowable($e, $output);
+      }
+    });
+
+    $workingDir = $input->getParameterOption(array('--cwd'));
+    if (FALSE !== $workingDir && '' !== $workingDir) {
+      if (!is_dir($workingDir)) {
+        throw new \RuntimeException("Invalid working directory specified, $workingDir does not exist.");
+      }
+      if (!chdir($workingDir)) {
+        throw new \RuntimeException("Failed to use directory specified, $workingDir as working directory.");
+      }
+    }
+    Cv::filter($this->getName() . '.app.run', []);
+    return parent::doRun($input, $output);
+  }
+
+  protected function configureIO(InputInterface $input, OutputInterface $output) {
+    ShellVerbosityIsEvil::doWithoutEvil(function() use ($input, $output) {
+      parent::configureIO($input, $output);
+    });
+  }
+
+}

--- a/lib/src/BaseApplication.php
+++ b/lib/src/BaseApplication.php
@@ -4,6 +4,7 @@ namespace Civi\Cv;
 use Civi\Cv\Util\AliasFilter;
 use Civi\Cv\Util\CvArgvInput;
 use LesserEvil\ShellVerbosityIsEvil;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -57,6 +58,19 @@ class BaseApplication extends \Symfony\Component\Console\Application {
     $definition->addOption(new InputOption('cwd', NULL, InputOption::VALUE_REQUIRED, 'If specified, use the given directory as working directory.'));
     $definition->addOption(new InputOption('site-alias', NULL, InputOption::VALUE_REQUIRED, 'Load site connection data based on its alias'));
     return $definition;
+  }
+
+  public function run(?InputInterface $input = NULL, ?OutputInterface $output = NULL) {
+    $input = $input ?: new CvArgvInput();
+    $output = $output ?: new ConsoleOutput();
+
+    try {
+      Cv::ioStack()->push($input, $output);
+      return parent::run($input, $output);
+    }
+    finally {
+      Cv::ioStack()->pop();
+    }
   }
 
   /**

--- a/lib/src/Cv.php
+++ b/lib/src/Cv.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Cv;
 
+use Civi\Cv\Util\IOStack;
+
 class Cv {
 
   protected static $instances = [];
@@ -63,6 +65,39 @@ class Cv {
     $event = new CvEvent($data);
     self::dispatcher()->dispatch($event, $eventName);
     return $event->getArguments();
+  }
+
+  /**
+   * Get a list of input/output objects for pending commands.
+   *
+   * @return \Civi\Cv\Util\IOStack
+   */
+  public static function ioStack(): IOStack {
+    if (!isset(static::$instances[__FUNCTION__])) {
+      static::$instances[__FUNCTION__] = new IOStack();
+    }
+    return static::$instances[__FUNCTION__];
+  }
+
+  /**
+   * @return \CvDeps\Symfony\Component\Console\Input\InputInterface|\Symfony\Component\Console\Input\InputInterface
+   */
+  public static function input() {
+    return static::ioStack()->current('input');
+  }
+
+  /**
+   * @return \CvDeps\Symfony\Component\Console\Output\OutputInterface|\Symfony\Component\Console\Output\OutputInterface
+   */
+  public static function output() {
+    return static::ioStack()->current('output');
+  }
+
+  /**
+   * @return \CvDeps\Symfony\Component\Console\Style\StyleInterface|\Symfony\Component\Console\Style\StyleInterface
+   */
+  public static function io() {
+    return static::ioStack()->current('io');
   }
 
   /**

--- a/lib/src/Cv.php
+++ b/lib/src/Cv.php
@@ -51,12 +51,15 @@ class Cv {
    * Filter a set of data through an event.
    *
    * @param string $eventName
+   *   Ex: "cv.app.run"
+   *   Note: This will dispatch listeners for both "cv.app.run" and "*.app.run".
    * @param array $data
    *   Open-ended set of data.
+   *
    * @return array
    *   Filtered $data
    */
-  public static function filter(string $eventName, array $data) {
+  public static function filter($eventName, array $data) {
     $event = new CvEvent($data);
     self::dispatcher()->dispatch($event, $eventName);
     return $event->getArguments();

--- a/lib/src/Cv.php
+++ b/lib/src/Cv.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Civi\Cv;
+
+class Cv {
+
+  protected static $instances = [];
+
+  // /**
+  //  * Get a PSR-16 cache service (`SimpleCache`).
+  //  *
+  //  * This is cache is file-based and user-scoped (e.g. `~/.cache/cv`).
+  //  * Don't expect it to be high-performance...
+  //  *
+  //  * NOTE: At time of writing, this is not used internally - but can be used by a plugin.
+  //  *
+  //  * @param string $namespace
+  //  * @return \Psr\SimpleCache\CacheInterface
+  //  */
+  // public static function cache($namespace = 'default') {
+  //   if (!isset(self::$instances["cache.$namespace"])) {
+  //     if (getenv('XDG_CACHE_HOME')) {
+  //       $dir = getenv('XDG_CACHE_HOME');
+  //     }
+  //     elseif (getenv('HOME')) {
+  //       $dir = getenv('HOME') . '/.cache';
+  //     }
+  //     else {
+  //       throw new \RuntimeException("Failed to determine cache location");
+  //     }
+  //     $fsCache = new FilesystemAdapter($namespace, 600, $dir . DIRECTORY_SEPARATOR . 'cv');
+  //     // In symfony/cache~3.x, the class name is weird.
+  //     self::$instances["cache.$namespace"] = new Psr6Cache($fsCache);
+  //   }
+  //   return self::$instances["cache.$namespace"];
+  // }
+
+  /**
+   * Get the system-wide event-dispatcher.
+   *
+   * @return \Civi\Cv\CvDispatcher
+   */
+  public static function dispatcher() {
+    if (!isset(self::$instances['dispatcher'])) {
+      self::$instances['dispatcher'] = new CvDispatcher();
+    }
+    return self::$instances['dispatcher'];
+  }
+
+  /**
+   * Filter a set of data through an event.
+   *
+   * @param string $eventName
+   * @param array $data
+   *   Open-ended set of data.
+   * @return array
+   *   Filtered $data
+   */
+  public static function filter(string $eventName, array $data) {
+    $event = new CvEvent($data);
+    self::dispatcher()->dispatch($event, $eventName);
+    return $event->getArguments();
+  }
+
+  /**
+   * Get the plugin manager.
+   *
+   * @return \Civi\Cv\CvPlugins
+   */
+  public static function plugins(): CvPlugins {
+    if (!isset(self::$instances['plugins'])) {
+      self::$instances['plugins'] = new CvPlugins();
+    }
+    return self::$instances['plugins'];
+  }
+
+}

--- a/lib/src/CvDispatcher.php
+++ b/lib/src/CvDispatcher.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Civi\Cv;
+
+class CvDispatcher {
+
+  protected $listeners = [];
+
+  public function dispatch($event, string $eventName = NULL) {
+    if (!isset($this->listeners[$eventName])) {
+      return $event;
+    }
+
+    ksort($this->listeners[$eventName], SORT_NUMERIC);
+    foreach ($this->listeners[$eventName] as $listeners) {
+      foreach ($listeners as $listener) {
+        $listener($event);
+      }
+    }
+
+    return $event;
+  }
+
+  public function addListener(string $eventName, $callback, int $priority = 0): void {
+    $id = $this->getCallbackId($callback);
+    $this->listeners[$eventName][$priority][$id] = $callback;
+  }
+
+  public function removeListener(string $eventName, $callback) {
+    $id = $this->getCallbackId($callback);
+    foreach ($this->listeners[$eventName] as &$listeners) {
+      unset($listeners[$id]);
+    }
+  }
+
+  /**
+   * @param $callback
+   * @return string
+   */
+  protected function getCallbackId($callback): string {
+    if (is_string($callback)) {
+      return $callback;
+    }
+    elseif (is_array($callback)) {
+      return implode('::', $callback);
+    }
+    else {
+      return spl_object_hash($callback);
+    }
+  }
+
+}

--- a/lib/src/CvEvent.php
+++ b/lib/src/CvEvent.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Civi\Cv;
+
+/**
+ * Standard event class used for most Cv events.
+ */
+class CvEvent implements \ArrayAccess, \IteratorAggregate {
+
+  private $propagationStopped = FALSE;
+
+  /**
+   * @var array
+   */
+  protected $arguments;
+
+  /**
+   * Encapsulate an event with $subject and $args.
+   *
+   * @param array $arguments Arguments to store in the event
+   */
+  public function __construct(array $arguments = []) {
+    $this->arguments = $arguments;
+  }
+
+  /**
+   * Get argument by key.
+   *
+   * @param string $key Key
+   * @return mixed Contents of array key
+   *
+   * @throws \InvalidArgumentException if key is not found
+   */
+  public function getArgument($key) {
+    if ($this->hasArgument($key)) {
+      return $this->arguments[$key];
+    }
+
+    throw new \InvalidArgumentException(sprintf('Argument "%s" not found.', $key));
+  }
+
+  /**
+   * Add argument to event.
+   *
+   * @param string $key Argument name
+   * @param mixed $value Value
+   *
+   * @return $this
+   */
+  public function setArgument($key, $value) {
+    $this->arguments[$key] = $value;
+
+    return $this;
+  }
+
+  /**
+   * Getter for all arguments.
+   *
+   * @return array
+   */
+  public function getArguments() {
+    return $this->arguments;
+  }
+
+  /**
+   * Set args property.
+   *
+   * @param array $args Arguments
+   *
+   * @return $this
+   */
+  public function setArguments(array $args = []) {
+    $this->arguments = $args;
+
+    return $this;
+  }
+
+  /**
+   * Has argument.
+   *
+   * @param string $key Key of arguments array
+   *
+   * @return bool
+   */
+  public function hasArgument($key) {
+    return \array_key_exists($key, $this->arguments);
+  }
+
+  /**
+   * IteratorAggregate for iterating over the object like an array.
+   *
+   * @return \ArrayIterator
+   */
+  public function getIterator(): \Traversable {
+    return new \ArrayIterator($this->arguments);
+  }
+
+  /**
+   * ArrayAccess for argument getter.
+   *
+   * @param string $key Array key
+   * @return mixed
+   * @throws \InvalidArgumentException if key does not exist in $this->args
+   */
+  #[\ReturnTypeWillChange]
+  public function &offsetGet($offset) {
+    return $this->arguments[$offset];
+  }
+
+  /**
+   * ArrayAccess for argument setter.
+   *
+   * @param string $offset Array key to set
+   * @param mixed $value Value
+   */
+  public function offsetSet($offset, $value): void {
+    $this->setArgument($offset, $value);
+  }
+
+  /**
+   * ArrayAccess for unset argument.
+   *
+   * @param string $offset Array key
+   */
+  public function offsetUnset($offset): void {
+    if ($this->hasArgument($offset)) {
+      unset($this->arguments[$offset]);
+    }
+  }
+
+  /**
+   * ArrayAccess has argument.
+   *
+   * @param string $offset Array key
+   * @return bool
+   */
+  public function offsetExists($offset): bool {
+    return $this->hasArgument($offset);
+  }
+
+  public function isPropagationStopped(): bool {
+    return $this->propagationStopped;
+  }
+
+  public function setPropagationStopped(bool $propagationStopped): void {
+    $this->propagationStopped = $propagationStopped;
+  }
+
+}

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -43,7 +43,7 @@ class CvPlugins {
             $this->plugins[$pluginName] = $file;
           }
           else {
-            fprintf(STDERR, "WARNING: Plugin %s has multiple definitions (%s, %s)\n", $file, $this->plugins[$pluginName]);
+            fprintf(STDERR, "WARNING: Plugin %s has multiple definitions (%s, %s)\n", $pluginName, $file, $this->plugins[$pluginName]);
           }
         }
       }

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -1,0 +1,90 @@
+<?php
+namespace Civi\Cv;
+
+class CvPlugins {
+
+  /**
+   * @var string[]
+   */
+  private $paths;
+
+  private $plugins;
+
+  /**
+   * Load any plugins.
+   *
+   * This will scan any folders listed in CV_PLUGIN_PATH. If CV_PLUGIN_PATH
+   * is undefined, then the default will be
+   * `$HOME/.cv/plugin:/etc/cv/plugin:/usr/local/share/cv/plugin:/usr/share/cv/plugin`.
+   */
+  public function init() {
+    if (getenv('CV_PLUGIN_PATH')) {
+      $this->paths = explode(PATH_SEPARATOR, getenv('CV_PLUGIN_PATH'));
+    }
+    else {
+      $this->paths = ['/etc/cv/plugin', '/usr/local/share/cv/plugin', '/usr/share/cv/plugin'];
+      if (getenv('HOME')) {
+        array_unshift($this->paths, getenv('HOME') . '/.cv/plugin');
+      }
+    }
+
+    // Always load internal plugins
+    $this->paths[] = dirname(__DIR__) . '/plugin';
+
+    $this->plugins = [];
+    foreach ($this->paths as $path) {
+      if (file_exists($path) && is_dir($path)) {
+        foreach ((array) glob("$path/*.php") as $file) {
+          $pluginName = preg_replace(';(\d+-)?(.*)(@\w+)?\.php;', '\\2', basename($file));
+          if ($pluginName === basename($file)) {
+            throw new \RuntimeException("Malformed plugin name: $file");
+          }
+          if (!isset($this->plugins[$pluginName])) {
+            $this->plugins[$pluginName] = $file;
+          }
+          else {
+            fprintf(STDERR, "WARNING: Plugin %s has multiple definitions (%s, %s)\n", $file, $this->plugins[$pluginName]);
+          }
+        }
+      }
+    }
+
+    ksort($this->plugins);
+    foreach ($this->plugins as $pluginName => $pluginFile) {
+      // FIXME: Refactor so that you can add more plugins post-boot `load("/some/glob*.php")`
+      $this->load([
+        'protocol' => 1,
+        'name' => $pluginName,
+        'file' => $pluginFile,
+      ]);
+    }
+  }
+
+  /**
+   * @param array $CV_PLUGIN
+   *   Description of the plugin being loaded.
+   *   Keys:
+   *   - version: Protocol version (ex: "1")
+   *   - name: Basenemae of the plugin (eg `hello.php`)
+   *   - file: Logic filename (eg `/etc/cv/plugin/hello.php`)
+   * @return void
+   */
+  protected function load(array $CV_PLUGIN) {
+    include $CV_PLUGIN['file'];
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getPaths(): array {
+    return $this->paths;
+  }
+
+  /**
+   * @return array
+   */
+  public function getPlugins(): array {
+    return $this->plugins;
+  }
+
+}

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -16,8 +16,12 @@ class CvPlugins {
    * This will scan any folders listed in CV_PLUGIN_PATH. If CV_PLUGIN_PATH
    * is undefined, then the default will be
    * `$HOME/.cv/plugin:/etc/cv/plugin:/usr/local/share/cv/plugin:/usr/share/cv/plugin`.
+   *
+   * @param array $pluginEnv
+   *   Description the current application environment.
+   *   Ex: ['appName' => 'cv', 'appVersion' => '0.3.50']
    */
-  public function init() {
+  public function init(array $pluginEnv) {
     if (getenv('CV_PLUGIN_PATH')) {
       $this->paths = explode(PATH_SEPARATOR, getenv('CV_PLUGIN_PATH'));
     }
@@ -52,7 +56,7 @@ class CvPlugins {
     ksort($this->plugins);
     foreach ($this->plugins as $pluginName => $pluginFile) {
       // FIXME: Refactor so that you can add more plugins post-boot `load("/some/glob*.php")`
-      $this->load([
+      $this->load($pluginEnv + [
         'protocol' => 1,
         'name' => $pluginName,
         'file' => $pluginFile,

--- a/lib/src/Util/AliasFilter.php
+++ b/lib/src/Util/AliasFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+class AliasFilter {
+
+  /**
+   * Find an option like `cv @mysite ext:list`. Convert the `@mysite`
+   * notation to `--site-alias=mysite`.
+   *
+   * @param array $input
+   * @return array
+   */
+  public static function filter(array $input): array {
+    $todo = $input;
+    $result = [];
+    $result[] = array_shift($todo);
+    while (count($todo) > 0) {
+      $value = array_shift($todo);
+      if ($value[0] === '@') {
+        $result[] = '--site-alias=' . substr($value, 1);
+        $result = array_merge($result, $todo);
+        $todo = [];
+      }
+      else {
+        $result[] = $value;
+      }
+    }
+    return $result;
+  }
+
+}

--- a/lib/src/Util/AliasFilter.php
+++ b/lib/src/Util/AliasFilter.php
@@ -2,31 +2,35 @@
 
 namespace Civi\Cv\Util;
 
+use Symfony\Component\Console\Input\ArgvInput;
+
 class AliasFilter {
 
   /**
    * Find an option like `cv @mysite ext:list`. Convert the `@mysite`
    * notation to `--site-alias=mysite`.
    *
-   * @param array $input
+   * @param array $argv
    * @return array
    */
-  public static function filter(array $input): array {
-    $todo = $input;
-    $result = [];
-    $result[] = array_shift($todo);
-    while (count($todo) > 0) {
-      $value = array_shift($todo);
-      if ($value[0] === '@') {
-        $result[] = '--site-alias=' . substr($value, 1);
-        $result = array_merge($result, $todo);
-        $todo = [];
-      }
-      else {
-        $result[] = $value;
-      }
+  public static function filter(array $argv): array {
+    if (!preg_grep('/^@/', $argv)) {
+      return $argv;
     }
-    return $result;
+
+    $input = new ArgvInput($argv);
+    $firstArg = $input->getFirstArgument();
+    if ($firstArg[0] === '@') {
+      return static::replace($argv, $firstArg, '--site-alias=' . substr($firstArg, 1));
+    }
+
+    return $argv;
+  }
+
+  private static function replace(array $original, $old, $new) {
+    $pos = array_search($old, $original, TRUE);
+    $original[$pos] = $new;
+    return $original;
   }
 
 }

--- a/lib/src/Util/CvArgvInput.php
+++ b/lib/src/Util/CvArgvInput.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
+
+/**
+ * @internal
+ */
+class CvArgvInput extends ArgvInput {
+
+  protected $originalArgv;
+
+  public function __construct(array $argv, InputDefinition $definition = NULL) {
+    $this->originalArgv = $argv;
+    parent::__construct($argv, $definition);
+  }
+
+  public function getOriginalArgv(): array {
+    return $this->originalArgv;
+  }
+
+}

--- a/lib/src/Util/CvArgvInput.php
+++ b/lib/src/Util/CvArgvInput.php
@@ -12,7 +12,8 @@ class CvArgvInput extends ArgvInput {
 
   protected $originalArgv;
 
-  public function __construct(array $argv, InputDefinition $definition = NULL) {
+  public function __construct(array $argv = NULL, InputDefinition $definition = NULL) {
+    $argv = $argv ?? $_SERVER['argv'] ?? [];
     $this->originalArgv = $argv;
     parent::__construct($argv, $definition);
   }

--- a/lib/src/Util/IOStack.php
+++ b/lib/src/Util/IOStack.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Track the active input/output objects.
+ *
+ * If you process sub-requests (with different input/output data), then you will
+ * likely need to push+pop new copies of the input/output objects.
+ */
+class IOStack {
+
+  private static $id = 0;
+
+  protected $stack = [];
+
+  /**
+   * Add a new pair of input/output objects to the top of the stack.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return scalar
+   *   Internal identifier for the stack-frame. ID formatting is not guaranteed.
+   */
+  public function push(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output) {
+    ++static::$id;
+    array_unshift($this->stack, [
+      'id' => static::$id,
+      'input' => $input,
+      'output' => $output,
+      'io' => new SymfonyStyle($input, $output),
+    ]);
+    return static::$id;
+  }
+
+  public function pop(): array {
+    return array_shift($this->stack);
+  }
+
+  /**
+   * Get a current property of the current (top) stack-frame.
+   *
+   * @param string $property
+   *   One of: 'input', 'output', 'io', 'id'
+   * @return mixed
+   */
+  public function current(string $property) {
+    return $this->stack[0][$property];
+  }
+
+  /**
+   * Lookup a property from a particular stack-frame.
+   *
+   * @param scalar $id
+   *   Internal identifier for the stack-frame.
+   * @param string $property
+   *   One of: 'input', 'output', 'io', 'id'
+   * @return mixed|null
+   */
+  public function get($id, string $property) {
+    foreach ($this->stack as $item) {
+      if ($item['id'] === $id) {
+        return $item[$property];
+      }
+    }
+    return NULL;
+  }
+
+  public function reset() {
+    $this->stack = [];
+  }
+
+}

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -3,6 +3,9 @@
 return [
   'prefix' => 'Cvphar',
   'exclude-namespaces' => [
+    // Provided by cv
+    'CvDeps',
+
     // Provided by civicrm
     'Civi',
     'Guzzle',

--- a/src/Application.php
+++ b/src/Application.php
@@ -42,7 +42,10 @@ class Application extends \Symfony\Component\Console\Application {
    * Primary entry point for execution of the standalone command.
    */
   public static function main($binDir, array $argv) {
-    $application = new Application('cv', static::version() ?? 'UNKNOWN');
+    Cv::plugins()->init();
+    $application = Cv::filter('cv.app.boot', [
+      'app' => new Application('cv', static::version() ?? 'UNKNOWN'),
+    ])['app'];
 
     $input = new ArgvInput($argv);
     $output = new ConsoleOutput();
@@ -91,6 +94,7 @@ class Application extends \Symfony\Component\Console\Application {
         throw new \RuntimeException("Failed to use directory specified, $workingDir as working directory.");
       }
     }
+    Cv::filter('cv.app.run', []);
     return parent::doRun($input, $output);
   }
 
@@ -141,6 +145,7 @@ class Application extends \Symfony\Component\Console\Application {
       $commands[] = new \Civi\Cv\Command\CoreUninstallCommand();
       $commands[] = new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand();
     }
+    $commands = Cv::filter('cv.app.commands', ['commands' => $commands])['commands'];
     return $commands;
   }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,8 +2,10 @@
 namespace Civi\Cv;
 
 use LesserEvil\ShellVerbosityIsEvil;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -39,12 +41,15 @@ class Application extends \Symfony\Component\Console\Application {
   /**
    * Primary entry point for execution of the standalone command.
    */
-  public static function main($binDir) {
+  public static function main($binDir, array $argv) {
     $application = new Application('cv', static::version() ?? 'UNKNOWN');
+
+    $input = new ArgvInput($argv);
+    $output = new ConsoleOutput();
 
     $application->setAutoExit(FALSE);
     ErrorHandler::pushHandler();
-    $result = $application->run();
+    $result = $application->run($input, $output);
     ErrorHandler::popHandler();
     exit($result);
   }

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,10 +3,19 @@ namespace Civi\Cv;
 
 class Application extends BaseApplication {
 
+  const DEV_VERSION = '0.3.x';
+
   protected $deprecatedAliases = [
     'debug:container' => 'service',
     'debug:event-dispatcher' => 'event',
   ];
+
+  public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN') {
+    if ($version === 'UNKNOWN') {
+      $version = static::version() ?? 'UNKNOWN';
+    }
+    parent::__construct($name, $version);
+  }
 
   /**
    * Determine the version number.
@@ -19,7 +28,7 @@ class Application extends BaseApplication {
     $marker = '@' . 'package' . '_' . 'version' . '@';
     $v = '@package_version@';
     if ($v !== $marker) {
-      return $v;
+      return ltrim($v, 'v');
     }
     if (is_callable('\Composer\InstalledVersions::getVersion')) {
       $v = \Composer\InstalledVersions::getVersion('civicrm/cv');
@@ -27,7 +36,7 @@ class Application extends BaseApplication {
         return $v;
       }
     }
-    return NULL;
+    return static::DEV_VERSION;
   }
 
   /**

--- a/src/ClassAliases.php
+++ b/src/ClassAliases.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Civi\Cv;
+
+class ClassAliases {
+
+  public static function register() {
+    // Plugins need to access some classes from the cv dependency tree.
+    // Concrete class names may be prefixed depending on build/environment.
+    // These aliases work with or without prefixing.
+
+    class_alias('Symfony\Component\Console\Command\Command', 'CvDeps\Symfony\Component\Console\Command\Command');
+    class_alias('Symfony\Component\Console\Command\LockableTrait', 'CvDeps\Symfony\Component\Console\Command\LockableTrait');
+
+    class_alias('Symfony\Component\Console\Input\InputInterface', 'CvDeps\Symfony\Component\Console\Input\InputInterface');
+    class_alias('Symfony\Component\Console\Input\InputArgument', 'CvDeps\Symfony\Component\Console\Input\InputArgument');
+    class_alias('Symfony\Component\Console\Input\InputDefinition', 'CvDeps\Symfony\Component\Console\Input\InputDefinition');
+    class_alias('Symfony\Component\Console\Input\InputOption', 'CvDeps\Symfony\Component\Console\Input\InputOption');
+
+    class_alias('Symfony\Component\Console\Output\OutputInterface', 'CvDeps\Symfony\Component\Console\Output\OutputInterface');
+
+    class_alias('Symfony\Component\Console\Style\OutputStyle', 'CvDeps\Symfony\Component\Console\Style\OutputStyle');
+    class_alias('Symfony\Component\Console\Style\SymfonyStyle', 'CvDeps\Symfony\Component\Console\Style\SymfonyStyle');
+    class_alias('Symfony\Component\Console\Style\StyleInterface', 'CvDeps\Symfony\Component\Console\Style\StyleInterface');
+
+    // NOTE: Using a static list of class-names serves two purposes:
+    // 1. It helps IDEs/static-analyzers recognize the aliases.
+    // 2. It allows php-scoper to rewrite the concrete names to their final/contingent form.
+  }
+
+}

--- a/tests/CvDispatcherTest.php
+++ b/tests/CvDispatcherTest.php
@@ -21,25 +21,25 @@ class CvDispatcherTest extends \PHPUnit\Framework\TestCase {
 
   public function testIgnoreUnrelated() {
     $d = new CvDispatcher();
-    $d->addListener('foo', function ($event) {
-      static::addLog('foo');
+    $d->addListener('myapp.foo', function ($event) {
+      static::addLog('myapp.foo');
     });
-    $d->addListener('bar', function ($event) {
+    $d->addListener('myapp.bar', function ($event) {
       static::addLog('unrelated');
     });
-    $d->dispatch(new CvEvent(['data' => 'yoyo']), 'foo')->getArguments();
-    $this->assertEquals(['foo'], static::$log);
+    $d->dispatch(new CvEvent(['data' => 'yoyo']), 'myapp.foo')->getArguments();
+    $this->assertEquals(['myapp.foo'], static::$log);
   }
 
   public function testCallbackTypes() {
     $d = new CvDispatcher();
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog("foo one data=" . $event['data']);
     });
-    $d->addListener('foo', __NAMESPACE__ . '\\cvdispatcher_global_func');
-    $d->addListener('foo', [__CLASS__, 'addFooThree']);
+    $d->addListener('myapp.foo', __NAMESPACE__ . '\\cvdispatcher_global_func');
+    $d->addListener('myapp.foo', [__CLASS__, 'addFooThree']);
 
-    $r = $d->dispatch(new CvEvent(['data' => 'yoyo']), 'foo')->getArguments();
+    $r = $d->dispatch(new CvEvent(['data' => 'yoyo']), 'myapp.foo')->getArguments();
     $this->assertEquals('yoyo', $r['data']);
     $this->assertEquals([
       'foo one data=yoyo',
@@ -50,43 +50,52 @@ class CvDispatcherTest extends \PHPUnit\Framework\TestCase {
 
   public function testAlter() {
     $d = new CvDispatcher();
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       $event['data'] .= ' first';
     });
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       $event['data'] .= ' second';
     });
-    $r = $d->dispatch(new CvEvent(['data' => 'seed']), 'foo')->getArguments();
+    $r = $d->dispatch(new CvEvent(['data' => 'seed']), 'myapp.foo')->getArguments();
     $this->assertEquals('seed first second', $r['data']);
   }
 
   public function testPriority() {
     $d = new CvDispatcher();
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.3.1');
     }, 3);
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.-200.1');
     }, -200);
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.1.1');
     }, 1);
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.2.1');
     }, 2);
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.1.2');
     }, 1);
-    $d->addListener('foo', function ($event) {
+    $d->addListener('myapp.foo', function ($event) {
       static::addLog('foo.1.3');
     }, 1);
-    $d->dispatch(new CvEvent([]), 'foo');
+    $d->addListener('*.foo', function ($event) {
+      static::addLog('wildFoo.1.1');
+    }, 1);
+    $d->addListener('*.foo', function ($event) {
+      static::addLog('wildFoo.2.1');
+    }, 2);
+
+    $d->dispatch(new CvEvent([]), 'myapp.foo');
     $this->assertEquals([
       'foo.-200.1',
       'foo.1.1',
       'foo.1.2',
       'foo.1.3',
+      'wildFoo.1.1',
       'foo.2.1',
+      'wildFoo.2.1',
       'foo.3.1',
     ], static::$log);
   }

--- a/tests/CvDispatcherTest.php
+++ b/tests/CvDispatcherTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Civi\Cv;
+
+function cvdispatcher_global_func() {
+  CvDispatcherTest::addLog('called ' . __FUNCTION__);
+}
+
+/**
+ * @group std
+ * @group util
+ */
+class CvDispatcherTest extends \PHPUnit\Framework\TestCase {
+
+  protected static $log;
+
+  protected function setUp(): void {
+    parent::setUp();
+    static::$log = [];
+  }
+
+  public function testIgnoreUnrelated() {
+    $d = new CvDispatcher();
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo');
+    });
+    $d->addListener('bar', function ($event) {
+      static::addLog('unrelated');
+    });
+    $d->dispatch(new CvEvent(['data' => 'yoyo']), 'foo')->getArguments();
+    $this->assertEquals(['foo'], static::$log);
+  }
+
+  public function testCallbackTypes() {
+    $d = new CvDispatcher();
+    $d->addListener('foo', function ($event) {
+      static::addLog("foo one data=" . $event['data']);
+    });
+    $d->addListener('foo', __NAMESPACE__ . '\\cvdispatcher_global_func');
+    $d->addListener('foo', [__CLASS__, 'addFooThree']);
+
+    $r = $d->dispatch(new CvEvent(['data' => 'yoyo']), 'foo')->getArguments();
+    $this->assertEquals('yoyo', $r['data']);
+    $this->assertEquals([
+      'foo one data=yoyo',
+      'called Civi\\Cv\\cvdispatcher_global_func',
+      'foo three data=yoyo',
+    ], static::$log);
+  }
+
+  public function testAlter() {
+    $d = new CvDispatcher();
+    $d->addListener('foo', function ($event) {
+      $event['data'] .= ' first';
+    });
+    $d->addListener('foo', function ($event) {
+      $event['data'] .= ' second';
+    });
+    $r = $d->dispatch(new CvEvent(['data' => 'seed']), 'foo')->getArguments();
+    $this->assertEquals('seed first second', $r['data']);
+  }
+
+  public function testPriority() {
+    $d = new CvDispatcher();
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.3.1');
+    }, 3);
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.-200.1');
+    }, -200);
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.1.1');
+    }, 1);
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.2.1');
+    }, 2);
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.1.2');
+    }, 1);
+    $d->addListener('foo', function ($event) {
+      static::addLog('foo.1.3');
+    }, 1);
+    $d->dispatch(new CvEvent([]), 'foo');
+    $this->assertEquals([
+      'foo.-200.1',
+      'foo.1.1',
+      'foo.1.2',
+      'foo.1.3',
+      'foo.2.1',
+      'foo.3.1',
+    ], static::$log);
+  }
+
+  public static function addLog(string $message) {
+    static::$log[] = $message;
+  }
+
+  public static function addFooThree($event) {
+    static::addLog("foo three data=" . $event['data']);
+  }
+
+}

--- a/tests/Plugin/AliasPluginTest.php
+++ b/tests/Plugin/AliasPluginTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Civi\Cv\Plugin;
+
+/**
+ * @group std
+ */
+class AliasPluginTest extends \Civi\Cv\CivilTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  protected function cv($command) {
+    $process = parent::cv($command);
+    $process->setEnv(['CV_PLUGIN_PATH' => preg_replace(';\.php$;', '', __FILE__)]);
+    return $process;
+  }
+
+  public function testDummyAlias() {
+    $output = $this->cvOk('@dummy ext:list -Li');
+    $this->assertMatchesRegularExpression(";^DUMMY: '.*/(cv|cv.phar)' --site-alias=dummy 'ext:list' -Li;", $output);
+  }
+
+  public function testUnknownAlias() {
+    $output = $this->cvFail('@eldorado ext:list -Li');
+    $this->assertMatchesRegularExpression('/Unknown site alias: eldorado/', $output);
+  }
+
+}

--- a/tests/Plugin/AliasPluginTest/dummy-alias.php
+++ b/tests/Plugin/AliasPluginTest/dummy-alias.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This plugin adds support for a site-alias named `@dummy`. If given, then all commands
+ * will are routed through a dummy transport -- which simply prints the details about the
+ * attempted command.
+ */
+
+// Plugin lives in a unique namespace
+namespace Civi\Cv\DummyAliasPlugin;
+
+use Civi\Cv\Cv;
+use Civi\Cv\CvEvent;
+use CvDeps\Symfony\Component\Console\Output\OutputInterface;
+
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
+  die("Expect CV_PLUGIN API v1");
+}
+
+Cv::dispatcher()->addListener('*.app.site-alias', function(CvEvent $event) {
+  if ($event['alias'] === 'dummy') {
+
+    foreach (['app', 'output', 'input'] as $key) {
+      if (empty($event[$key])) {
+        throw new \RuntimeException("Event *.app.site-alias is missing value for \"$key\"");
+      }
+    }
+
+    /**
+     * @var \Civi\Cv\Util\CvArgvInput $input
+     */
+    $input = $event['input'];
+
+    /**
+     * @var \CvDeps\Symfony\Component\Console\Output\OutputInterface $output
+     */
+    $output = $event['output'];
+
+    $args = array_map(__NAMESPACE__ . '\\escapeString', $input->getOriginalArgv());
+    $fullCommand = implode(' ', $args);
+
+    $event['transport'] = function() use ($input, $output, $fullCommand) {
+      $output->writeln("DUMMY: $fullCommand", OutputInterface::OUTPUT_RAW);
+    };
+  }
+});
+
+function escapeString(string $expr): string {
+  return preg_match('{^[\w=-]+$}', $expr) ? $expr : escapeshellarg($expr);
+}

--- a/tests/Plugin/HelloPluginTest.php
+++ b/tests/Plugin/HelloPluginTest.php
@@ -18,7 +18,12 @@ class HelloPluginTest extends \Civi\Cv\CivilTestCase {
 
   public function testRun() {
     $output = $this->cvOk('hello');
-    $this->assertMatchesRegularExpression('/^Hello there/', $output);
+    $this->assertMatchesRegularExpression('/Hello world via parameter.*Hello world via StyleInterface/s', $output);
+  }
+
+  public function testRunWithName() {
+    $output = $this->cvOk('hello Bob');
+    $this->assertMatchesRegularExpression('/Hello Bob via parameter.*Hello Bob via StyleInterface/s', $output);
   }
 
 }

--- a/tests/Plugin/HelloPluginTest.php
+++ b/tests/Plugin/HelloPluginTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Civi\Cv\Plugin;
+
+/**
+ * @group std
+ */
+class HelloPluginTest extends \Civi\Cv\CivilTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  protected function cv($command) {
+    $process = parent::cv($command);
+    $process->setEnv(['CV_PLUGIN_PATH' => preg_replace(';\.php$;', '', __FILE__)]);
+    return $process;
+  }
+
+  public function testRun() {
+    $output = $this->cvOk('hello');
+    $this->assertMatchesRegularExpression('/^Hello there/', $output);
+  }
+
+}

--- a/tests/Plugin/HelloPluginTest/hello.php
+++ b/tests/Plugin/HelloPluginTest/hello.php
@@ -9,6 +9,21 @@ if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
   die("Expect CV_PLUGIN API v1");
 }
 
+if (!preg_match(';^[\w_-]+$;', $CV_PLUGIN['appName'])) {
+  throw new \RuntimeException("Invalid CV_PLUGIN[appName]" . json_encode($CV_PLUGIN['appName']));
+}
+
+if (!preg_match(';^([0-9x\.]+(-[\w-]+)?|UNKNOWN)$;', $CV_PLUGIN['appVersion'])) {
+  throw new \RuntimeException("Invalid CV_PLUGIN[appVersion]: " . json_encode($CV_PLUGIN['appVersion']));
+}
+
+if ($CV_PLUGIN['name'] !== 'hello') {
+  throw new \RuntimeException("Invalid CV_PLUGIN[name]");
+}
+if (realpath($CV_PLUGIN['file']) !== realpath(__FILE__)) {
+  throw new \RuntimeException("Invalid CV_PLUGIN[file]");
+}
+
 Cv::dispatcher()->addListener('*.app.boot', function ($e) {
   Cv::io()->writeln("Hello during initial bootstrap!");
 });

--- a/tests/Plugin/HelloPluginTest/hello.php
+++ b/tests/Plugin/HelloPluginTest/hello.php
@@ -9,15 +9,24 @@ if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
   die("Expect CV_PLUGIN API v1");
 }
 
+Cv::dispatcher()->addListener('*.app.boot', function ($e) {
+  Cv::io()->writeln("Hello during initial bootstrap!");
+});
+
 Cv::dispatcher()->addListener('cv.app.commands', function ($e) {
   $e['commands'][] = new class extends Command {
 
     protected function configure() {
-      $this->setName('hello')->setDescription('Say a greeting');
+      $this->setName('hello')->setDescription('Say a greeting')->addArgument('name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) {
-      $output->writeln('Hello there!');
+      if ($input->getArgument('name') !== Cv::input()->getArgument('name')) {
+        throw new \RuntimeException("Argument \"name\" is inconsistent!");
+      }
+      $name = $input->getArgument('name') ?: 'world';
+      $output->writeln("Hello $name via parameter!");
+      Cv::io()->writeln("Hello $name via StyleInterface!");
     }
 
   };

--- a/tests/Plugin/HelloPluginTest/hello.php
+++ b/tests/Plugin/HelloPluginTest/hello.php
@@ -1,15 +1,16 @@
 <?php
 
 use Civi\Cv\Cv;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use CvDeps\Symfony\Component\Console\Input\InputInterface;
+use CvDeps\Symfony\Component\Console\Output\OutputInterface;
+use CvDeps\Symfony\Component\Console\Command\Command;
 
 if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
   die("Expect CV_PLUGIN API v1");
 }
 
 Cv::dispatcher()->addListener('cv.app.commands', function ($e) {
-  $e['commands'][] = new class extends \Symfony\Component\Console\Command\Command {
+  $e['commands'][] = new class extends Command {
 
     protected function configure() {
       $this->setName('hello')->setDescription('Say a greeting');

--- a/tests/Plugin/HelloPluginTest/hello.php
+++ b/tests/Plugin/HelloPluginTest/hello.php
@@ -35,13 +35,14 @@ Cv::dispatcher()->addListener('cv.app.commands', function ($e) {
       $this->setName('hello')->setDescription('Say a greeting')->addArgument('name');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output) {
+    protected function execute(InputInterface $input, OutputInterface $output): int {
       if ($input->getArgument('name') !== Cv::input()->getArgument('name')) {
         throw new \RuntimeException("Argument \"name\" is inconsistent!");
       }
       $name = $input->getArgument('name') ?: 'world';
       $output->writeln("Hello $name via parameter!");
       Cv::io()->writeln("Hello $name via StyleInterface!");
+      return 0;
     }
 
   };

--- a/tests/Plugin/HelloPluginTest/hello.php
+++ b/tests/Plugin/HelloPluginTest/hello.php
@@ -1,0 +1,23 @@
+<?php
+
+use Civi\Cv\Cv;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
+  die("Expect CV_PLUGIN API v1");
+}
+
+Cv::dispatcher()->addListener('cv.app.commands', function ($e) {
+  $e['commands'][] = new class extends \Symfony\Component\Console\Command\Command {
+
+    protected function configure() {
+      $this->setName('hello')->setDescription('Say a greeting');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) {
+      $output->writeln('Hello there!');
+    }
+
+  };
+});

--- a/tests/Util/AliasFilterTest.php
+++ b/tests/Util/AliasFilterTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Civi\Cv\Util;
+
+/**
+ * @group std
+ * @group util
+ */
+class AliasFilterTest extends \PHPUnit\Framework\TestCase {
+
+  public function getExamples() {
+    $exs = [];
+    $exs[] = [
+      ['/path/to/cv'],
+      ['/path/to/cv'],
+    ];
+    $exs[] = [
+      ['/path/to/cv', '@mysite'],
+      ['/path/to/cv', '--site-alias=mysite'],
+    ];
+    $exs[] = [
+      ['/path/to/cv', '@mysite', 'ext:dl'],
+      ['/path/to/cv', '--site-alias=mysite', 'ext:dl'],
+    ];
+    $exs[] = [
+      ['/path/to/cv', 'ext:dl', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+      ['/path/to/cv', 'ext:dl', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+    ];
+    $exs[] = [
+      ['/path/to/cv', '@mysite', 'ext:dl', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+      ['/path/to/cv', '--site-alias=mysite', 'ext:dl', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+    ];
+    // We don't have a way to distinguish later argument-data from from aliases.
+    // For now, simply require aliases go at the start.
+    // $exs[] = [
+    //   ['/path/to/cv', 'ext:dl', '@mysite', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+    //   ['/path/to/cv', 'ext:dl', '--site-alias=mysite', '-b', '@/path/to/file.xml', '--to=@/path/to/stuff'],
+    // ];
+    return $exs;
+    // return [$exs[6]];
+  }
+
+  /**
+   * @param $inputArray
+   * @param $expectOutput
+   * @return void
+   * @dataProvider getExamples
+   */
+  public function testAliasFilter($inputArray, $expectOutput): void {
+    // In theory, providing the full command definition might allow us to find aliases in other spots?
+    // Hasn't actually worked out that way yet. But if we do, this example will  be handy.
+    // $app = new Application();
+    // $command = new Command('ext:dl');
+    // $command->addOption('bare', 'b', InputOption::VALUE_NONE, 'Perform a basic download in a non-bootstrapped environment. Implies --level=none, --no-install, and no --refresh. You must specify the download URL.');
+    // $command->addOption('to', NULL, InputOption::VALUE_OPTIONAL, 'Download to a specific directory (absolute path).');
+    // $command->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Optionally append a URL.');
+    // $app->add($command);
+
+    $actualOutput = AliasFilter::filter($inputArray);
+    $this->assertEquals($expectOutput, $actualOutput);
+  }
+
+}


### PR DESCRIPTION
Overview
----------

Adds support for loading plugins (`*.php` files) to modify the behavior of `cv`. In particular, some useful things you might do are (a) defining new subcommands or (b) defining alias services (`cv @mysite ext:list`).

The design is based on heavily on [loco CLI plugins](https://github.com/totten/loco/blob/master/doc/plugins.md).

Plugin Loading
-------

Plugins are loaded from the `CV_PLUGIN_PATH`. If the path is not set, then it loads PHP files from these folders:

* `$HOME/.cv/plugin`
* `/etc/cv/plugin`
* `/usr/local/share/cv/plugin`
* `/usr/share/cv/plugin`

Each plugin is a `*.php` file.

Example: "Hello" Command
--------------------------

For example, to implement `cv hello`, you could create:

```php
// FILE: /etc/cv/plugin/hello-command.php
use Civi\Cv\Cv;
use CvDeps\Symfony\Component\Console\Input\InputInterface;
use CvDeps\Symfony\Component\Console\Output\OutputInterface;
use CvDeps\Symfony\Component\Console\Command\Command;

Cv::dispatcher()->addListener('cv.app.commands', function($e) {
  $e['commands'][] = new class extends Command {
    protected function configure() {
      $this->setName('hello')
        ->setDescription('Say a greeting');
    }
    protected function execute(InputInterface $input, OutputInterface $output): int {
      $output->writeln('Hello there!');
      return 0;
    }
  };
});
```

The file `doc/plugins.md` gives more details.

Example: Site Aliases
-----------------

Additionally, I've drafted a bigger example with support for site-aliases, eg

```bash
cv @mysite ext:list
```

The draft is at https://gist.github.com/totten/8241b80440221555c0051d4f3447fa40

Why do this as a plugin? Well, there are several little questions to sort out. Like:

* Do you register aliases globally (in `$HOME/.cv` or `/etc`)? Or do you have contextual aliases (like `@prod`  and `@staging` for a specific site)?
* Do you use JSON or YAML?
* Does each file define a single alias... or multiple?
* Do you give a small number of powerful options... or a large number of narrow options? Compare:
    ```yaml
    ## One generic option, "remote_command", can work with many kind of remotes...
    ## such as ssh, mosh, docker, or virsh.
    remote_command: "ssh myuser@example.com -P4567"

    ## If you don't know how to write those commands, or if the commands get somehow fiddly,
    ## then smaller flags might be easier for the user. But as a dev, you have to fiddle more to support each.
    ssh:
      hostname: example.com
      user: myuser
      port: 4567
* Do you read metadata from other sources -- like `drush` config-files, `wp-cli` config-files, or `civibuild` config-files? 

Whatever the eventual answers, we'd probably want to include something like this in `cv` by default. But TBH, I'm kinda ambivalent about the details of those questions. Seems appealing to incubate as a plugin...


Documentation
----------------

The PR also adds a file `doc/plugins.md`.