### PR TITLE
execute() - Update return types for more methods

### DIFF
--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -37,7 +37,7 @@ Examples:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     if (!$input->getOption('user')) {
       $output->getErrorOutput()->writeln("<comment>For a full list, try passing --user=[username].</comment>");

--- a/src/Command/AngularHtmlShowCommand.php
+++ b/src/Command/AngularHtmlShowCommand.php
@@ -41,7 +41,7 @@ Examples:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     if (!$input->getOption('user')) {
       $output->getErrorOutput()->writeln("<comment>For a full list, try passing --user=[username].</comment>");

--- a/src/Command/AngularModuleListCommand.php
+++ b/src/Command/AngularModuleListCommand.php
@@ -39,7 +39,7 @@ Examples:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     if (!$input->getOption('user')) {
       $output->getErrorOutput()->writeln("<comment>For a full list, try passing --user=[username].</comment>");

--- a/src/Command/Api4Command.php
+++ b/src/Command/Api4Command.php
@@ -125,7 +125,7 @@ NOTE: To change the default output format, set CV_OUTPUT.
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $C = '<comment>';
     $_C = '</comment>';
     $I = '<info>';

--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -50,7 +50,7 @@ TIP: To display a full backtrace of any errors, pass "-vv" (very verbose).
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $C = '<comment>';
     $_C = '</comment>';
     $I = '<info>';

--- a/src/Command/CliCommand.php
+++ b/src/Command/CliCommand.php
@@ -21,7 +21,7 @@ class CliCommand extends BaseCommand {
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     $cv = new Application();
@@ -32,6 +32,7 @@ class CliCommand extends BaseCommand {
     //  new ApiMatcher(),
     //));
     $sh->run();
+    return 0;
   }
 
 }

--- a/src/Command/CoreCheckReqCommand.php
+++ b/src/Command/CoreCheckReqCommand.php
@@ -38,7 +38,7 @@ $ cv core:check-req -we
     $this->configureBootOptions('none');
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $filterSeverities = $this->parseFilter($input);
 
     $showBootMsgsByDefault = in_array($input->getOption('out'), ['table', 'pretty']);

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -52,7 +52,7 @@ $ cv core:install -m extras.opt-in.versionCheck=1
     $this->configureBootOptions('none');
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $setup = $this->bootSetupSubsystem($input, $output);
 
     $debugMode = FALSE;

--- a/src/Command/CoreUninstallCommand.php
+++ b/src/Command/CoreUninstallCommand.php
@@ -31,7 +31,7 @@ options for "core:uninstall" as the preceding "core:install".
     $this->configureBootOptions('none');
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $setup = $this->bootSetupSubsystem($input, $output);
 
     $debugEvent = $this->parseOptionalOption($input, ['--debug-event'], NULL, '');
@@ -74,6 +74,8 @@ options for "core:uninstall" as the preceding "core:install".
       $output->writeln(sprintf("<info>Removing <comment>%s</comment> from <comment>%s</comment></info>", basename($setup->getModel()->settingsPath), dirname($setup->getModel()->settingsPath)));
       $setup->uninstallFiles();
     }
+
+    return 0;
   }
 
 }

--- a/src/Command/EditCommand.php
+++ b/src/Command/EditCommand.php
@@ -46,7 +46,7 @@ class EditCommand extends BaseCommand {
     });
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     $config = Config::read();

--- a/src/Command/EvalCommand.php
+++ b/src/Command/EvalCommand.php
@@ -40,7 +40,7 @@ NOTE: To change the default output format, set CV_OUTPUT.
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     if ($input->getOption('out') === 'auto') {

--- a/src/Command/ExtensionDisableCommand.php
+++ b/src/Command/ExtensionDisableCommand.php
@@ -37,7 +37,7 @@ Note:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
 

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -68,7 +68,7 @@ Note:
     parent::initialize($input, $output);
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $fs = new Filesystem();
 
     if ($extRepoUrl = $this->parseRepoUrl($input)) {

--- a/src/Command/ExtensionEnableCommand.php
+++ b/src/Command/ExtensionEnableCommand.php
@@ -40,7 +40,7 @@ Note:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     // Refresh extensions if (a) ---refresh enabled or (b) there's a cache-miss.

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -49,7 +49,7 @@ Note:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $wo = ($input->getOption('out') === 'table')
       ? (OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL)
       : (OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_VERBOSE);

--- a/src/Command/ExtensionUninstallCommand.php
+++ b/src/Command/ExtensionUninstallCommand.php
@@ -37,7 +37,7 @@ Note:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     list ($foundKeys, $missingKeys) = $this->parseKeys($input, $output);
 

--- a/src/Command/FillCommand.php
+++ b/src/Command/FillCommand.php
@@ -58,7 +58,7 @@ class FillCommand extends BaseCommand {
     );
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     if (!$input->getOption('file')) {
       $reader = new SiteConfigReader(CIVICRM_SETTINGS_PATH);
@@ -105,6 +105,7 @@ class FillCommand extends BaseCommand {
       });
       $output->writeln(sprintf("<info>Please edit</info> %s", Config::getFileName()));
     }
+    return 0;
   }
 
 }

