### PR TITLE
Fix "Stringable" error when using PHAR on PHP 7.x

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -30,6 +30,9 @@ return [
     '/^(drupal|backdrop|user|module)_/',
     't',
   ],
+  'exclude-files' => [
+    'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php'
+  ],
 
   // Do not generate wrappers/aliases for `civicrm_api()` etc or various CMS-booting functions.
   'expose-global-functions' => FALSE,


### PR DESCRIPTION
The recent v0.3.52 brought in updates `symfony/polyfill-php80` and new `symfony/string`. The polyfilled `interface Stringable` becomes important in this build.

box+scoper are usually clever about skipping polyfills, but in this case they need the extra hint...