### PR TITLE
Combine "upgrade:db" and "ext:upgrade-db". Support "updb" alias.

### DIFF
--- a/src/Command/ExtensionUpgradeDbCommand.php
+++ b/src/Command/ExtensionUpgradeDbCommand.php
@@ -31,6 +31,7 @@ Note:
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $output->writeln("<error>WARNING: \"ext:upgrade-db\" is deprecated. Use the main \"updb\" command instead.</error>");
     $this->boot($input, $output);
 
     $output->writeln("<info>Applying database upgrades from extensions</info>");

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -19,12 +19,14 @@ class UpgradeDbCommand extends BaseCommand {
   protected function configure() {
     $this
       ->setName('upgrade:db')
+      ->setAliases(['updb'])
       ->setDescription('Run the database upgrade')
       ->configureOutputOptions(['fallback' => 'pretty'])
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Preview the list of upgrade tasks')
       ->addOption('retry', NULL, InputOption::VALUE_NONE, 'Resume a failed upgrade, retrying the last step')
       ->addOption('skip', NULL, InputOption::VALUE_NONE, 'Resume a failed upgrade, skipping the last step')
       ->addOption('step', NULL, InputOption::VALUE_NONE, 'Run the upgrade queue in steps, pausing before each step')
+      ->addOption('mode', NULL, InputOption::VALUE_REQUIRED, 'Mode to run upgrade (auto|full|ext)', 'auto')
       ->setHelp('Run the database upgrade
 
 Examples:
@@ -33,6 +35,24 @@ Examples:
   cv upgrade:db --retry
 ');
     $this->configureBootOptions();
+  }
+
+  /**
+   * @var \Symfony\Component\Console\Input\InputInterface
+   */
+  protected $input;
+
+  /**
+   * @var \Symfony\Component\Console\Output\OutputInterface
+   */
+  protected $output;
+
+  protected $niceVerbosity;
+
+  protected function initialize(InputInterface $input, OutputInterface $output) {
+    $this->input = $input;
+    $this->output = $output;
+    parent::initialize($input, $output);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
@@ -54,125 +74,39 @@ Examples:
       }
     }
 
-    $niceMsgVerbosity = $input->getOption('out') === 'pretty' ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE;
+    $this->niceVerbosity = $input->getOption('out') === 'pretty' ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE;
     $isFirstTry = !$input->getOption('retry') && !$input->getOption('skip');
 
     $codeVer = \CRM_Utils_System::version();
     $dbVer = \CRM_Core_BAO_Domain::version();
     $postUpgradeMessageFile = $this->getUpgradeFile();
-    $output->writeln(sprintf("<info>Found CiviCRM database version <comment>%s</comment>.</info>", $dbVer), $niceMsgVerbosity);
-    $output->writeln(sprintf("<info>Found CiviCRM code version <comment>%s</comment>.</info>", $codeVer), $niceMsgVerbosity);
+    $output->writeln(sprintf("<info>Found CiviCRM database version <comment>%s</comment>.</info>", $dbVer), $this->niceVerbosity);
+    $output->writeln(sprintf("<info>Found CiviCRM code version <comment>%s</comment>.</info>", $codeVer), $this->niceVerbosity);
 
-    if (version_compare($codeVer, $dbVer) == 0) {
-      $result = array(
-        'latestVer' => $codeVer,
-        'message' => "You are already upgraded to CiviCRM $codeVer",
-      );
-      $result['text'] = $result['message'];
-      $this->sendResult($input, $output, $result);
-      return 0;
-    }
-
-    if ($isFirstTry && FALSE !== stripos($dbVer, 'upgrade')) {
-      throw new \Exception("Cannot begin upgrade: The database indicates that an incomplete upgrade is pending. If you would like to resume, use --retry or --skip.");
+    if ($isFirstTry) {
+      file_put_contents($postUpgradeMessageFile, "");
+      chmod($postUpgradeMessageFile, 0700);
     }
     if (!$isFirstTry && !file_exists($postUpgradeMessageFile)) {
       throw new \Exception("Cannot resume upgrade: The log file ($postUpgradeMessageFile) is missing. Consider a regular upgrade (without --retry or --skip).");
     }
 
-    $upgrade = new \CRM_Upgrade_Form();
-
-    if ($error = $upgrade->checkUpgradeableVersion($dbVer, $codeVer)) {
-      throw new \Exception($error);
+    $result = 0;
+    $mode = $input->getOption('mode');
+    if ($mode === 'auto') {
+      $mode = (version_compare($dbVer, $codeVer, '<') ? 'full' : 'ext');
     }
 
-    if ($isFirstTry) {
-      $output->writeln("<info>Checking pre-upgrade messages...</info>", $niceMsgVerbosity);
-      $preUpgradeMessage = NULL;
-      $upgrade->setPreUpgradeMessage($preUpgradeMessage, $dbVer, $codeVer);
-      if ($preUpgradeMessage) {
-        $output->writeln(\CRM_Utils_String::htmlToText($preUpgradeMessage), $niceMsgVerbosity);
-        if (!$this->getIO()->confirm('Continue?')) {
-          $output->writeln("<error>Abort</error>");
-          return 1;
-        }
-      }
-      else {
-        $output->writeln("(No messages)", $niceMsgVerbosity);
-      }
+    if ($mode === 'full') {
+      $result += $this->runCoreUpgrade($isFirstTry, $dbVer, $postUpgradeMessageFile, $codeVer);
+      $this->sendMessages($postUpgradeMessageFile, $codeVer);
+    }
+    elseif ($mode === 'ext') {
+      $result += $this->runExtensionUpgrade($isFirstTry);
     }
 
-    // Why is dropTriggers() hard-coded? Can't we just enqueue this as part of buildQueue()?
-    if ($isFirstTry) {
-      $output->writeln("<info>Dropping SQL triggers...</info>", $niceMsgVerbosity);
-      if (!$input->getOption('dry-run')) {
-        \CRM_Core_DAO::dropTriggers();
-      }
-    }
-
-    if ($isFirstTry) {
-      $output->writeln("<info>Preparing upgrade...</info>", $niceMsgVerbosity);
-      file_put_contents($postUpgradeMessageFile, "");
-      chmod($postUpgradeMessageFile, 0700);
-      $queue = \CRM_Upgrade_Form::buildQueue($dbVer, $codeVer, $postUpgradeMessageFile);
-
-      if (!($queue instanceof \CRM_Queue_Queue_Sql)) {
-        // Sanity check -- only SQL queues are resuamble.
-        throw new \RuntimeException("Error: \"cv upgrade\" only supports SQL-based queues.");
-      }
-    }
-    else {
-      $output->writeln("<info>Resuming upgrade...</info>", $niceMsgVerbosity);
-      $queue = \CRM_Queue_Service::singleton()->load(array(
-        'name' => \CRM_Upgrade_Form::QUEUE_NAME,
-        'type' => 'Sql',
-      ));
-
-      if ($input->getOption('skip')) {
-        $item = $queue->stealItem();
-        $output->writeln(sprintf("<error>Skip task: %s</error>", $item->data->title));
-        $queue->deleteItem($item);
-      }
-
-    }
-
-    $output->writeln("<info>Executing upgrade...</info>", $niceMsgVerbosity);
-    $runner = new ConsoleQueueRunner($this->getIO(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
-    $runner->runAll();
-
-    $output->writeln("<info>Finishing upgrade...</info>", $niceMsgVerbosity);
-    if (!$input->getOption('dry-run')) {
-      \CRM_Upgrade_Form::doFinish();
-    }
-
-    $output->writeln("<info>Upgrade to <comment>$codeVer</comment> completed.</info>", $niceMsgVerbosity);
-
-    if (version_compare($codeVer, '5.26.alpha', '<')) {
-      // Work-around for bugs like dev/core#1713.
-      // Note that #1713 didn't affect earlier versions of `cv` because they mistakenly omitted CIVICRM_UPGRADE_ACTIVE.
-      $output->writeln('<info>Detected CiviCRM 5.25 or earlier. Force flush.</info>');
-      \Civi\Cv\Util\Cv::passthru("flush");
-    }
-
-    $output->writeln("<info>Checking post-upgrade messages...</info>", $niceMsgVerbosity);
-    $message = file_get_contents($postUpgradeMessageFile);
-    if ($input->getOption('out') === 'pretty') {
-      if ($message) {
-        $output->writeln(\CRM_Utils_String::htmlToText($message), OutputInterface::OUTPUT_RAW);
-      }
-      else {
-        $output->writeln("(No messages)", $niceMsgVerbosity);
-      }
-      $output->writeln("<info>Have a nice day.</info>", $niceMsgVerbosity);
-    }
-    else {
-      $this->sendResult($input, $output, array(
-        'latestVer' => $codeVer,
-        'message' => $message,
-        'text' => \CRM_Utils_String::htmlToText($message),
-      ));
-    }
-    unlink($postUpgradeMessageFile);
+    $output->writeln("<info>Have a nice day.</info>");
+    return $result;
   }
 
   /**
@@ -216,6 +150,163 @@ Examples:
     )));
 
     return $dir . DIRECTORY_SEPARATOR . $id . '.dat';
+  }
+
+  /**
+   * @param bool $isFirstTry
+   * @param string $dbVer
+   * @param string $postUpgradeMessageFile
+   * @param string $codeVer
+   *
+   * @return int|null
+   * @throws \CRM_Core_Exception
+   */
+  protected function runCoreUpgrade(bool $isFirstTry, string $dbVer, string $postUpgradeMessageFile, string $codeVer): ?int {
+    $input = $this->input;
+    $output = $this->output;
+
+    if ($isFirstTry && FALSE !== stripos($dbVer, 'upgrade')) {
+      throw new \Exception("Cannot begin upgrade: The database indicates that an incomplete upgrade is pending. If you would like to resume, use --retry or --skip.");
+    }
+
+    $upgrade = new \CRM_Upgrade_Form();
+
+    if ($error = $upgrade->checkUpgradeableVersion($dbVer, $codeVer)) {
+      throw new \Exception($error);
+    }
+
+    if ($isFirstTry) {
+      $output->writeln("<info>Checking pre-upgrade messages...</info>", $this->niceVerbosity);
+      $preUpgradeMessage = NULL;
+      $upgrade->setPreUpgradeMessage($preUpgradeMessage, $dbVer, $codeVer);
+      if ($preUpgradeMessage) {
+        $output->writeln(\CRM_Utils_String::htmlToText($preUpgradeMessage), $this->niceVerbosity);
+        if (!$this->getIO()->confirm('Continue?')) {
+          $output->writeln("<error>Abort</error>");
+          return 1;
+        }
+      }
+      else {
+        $output->writeln("(No messages)", $this->niceVerbosity);
+      }
+    }
+
+    // Why is dropTriggers() hard-coded? Can't we just enqueue this as part of buildQueue()?
+    if ($isFirstTry) {
+      $output->writeln("<info>Dropping SQL triggers...</info>", $this->niceVerbosity);
+      if (!$input->getOption('dry-run')) {
+        \CRM_Core_DAO::dropTriggers();
+      }
+    }
+
+    if ($isFirstTry) {
+      $output->writeln("<info>Preparing upgrade...</info>", $this->niceVerbosity);
+      $queue = \CRM_Upgrade_Form::buildQueue($dbVer, $codeVer, $postUpgradeMessageFile);
+      $this->assertResumableQueue($queue);
+    }
+    else {
+      $output->writeln("<info>Resuming upgrade...</info>", $this->niceVerbosity);
+      $queue = \CRM_Queue_Service::singleton()->load([
+        'name' => \CRM_Upgrade_Form::QUEUE_NAME,
+        'type' => 'Sql',
+      ]);
+
+      if ($input->getOption('skip')) {
+        $item = $queue->stealItem();
+        $output->writeln(sprintf("<error>Skip task: %s</error>", $item->data->title));
+        $queue->deleteItem($item);
+      }
+    }
+
+    $output->writeln("<info>Executing upgrade...</info>", $this->niceVerbosity);
+    $runner = new ConsoleQueueRunner($this->getIO(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
+    $runner->runAll();
+
+    $output->writeln("<info>Finishing upgrade...</info>", $this->niceVerbosity);
+    if (!$input->getOption('dry-run')) {
+      \CRM_Upgrade_Form::doFinish();
+    }
+
+    if (version_compare($codeVer, '5.53.alpha1', '<')) {
+      // Note: Before 5.53+, core-upgrade didn't touch extensions.
+      $this->runExtensionUpgrade($isFirstTry);
+    }
+
+    $output->writeln("<info>Upgrade to <comment>$codeVer</comment> completed.</info>", $this->niceVerbosity);
+
+    if (version_compare($codeVer, '5.26.alpha', '<')) {
+      // Work-around for bugs like dev/core#1713.
+      // Note that #1713 didn't affect earlier versions of `cv` because they mistakenly omitted CIVICRM_UPGRADE_ACTIVE.
+      $output->writeln('<info>Detected CiviCRM 5.25 or earlier. Force flush.</info>');
+      \Civi\Cv\Util\Cv::passthru("flush");
+    }
+
+    return 0;
+  }
+
+  protected function sendMessages(string $postUpgradeMessageFile, string $codeVer): void {
+    $input = $this->input;
+    $output = $this->output;
+
+    $output->writeln("<info>Checking post-upgrade messages...</info>", $this->niceVerbosity);
+    $message = file_get_contents($postUpgradeMessageFile);
+    if ($input->getOption('out') === 'pretty') {
+      if ($message) {
+        $output->writeln(\CRM_Utils_String::htmlToText($message), OutputInterface::OUTPUT_RAW);
+      }
+      else {
+        $output->writeln("(No messages)", $this->niceVerbosity);
+      }
+    }
+    else {
+      $this->sendResult($input, $output, [
+        'latestVer' => $codeVer,
+        'message' => $message,
+        'text' => \CRM_Utils_String::htmlToText($message),
+      ]);
+    }
+    unlink($postUpgradeMessageFile);
+  }
+
+  protected function runExtensionUpgrade(bool $isFirstTry): int {
+    $input = $this->input;
+    $output = $this->output;
+
+    if ($isFirstTry) {
+      $output->writeln("<info>Preparing extension upgrade...</info>", $this->niceVerbosity);
+      \CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+      $queue = \CRM_Extension_Upgrades::createQueue();
+      $this->assertResumableQueue($queue);
+    }
+    else {
+      $output->writeln("<info>Resuming extension upgrade...</info>", $this->niceVerbosity);
+      $queue = \CRM_Queue_Service::singleton()->load([
+        'name' => \CRM_Extension_Upgrades::QUEUE_NAME,
+        'type' => 'Sql',
+      ]);
+
+      if ($input->getOption('skip')) {
+        $item = $queue->stealItem();
+        $output->writeln(sprintf("<error>Skip task: %s</error>", $item->data->title));
+        $queue->deleteItem($item);
+      }
+    }
+
+    $runner = new ConsoleQueueRunner($this->getIO(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
+    $runner->runAll();
+    return 0;
+  }
+
+  /**
+   * @param \CRM_Queue_Service $queue
+   *
+   * @return void
+   */
+  protected function assertResumableQueue($queue): void {
+    if (!($queue instanceof \CRM_Queue_Queue_Sql)) {
+      // Sanity check -- only SQL queues are resuamble.
+      throw new \RuntimeException("Error: \"cv upgrade\" only supports SQL-based queues.");
+    }
   }
 
 }


### PR DESCRIPTION
Before
-------

* `cv updb` does not exist.
* `cv ext:upgrade-db` runs the extension upgrades.
* `cv upgrade:db` runs the core upgrade. Sometimes, it may also run extension upgrades:
    * If the core schema is up-to-date, then it does nothing. (Neither core nor extension.)
    * If the core schema is out-of-date, then it runs core upgrades. If the version is >=5.53, then it also runs extension upgrades.

After
-------

* `cv updb` is an alias for `cv upgrade:db`
* `cv ext:upgrade-db` is deprecated
* `cv upgrade:db` runs core and/or extension upgrades.
    * If the core schema is out-of-date, then it runs both core and extension upgrades. (This is also known as `--mode=full`.)
    * If the core schema is up-to-date, then it just runs the extension upgrades. (This is known as `--mode=ext`.)


<img width="1132" alt="Screenshot 2024-06-21 at 6 36 12 PM" src="https://github.com/civicrm/cv/assets/1336047/ff185983-dd48-409e-8a4e-fd0b2ba8b6ee">

Comments
-----------

The traditional command `upgrade:db` has been more featureful -- it provides progress-indicators, verbose output, and resume/skip options... but `ext:upgrade-db` had none of these. With the combined command, these features are available in both contexts.

