### PR TITLE
UpgradeDbCommand - Fix failure to upgrade extensions on Standalone/WP

### DIFF
--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -269,6 +269,11 @@ Examples:
   }
 
   protected function runExtensionUpgrade(bool $isFirstTry): int {
+    // `cv upgrade:db` started with CIVICRM_UPGRADE_ACTIVE, which means that the system
+    // booted with a narrow dispatch policy (preventing extensions from mucking with core-upgrade).
+    // But we've now decided we don't need full core-upgrade. So we can use an ordinary environment.
+    \Civi::dispatcher()->setDispatchPolicy(NULL);
+
     $input = $this->input;
     $output = $this->output;
 


### PR DESCRIPTION
Overview
------------

Follow-up to #200. Fixes an intermittent issue with running extension-upgrades.

Before
--------

`cv updb` ran extension-upgrades fine on my D7 build. But on standalone and WordPress, I've seen problems like:

```
[bknix-max:~/bknix/build/build-0/web] cv updb -v
Found CiviCRM database version 5.76.alpha1.
Found CiviCRM code version 5.76.alpha1.
Preparing extension upgrade...

In CiviEventDispatcher.php line 235:
                                                                  
  [RuntimeException]                                              
  The dispatch policy prohibits event "hook_civicrm_permission".  
                                                                  

Exception trace:
  at /home/totten/bknix/build/build-0/web/core/Civi/Core/CiviEventDispatcher.php:235
 Civi\Core\CiviEventDispatcher->dispatch() at /home/totten/bknix/build/build-0/web/core/CRM/Utils/Hook.php:168
 CRM_Utils_Hook->invoke() at /home/totten/bknix/build/build-0/web/core/CRM/Utils/Hook.php:2325
 CRM_Utils_Hook::permission() at /home/totten/bknix/build/build-0/web/core/CRM/Core/Permission/Base.php:413
 CRM_Core_Permission_Base->getAllModulePermissions() at /home/totten/bknix/build/build-0/web/core/CRM/Core/Permission.php:592
 CRM_Core_Permission::assembleBasicPermissions() at /home/totten/bknix/build/build-0/web/core/CRM/Core/Permission.php:576
 CRM_Core_Permission::basicPermissions() at /home/totten/bknix/build/build-0/web/core/CRM/Core/Config.php:312
 CRM_Core_Config->cleanupPermissions() at /home/totten/bknix/build/build-0/web/core/CRM/Core/Invoke.php:409
 CRM_Core_Invoke::rebuildMenuAndCaches() at phar:///home/totten/bknix/bin/cv/src/Command/UpgradeDbCommand.php:179
 Civi\Cv\Command\UpgradeDbCommand->runExtensionUpgrade() at phar:///home/totten/bknix/bin/cv/src/Command/UpgradeDbCommand.php:75
 Civi\Cv\Command\UpgradeDbCommand->execute() at phar:///home/totten/bknix/bin/cv/vendor/symfony/console/Command/Command.php:127
```

After
------

OK

Comments
---------------

* Background
    * When running `CRM_Upgrade_Form` (aka `$mode=full`), the core-upgrade logic starts with a restricted environment -- and then changes/revises the dispatch policy as we approach completion.
    * When running `CRM_Extension_Upgrades` (aka `$mode=ext`), it assumes that you've started in a normal environment. It doesn't do anything to change/revise the dispatch-policy.
* Synthesis:
    * We still need to start in the restricted mode (just in case there's a core-upgrade pending).
    * But if there is no core-upgrade, then we can move on to the normal mode.