### PR TITLE
Tabular Outputs - Expand support for "all columns" (and other shortcuts)

### DIFF
--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -25,7 +25,7 @@ class AngularHtmlListCommand extends BaseCommand {
       ->setName('ang:html:list')
       ->setAliases(array())
       ->setDescription('List Angular HTML files')
-      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'list', 'defaultColumns' => 'file'])
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'list', 'defaultColumns' => 'file', 'shortcuts' => TRUE])
       ->addArgument('filter', InputArgument::OPTIONAL,
         'Filter by filename. For regex filtering, use semicolon delimiter.')
       ->setHelp('List Angular HTML files

--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Util\ArrayUtil;
 use Civi\Cv\Util\BootTrait;
 use Civi\Cv\Util\StructuredOutputTrait;
 use Symfony\Component\Console\Input\InputArgument;
@@ -44,7 +45,7 @@ Examples:
     }
 
     $columns = explode(',', $input->getOption('columns'));
-    $records = $this->sort($this->find($input), $columns);
+    $records = ArrayUtil::sortColumns($this->find($input), $columns);
     $this->sendTable($input, $output, $records, $columns);
     return 0;
   }
@@ -78,23 +79,6 @@ Examples:
         }
       }
       return TRUE;
-    });
-
-    return $rows;
-  }
-
-  protected function sort($rows, $orderByColumns) {
-    usort($rows, function ($a, $b) use ($orderByColumns) {
-      foreach ($orderByColumns as $col) {
-        if ($a[$col] < $b[$col]) {
-          return -1;
-        }
-        if ($a[$col] > $b[$col]) {
-          return 1;
-        }
-      }
-
-      return 0;
     });
 
     return $rows;

--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -44,9 +44,7 @@ Examples:
       $output->getErrorOutput()->writeln("<comment>For a full list, try passing --user=[username].</comment>");
     }
 
-    $columns = explode(',', $input->getOption('columns'));
-    $records = ArrayUtil::sortColumns($this->find($input), $columns);
-    $this->sendTable($input, $output, $records, $columns);
+    $this->sendStandardTable($this->find($input));
     return 0;
   }
 

--- a/src/Command/AngularModuleListCommand.php
+++ b/src/Command/AngularModuleListCommand.php
@@ -46,11 +46,7 @@ Examples:
       $output->getErrorOutput()->writeln("<comment>For a full list, try passing --user=[username].</comment>");
     }
 
-    $columns = explode(',', $input->getOption('columns'));
-    $records = ArrayUtil::sortColumns($this->find($input), $columns);
-
-    $this->sendTable($input, $output, $records, $columns);
-
+    $this->sendStandardTable($this->find($input));
     return 0;
   }
 

--- a/src/Command/AngularModuleListCommand.php
+++ b/src/Command/AngularModuleListCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Util\ArrayUtil;
 use Civi\Cv\Util\BootTrait;
 use Civi\Cv\Util\StructuredOutputTrait;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,7 +25,7 @@ class AngularModuleListCommand extends BaseCommand {
       ->setName('ang:module:list')
       ->setAliases(array())
       ->setDescription('List Angular modules')
-      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'name,basePages,requires'])
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'name,basePages,requires', 'shortcuts' => TRUE])
       ->addArgument('regex', InputArgument::OPTIONAL,
         'Filter extensions by full key or short name')
       ->setHelp('List Angular modules
@@ -46,7 +47,7 @@ Examples:
     }
 
     $columns = explode(',', $input->getOption('columns'));
-    $records = $this->sort($this->find($input), $columns);
+    $records = ArrayUtil::sortColumns($this->find($input), $columns);
 
     $this->sendTable($input, $output, $records, $columns);
 
@@ -102,23 +103,6 @@ Examples:
         }
       }
       return TRUE;
