### PR TITLE
Trimmed down version of #211 - just remove the `@` suppression

### DIFF
--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -213,7 +213,7 @@ class Bootstrap {
 
       $this->log->debug("Load settings file \"" . $settings . "\"");
       define('CIVICRM_SETTINGS_PATH', $settings);
-      $error = @include_once $settings;
+      $error = include_once $settings;
       if ($error == FALSE) {
         $this->log->notice("Failed to load settings file");
         throw new \Exception("Could not load the CiviCRM settings file: {$settings}");


### PR DESCRIPTION
This can lead to silent fatals where cv just appears to do nothing, and doesn't seem needed.

One way to reproduce is:
1. Install drupal 10+civi (with php 8.1+ since you can't with anything lower anyway).
2. Using php 7.4, run something like cv vars:show. It just exits. Running with -vvv doesn't tell you the actual problem.
3. If you remove the `@`, then it tells you there's a symfony lib that isn't compatible with php 7. Also there's a message about composer.