--- a/src/Command/FlushCommand.php
+++ b/src/Command/FlushCommand.php
@@ -22,7 +22,7 @@ Flush system caches
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     // The main reason we have this as separate command -- so we can ignore
     // stale class-references that might be retained by the container cache.
     define('CIVICRM_CONTAINER_CACHE', 'never');

--- a/src/Command/HttpCommand.php
+++ b/src/Command/HttpCommand.php
@@ -46,7 +46,7 @@ NOTE: If you use `--login` and do not have `authx`, then it prompts about
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     $method = $input->getOption('request');
@@ -67,6 +67,7 @@ NOTE: If you use `--login` and do not have `authx`, then it prompts about
       $statusCode = $this->sendRequest($output, $method, $row['value'], array_merge($headers, $row['headers'] ?? []), $data);
       return ($statusCode >= 200 && $statusCode < 300) ? 0 : $statusCode;
     }
+    return 0;
   }
 
   /**

--- a/src/Command/PathCommand.php
+++ b/src/Command/PathCommand.php
@@ -58,7 +58,7 @@ Example: Lookup multiple items
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     if (!$input->getOption('ext') && !$input->getOption('config') && !$input->getOption('dynamic')) {

--- a/src/Command/PipeCommand.php
+++ b/src/Command/PipeCommand.php
@@ -50,7 +50,7 @@ See also: https://docs.civicrm.org/dev/en/latest/framework/pipe
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     if (!is_callable(['Civi', 'pipe'])) {
       fwrite(STDERR, "This version of CiviCRM does not include Civi::pipe() support.\n");

--- a/src/Command/ScriptCommand.php
+++ b/src/Command/ScriptCommand.php
@@ -21,7 +21,7 @@ class ScriptCommand extends BaseCommand {
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $fs = new Filesystem();
     $origScript = $fs->toAbsolutePath($input->getArgument('script'));
     $scriptArguments = $input->getArgument('scriptArguments');

--- a/src/Command/SettingGetCommand.php
+++ b/src/Command/SettingGetCommand.php
@@ -71,7 +71,7 @@ class SettingGetCommand extends BaseCommand {
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     $filter = $this->createSettingFilter($input->getArgument('name'));

--- a/src/Command/SettingRevertCommand.php
+++ b/src/Command/SettingRevertCommand.php
@@ -62,7 +62,7 @@ class SettingRevertCommand extends BaseCommand {
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
     $errorOutput = is_callable([$output, 'getErrorOutput']) ? $output->getErrorOutput() : $output;
 

--- a/src/Command/SettingSetCommand.php
+++ b/src/Command/SettingSetCommand.php
@@ -85,7 +85,7 @@ If you'd like to inspect the behavior more carefully, try using {$I}--dry-run{$_
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $C = '<comment>';
     $_C = '</comment>';
     $I = '<info>';

--- a/src/Command/SqlCliCommand.php
+++ b/src/Command/SqlCliCommand.php
@@ -47,7 +47,7 @@ The ENV expressions are prefixed to indicate their escaping rule:
     }
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->boot($input, $output);
 
     $datasource = new Datasource();

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -24,7 +24,7 @@ Examples:
     // parent::configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
 
     throw new \RuntimeException("FIXME: Calls to run() should be escaped, e.g. with Process::sprintf()");
 

--- a/src/Command/UpgradeDlCommand.php
+++ b/src/Command/UpgradeDlCommand.php
@@ -37,7 +37,7 @@ Returns a JSON object with the properties:
     // parent::configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     // Figure out the URL, whether specified or automatic
     $url = $input->getOption('url');
     if (empty($url)) {
@@ -114,6 +114,7 @@ Returns a JSON object with the properties:
     $result['installedTo'] = $dest;
 
     $this->sendResult($input, $output, $result);
+    return 0;
   }
 
   /**

--- a/src/Command/UpgradeGetCommand.php
+++ b/src/Command/UpgradeGetCommand.php
@@ -42,7 +42,7 @@ Returns a JSON object with the properties:
     $this->configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $result = array();
     $exitCode = 0;
     $stability = $input->getOption('stability');

--- a/src/Command/UpgradeReportCommand.php
+++ b/src/Command/UpgradeReportCommand.php
@@ -55,7 +55,7 @@ Returns a JSON object with the properties:
     // parent::configureBootOptions();
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     // $report will be POSTed too https://upgrade.civicrm.org/report.
     // See also: https://github.com/civicrm/civicrm-dist-manager#route-post-report-web-service
 
@@ -111,6 +111,7 @@ Returns a JSON object with the properties:
     $report['response'] = $this->reportToCivi($report);
 
     $this->sendResult($input, $output, $report);
+    return 0;
   }
 
   /**

--- a/src/Command/UrlCommand.php
+++ b/src/Command/UrlCommand.php
@@ -76,7 +76,7 @@ NOTE: If you use `--login` and do not have `authx`, then it prompts about
     }
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     if (in_array($input->getOption('out'), Encoder::getTabularFormats())
     && !in_array($input->getOption('out'), Encoder::getFormats())) {
       $input->setOption('tabular', TRUE);


### PR DESCRIPTION
This should fix errors in a few more scenarios (*by explicitly returning `0`*). Additionally, it should give better IDE hints. (*It may also make the code more interoperable with newer Symfony versions, but that's a fringe improvement.*)