### PR TITLE
Look for civicrm.standalone.php to bootstrap standalone

### DIFF
--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -374,8 +374,16 @@ class Bootstrap {
         break;
 
       case 'standalone':
-        $settings = $cmsRoot . '/data/civicrm.settings.php';
-        // $result =  $cmsRoot . 'components/com_civicrm/civicrm.settings.php';
+        $settings = $this->findFirstFile(
+          [
+            $cmsRoot,
+            implode(DIRECTORY_SEPARATOR, [$cmsRoot, 'data'])
+          ],
+          [
+           'civicrm.standalone.php',
+           'civicrm.settings.php',
+          ]
+        );
         break;
     }
     return array($cmsType, $cmsRoot, $settings);
@@ -447,6 +455,7 @@ class Bootstrap {
         'core/modules/layout/layout.module',
       ),
       'standalone' => array(
+        'civicrm.standalone.php',
         'civicrm.config.php.standalone',
       ),
     );

--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -404,6 +404,7 @@ class CmsBootstrap {
     /* @todo clarify: assumes $cmsPath is to the project root, not the webroot */
     $candidates = [
       $cmsPath . '/vendor/autoload.php',
+      $cmsPath . '/core/vendor/autoload.php',
       $cmsPath . '/web/core/vendor/autoload.php',
       dirname($cmsPath) . '/vendor/autoload.php',
     ];
@@ -471,6 +472,7 @@ class CmsBootstrap {
         'core/modules/layout/layout.module',
       ),
       'Standalone' => array(
+        'civicrm.standalone.php',
         'civicrm.config.php.standalone',
         // or?
         // 'data/civicrm.settings.php',

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -67,6 +67,7 @@ trait SetupCommandTrait {
       implode(DIRECTORY_SEPARATOR, [dirname($b->getBootedCmsPath()), 'vendor', 'civicrm', 'civicrm-core']),
     ];
     if ($b->getBootedCmsType() === 'Standalone') {
+      $possibleSrcPaths[] = implode(DIRECTORY_SEPARATOR, [$b->getBootedCmsPath(), 'core']);
       $possibleSrcPaths[] = implode(DIRECTORY_SEPARATOR, [$b->getBootedCmsPath(), 'web', 'core']);
       $possibleSrcPaths[] = dirname($b->getBootedCmsPath());
     }


### PR DESCRIPTION
Attempt to get cv playing nice with an updated directory structure for standalone in this PR: https://github.com/civicrm/civicrm-core/pull/29960

I think I've essentially merged the flag file and the settings file... but I noticed the old flag file had some "config" type script in it, and wondering if they were split out in the first place?

To my mind it seems to make sense that this file says "Hi, I'm a standalone installation, run me to bootstap the install (classloader/settings etc)". But I might be missing something.


