### PR TITLE
Backdrop - Fix for E2E_Core_PathUrlTest

### DIFF
--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -137,7 +137,12 @@ trait UrlCommandTrait {
   protected function resolveExt($extExpr, OutputInterface $output) {
     $mapper = \CRM_Extension_System::singleton()->getMapper();
 
-    [$keyOrName, $file] = explode('/', $extExpr, 2);
+    if (strpos($extExpr, '/')) {
+      [$keyOrName, $file] = explode('/', $extExpr, 2);
+    }
+    else {
+      [$keyOrName, $file] = [$extExpr, NULL];
+    }
     if ($keyOrName === '.') {
       return array(
         'type' => 'ext',

--- a/src/Util/UrlCommandTrait.php
+++ b/src/Util/UrlCommandTrait.php
@@ -71,6 +71,9 @@ trait UrlCommandTrait {
         throw new \RuntimeException("No paths specified");
       }
     }
+    foreach (array_keys($rows) as $rowId) {
+      $rows[$rowId]['value'] = $this->normalizeUrl($rows[$rowId]['value']);
+    }
 
     if ($input->getOption('login')) {
       if (!\CRM_Extension_System::singleton()->getMapper()->isActiveModule('authx')) {
@@ -267,6 +270,20 @@ trait UrlCommandTrait {
         ($entry === 'backend')
       ),
     ];
+  }
+
+  protected function normalizeUrl(string $url): string {
+    // Across different versions+environments+APIs, we don't get consistent renditions of relative/absolute.
+    $preferRelative = \Civi\Cv\Cv::input()->getOption('relative');
+    if (!$preferRelative && $url[0] === '/') {
+      // Base of the domain. Drop paths. Keep scheme+host+port.
+      $baseUrl = preg_replace(';^(https?://[^/]+/?).*$;', '\1', \CRM_Utils_System::baseCMSURL());
+      return $this->urlJoin($baseUrl, ltrim($url, '/'));
+    }
+    if ($preferRelative && preg_match(';^(https?://[^/]+)(/.*)$;', $url, $m)) {
+      return $m[2];
+    }
+    return $url;
   }
 
 }


### PR DESCRIPTION
This fixes a failure in `E2E_Core_PathUrlTest`.

Sort of. It's a bit tricky, because there are actually two problems afflicting this test/environment. You can fix the `cv.git` problem, and then the test still doesn't pass -- because the second problem remains in `civicrm-core.git`. The only way to get the test to pass is to fix both.

The other fix is included with https://github.com/civicrm/civicrm-core/pull/31008