### PR TITLE
With pear/log 1.14+ the filename property no longer exists

### DIFF
--- a/lib/src/SiteConfigReader.php
+++ b/lib/src/SiteConfigReader.php
@@ -79,6 +79,7 @@ class SiteConfigReader {
     }
 
     $paths = is_callable(array('Civi', 'paths')) ? \Civi::paths() : NULL;
+    $log = \CRM_Core_Error::createDebugLogger();
     $data = array(
       'CMS_DB_DSN' => CIVICRM_UF_DSN,
       'CMS_VERSION' => \CRM_Core_Config::singleton()->userSystem->getVersion(),
@@ -87,7 +88,7 @@ class SiteConfigReader {
       'CIVI_VERSION' => \CRM_Utils_System::version(),
       'CIVI_SETTINGS' => CIVICRM_SETTINGS_PATH,
       'CIVI_TEMPLATEC' => \CRM_Core_Config::singleton()->templateCompileDir,
-      'CIVI_LOG' => \CRM_Core_Error::createDebugLogger()->_filename,
+      'CIVI_LOG' => is_callable(['CRM_Core_Error', 'generateLogFileName']) ? \CRM_Core_Error::generateLogFileName('') : $log->_filename,
       'CIVI_UF' => \CRM_Core_Config::singleton()->userFramework,
       'IS_INSTALLED' => '1',
       'SITE_TYPE' => 'cv-auto',


### PR DESCRIPTION
There is no way to get the filename anymore from the Log object. We instead made CRM_Core_Error::generateLogFileName() publicly callable.

I tested and this works with both earlier and new versions of pear/log.

I'm not sure where tests run but I expect ShowCommandTest will be failing after yesterday with an undefined property warning.