### PR TITLE
Crash with core:install - typeerror on return value from execute()

### DIFF
--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -77,6 +77,7 @@ $ cv core:install -m extras.opt-in.versionCheck=1
     if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
       $output->writeln(Encoder::encode($setup->getModel()->getValues(), 'json-pretty'));
     }
+    return 0;
   }
 
   /**


### PR DESCRIPTION
`TypeError: Return value of "Civi\Cv\Command\CoreInstallCommand::execute()" must be of the type int, "null" returned. in Symfony\Component\Console\Command\Command->run() (line 301 of ...\vendor\symfony\console\Command\Command.php).` when doing `cv core:install`

Looks like symfony console was just updated to v5 here.

@totten 