-    });
-
-    return $rows;
-  }
-
-  protected function sort($rows, $orderByColumns) {
-    usort($rows, function ($a, $b) use ($orderByColumns) {
-      foreach ($orderByColumns as $col) {
-        if ($a[$col] < $b[$col]) {
-          return -1;
-        }
-        if ($a[$col] > $b[$col]) {
-          return 1;
-        }
-      }
-
-      return 0;
     });
 
     return $rows;

--- a/src/Command/Api4Command.php
+++ b/src/Command/Api4Command.php
@@ -38,7 +38,7 @@ class Api4Command extends BaseCommand {
       ->setName('api4')
       ->setDescription('Call APIv4')
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
-      ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list']])
+      ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list', 'json']])
       ->addOption('dry-run', 'N', InputOption::VALUE_NONE, 'Preview the API call. Do not execute.')
       ->addArgument('Entity.action', InputArgument::REQUIRED)
       ->addArgument('key=value', InputArgument::IS_ARRAY)

--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -33,7 +33,7 @@ class ApiCommand extends BaseCommand {
       ->setAliases(['api'])
       ->setDescription('Call APIv3')
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
-      ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list']])
+      ->configureOutputOptions(['tabular' => TRUE, 'shortcuts' => ['table', 'list', 'json']])
       ->addArgument('Entity.action', InputArgument::REQUIRED)
       ->addArgument('key=value', InputArgument::IS_ARRAY)
       ->setHelp('Call APIv3

--- a/src/Command/CoreCheckReqCommand.php
+++ b/src/Command/CoreCheckReqCommand.php
@@ -48,9 +48,7 @@ $ cv core:check-req -we
     $messages = array_filter($reqs->getMessages(), function ($m) use ($filterSeverities) {
       return in_array($m['severity'], $filterSeverities);
     });
-    $columns = ArrayUtil::resolveColumns($this->parseColumns($input), $messages);
-    $messages = ArrayUtil::sortColumns($messages, $columns);
-    $this->sendTable($input, $output, $messages, $columns);
+    $this->sendStandardTable($messages);
     return $reqs->getErrors() ? 1 : 0;
   }
 

--- a/src/Command/DebugContainerCommand.php
+++ b/src/Command/DebugContainerCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Util\ArrayUtil;
 use Civi\Cv\Util\BootTrait;
 use Civi\Cv\Util\Relativizer;
 use Civi\Cv\Util\StructuredOutputTrait;
@@ -26,7 +27,7 @@ class DebugContainerCommand extends BaseCommand {
       ->addOption('concrete', 'C', InputOption::VALUE_NONE, 'Display concrete class names. (This requires activating every matching service.)')
       ->addOption('internal', 'i', InputOption::VALUE_NONE, 'Include internal services')
       ->addOption('tag', NULL, InputOption::VALUE_REQUIRED, 'Find services by tag.')
-      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table'])
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'service,class,events,extras', 'shortcuts' => ['table', 'list', 'json', 'all']])
       ->setHelp('
 Dump the container configuration
 
@@ -113,7 +114,7 @@ internal services (eg `--all`, `--tag=XXX`, or `-v`).
       $rows[] = array('service' => $name, 'class' => $class, 'events' => $events ? count($events) : '', 'extras' => implode(' ', $extras));
     }
 
-    $this->sendTable($input, $output, $rows, array('service', 'class', 'events', 'extras'));
+    $this->sendStandardTable($rows);
   }
 
   public function showVerboseReport(InputInterface $input, OutputInterface $output, array $definitions): void {

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -80,11 +80,7 @@ Note:
       }
     }
 
-    $columns = explode(',', $input->getOption('columns'));
-    $records = ArrayUtil::sortColumns($this->find($input), $columns);
-
-    $this->sendTable($input, $output, $records, $columns);
-
+    $this->sendStandardTable($this->find($input));
     return 0;
   }
 

--- a/src/Command/ExtensionListCommand.php
+++ b/src/Command/ExtensionListCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Util\ArrayUtil;
 use Civi\Cv\Util\StructuredOutputTrait;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,7 +29,7 @@ class ExtensionListCommand extends BaseExtensionCommand {
       ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the list of extensions')
       ->addOption('installed', 'i', InputOption::VALUE_NONE, 'Filter extensions by "installed" status (Equivalent to --statuses=installed)')
       ->addOption('statuses', NULL, InputOption::VALUE_REQUIRED, 'Filter extensions by status (comma separated)', '*')
-      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'location,key,name,version,status,downloadUrl'])
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'location,key,name,version,status,downloadUrl', 'shortcuts' => TRUE])
       ->addArgument('regex', InputArgument::OPTIONAL, 'Filter extensions by full key or short name')
       ->setHelp('List extensions
 
@@ -37,9 +38,10 @@ Examples:
   cv ext:list --remote --dev /mail/
   cv ext:list /^org.civicrm.*/
   cv ext:list -Li --columns=key,label
+  cv ext:list -Ra /mosaico/
 
 Note:
-  If you do not specify --local (-L) or --remote (-R), then all are listed.
+  If you do not specify --local (-L) or --remote (-R), then both are listed.
 
   Beginning circa CiviCRM v4.2+, it has been recommended that extensions
   include a unique long name ("org.example.foobar") and a unique short
@@ -79,7 +81,7 @@ Note:
     }
 
     $columns = explode(',', $input->getOption('columns'));
