### PR TITLE
Backdrop - Fix bootstrap warning about `explode()` and `null`

### DIFF
--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -377,11 +377,11 @@ class Bootstrap {
         $settings = $this->findFirstFile(
           [
             $cmsRoot,
-            implode(DIRECTORY_SEPARATOR, [$cmsRoot, 'data'])
+            implode(DIRECTORY_SEPARATOR, [$cmsRoot, 'data']),
           ],
           [
-           'civicrm.standalone.php',
-           'civicrm.settings.php',
+            'civicrm.standalone.php',
+            'civicrm.settings.php',
           ]
         );
         break;

--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -202,6 +202,10 @@ class Bootstrap {
           // Hint for D7 multisite
           $_SERVER['HTTP_HOST'] = $options['httpHost'];
         }
+        elseif (empty($_SERVER['HTTP_HOST']) && $cmsType === 'backdrop') {
+          // backdrop_settings_initialize() tries to configure cookie policy - and complains if HTTP_HOST is missing
+          $_SERVER['HTTP_HOST'] = 'localhost';
+        }
         if (ord($_SERVER['SCRIPT_NAME']) != 47) {
           $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
         }
@@ -254,6 +258,10 @@ class Bootstrap {
       'REQUEST_METHOD',
       'SCRIPT_NAME',
     );
+    if (CIVICRM_UF === 'Backdrop') {
+      $srvVars[] = 'HTTP_HOST';
+      // ^^ This might make sense for all UF's, but it would require more testing to QA.
+    }
     foreach ($srvVars as $srvVar) {
       $code[] = sprintf('$_SERVER["%s"] = %s;',
         $srvVar, var_export($_SERVER[$srvVar], 1));


### PR DESCRIPTION
Overview
-------------

This fixes a console warning using traditional bootstrap on Backdrop.

Before
--------

```
$ cv ev 'echo 123;'
[PHP Deprecation] explode(): Passing null to parameter #2 ($string) of type string is deprecated at /home/totten/bknix/build/bcmaster/web/core/includes/bootstrap.inc:991
123
```

After
---------

```
$ cv ev 'echo 123;'
123
```