-    $records = $this->sort($this->find($input), $columns);
+    $records = ArrayUtil::sortColumns($this->find($input), $columns);
 
     $this->sendTable($input, $output, $records, $columns);
 
@@ -169,23 +171,6 @@ Note:
         }
       }
       return TRUE;
-    });
-
-    return $rows;
-  }
-
-  protected function sort($rows, $orderByColumns) {
-    usort($rows, function ($a, $b) use ($orderByColumns) {
-      foreach ($orderByColumns as $col) {
-        if ($a[$col] < $b[$col]) {
-          return -1;
-        }
-        if ($a[$col] > $b[$col]) {
-          return 1;
-        }
-      }
-
-      return 0;
     });
 
     return $rows;

--- a/src/Command/SettingGetCommand.php
+++ b/src/Command/SettingGetCommand.php
@@ -28,7 +28,7 @@ class SettingGetCommand extends BaseCommand {
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
       ->configureOutputOptions([
         'tabular' => TRUE,
-        'shortcuts' => ['table', 'list'],
+        'shortcuts' => TRUE,
         'fallback' => 'table',
         'availColumns' => 'scope,key,value,default,explicit,mandatory,layer',
         'defaultColumns' => 'scope,key,value,layer',

--- a/src/Command/SettingRevertCommand.php
+++ b/src/Command/SettingRevertCommand.php
@@ -28,7 +28,7 @@ class SettingRevertCommand extends BaseCommand {
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
       ->configureOutputOptions([
         'tabular' => TRUE,
-        'shortcuts' => ['table', 'list'],
+        'shortcuts' => TRUE,
         'fallback' => 'table',
         'availColumns' => 'scope,key,value,default,explicit,mandatory,layer',
         'defaultColumns' => 'scope,key,value,layer',

--- a/src/Command/SettingSetCommand.php
+++ b/src/Command/SettingSetCommand.php
@@ -28,7 +28,7 @@ class SettingSetCommand extends BaseCommand {
       ->addOption('in', NULL, InputOption::VALUE_REQUIRED, 'Input format (args,json)', 'args')
       ->configureOutputOptions([
         'tabular' => TRUE,
-        'shortcuts' => ['table', 'list'],
+        'shortcuts' => TRUE,
         'fallback' => 'table',
         'availColumns' => 'scope,key,value,default,explicit,mandatory,layer',
         'defaultColumns' => 'scope,key,value,layer',

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -147,6 +147,41 @@ class ArrayUtil {
   }
 
   /**
+   * Given some requested columns, determine the actual set of columns (available for this data).
+   *
+   * @param string[]|null $columns
+   *   List of requested columns. May include wildcard '*'.
+   * @param array $records
+   *   List of records
+   * @return array
+   *   The concrete list of column-names. (Wildcard replaced by actual values.)
+   */
+  public static function resolveColumns(?array $columns, array $records): array {
+    if (is_array($columns) && in_array('*', $columns)) {
+      $columns = NULL;
+    }
+    return $columns ?: ArrayUtil::findColumns($records);
+  }
+
+  public static function sortColumns(array $records, ?array $columns): array {
+    $columns = static::resolveColumns($columns, $records);
+    usort($records, function ($a, $b) use ($columns) {
+      foreach ($columns as $col) {
+        if ($a[$col] < $b[$col]) {
+          return -1;
+        }
+        if ($a[$col] > $b[$col]) {
+          return 1;
+        }
+      }
+
+      return 0;
+    });
+
+    return $records;
+  }
+
+  /**
    * Grab the first non-empty-ish value.
    *
    * @param array $values

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -3,6 +3,64 @@ namespace Civi\Cv\Util;
 
 class ArrayUtil {
 
+  /**
+   * Evaluate each item in the list. Concatenate the results.
+   *
+   * @param array $items
+   *   Ex: ["a", "b"]
+   * @param callable $filter
+   *   Ex: fn($item) => "<li>$item</li>"
+   * @param string $delimiter
+   * @return string
+   *   Ex: "<li>a</li><li>b</li>"
+   */
+  public static function mapImplode(array $items, callable $filter, string $delimiter = ''): string {
+    return implode($delimiter, array_map($filter, $items));
+  }
+
+  /**
+   * Evaluate each item in the list.
+   *
+   * Similar to array_map(), but the order matches the other variants of map.
+   *
+   * @param array $array
+   * @param callable $func
+   *   function($value): mixed
+   * @return array
+   */
+  public static function map(array $array, callable $func): array {
+    return array_map($func, $array);
+  }
+
+  /**
+   * Evaluate each item in the list.
+   *
+   * Similar to array_map(), but guaranteed to provide two inputs ($key,$value).
+   *
+   * @param array $array
+   * @param callable $func
+   *   function($key, $value): mixed
+   * @return array
+   */
+  public static function mapKV(array $array, callable $func): array {
+    return array_map($func, array_keys($array), array_values($array));
+  }
+
+  /**
+   * Evaluate each item in the list. Concatenate the results.
+   *
+   * @param array $items
+   *   Ex: ["Ray" => "A drop of golden sun"]
+   * @param callable $filter
+   *   Ex: fn($key, $value) => "<dt>$key</dt><dd>$value</dd>"
+   * @param string $delimiter
+   * @return string
+   *   Ex: "<dt>Ray</dt><dd>A drop of golden sun</dd>"
+   */
+  public static function mapImplodeKV(array $items, callable $filter, string $delimiter = '') {
+    return implode($delimiter, static::mapKV($items, $filter));
+  }
+
   public static function collect($array, $index) {
     $result = array();
     foreach ($array as $item) {

--- a/src/Util/SettingTrait.php
+++ b/src/Util/SettingTrait.php
@@ -73,10 +73,6 @@ trait SettingTrait {
 
     $result = $this->fillMeta($result);
 
-    usort($result, function ($a, $b) {
-      return strcmp($a['key'], $b['key']);
-    });
-
     $maxColWidth = 40;
     $abridged = FALSE;
     if (in_array($input->getOption('out'), ['table'])) {
@@ -96,9 +92,7 @@ trait SettingTrait {
       }
     }
 
-    $columns = explode(',', $input->getOption('columns'));
-
-    $this->sendTable($input, $output, $result, $columns);
+    $this->sendStandardTable($result);
     if ($abridged) {
       $errorOutput->writeln('<comment>NOTE: Some values were truncated for readability. To see full data, use "-v" or "--out=json".</comment>');
     }

--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -134,10 +134,7 @@ trait StructuredOutputTrait {
   protected function sendTable(InputInterface $input, OutputInterface $output, $records, $columns = NULL) {
     // Maybe we should standardize '--columns=...' so it doesn't ned to be passed in?
 
-    if (is_array($columns) && in_array('*', $columns)) {
-      $columns = NULL;
-    }
-    $columns = $columns ? $columns : ArrayUtil::findColumns($records);
+    $columns = ArrayUtil::resolveColumns($columns, $records);
 
     // If it's not one of our, then fallback to generic rendering
     if (!in_array($input->getOption('out'), ['table', 'csv', 'list'])) {

--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -230,6 +230,20 @@ trait StructuredOutputTrait {
   }
 
   /**
+   * Send a sorted table (with user-configurable columns).
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param $records
+   * @return void
+   */
+  protected function sendStandardTable($records) {
+    $columns = ArrayUtil::resolveColumns($this->parseColumns(\Civi\Cv\Cv::input()), $records);
+    $records = ArrayUtil::sortColumns($records, $columns);
+    $this->sendTable(\Civi\Cv\Cv::input(), \Civi\Cv\Cv::output(), $records, $columns);
+  }
+
+  /**
    * Determine the columns to display.
    *
    * @param \Symfony\Component\Console\Input\InputInterface $input


### PR DESCRIPTION
Synopsis
------------

Many subcommands produce some kind of tabular data-set for output.  The default tables are designed to be generally useful. But for more advanced cases, the output can be customized to use particular columns and output-formats.

This branches provides more options to help with those advanced. In particular, the option `-a` (`--all-columns`) can help inspect output. Additionally, it reduces some duplicate code to further standardize behavior of more commands.

```bash
## Print summary of extensions; then all details; then custom listings
cv ext:list
cv ext:list -a | less
cv ext:list --out=csv --columns=key,version
cv ext:list -R -I --columns=downloadUrl | grep githu

## Print summary of settings; then all details; then custom listings
cv vget
cv vget -a | less
cv vget --out=csv --columns=key,value,meta.default
```

(*Note that `-a` is a bit different from `-v`. "Verbose" output enables more logging throughout the execution of the job. "All Columns" enables a full view of the final result-set.*)

Technical Details
----------------

This includes some work on extractions, refactorings, helpers. The big one is `sendStandardTable()`. This is like `sendTable()` used here-to-fore, but it enforces some standardized behaviors for column-selection and sorting.