### PR TITLE
cv flush - Remove extra call to boot()

### DIFF
--- a/src/Command/FlushCommand.php
+++ b/src/Command/FlushCommand.php
@@ -24,12 +24,11 @@ Flush system caches
     // stale class-references that might be retained by the container cache.
     define('CIVICRM_CONTAINER_CACHE', 'never');
 
+    // Now we can let the parent proceed with bootstrap...
     parent::initialize($input, $output);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $this->boot($input, $output);
-
     $params = array();
     if ($input->getOption('triggers')) {
       $params['triggers'] = TRUE;


### PR DESCRIPTION
As part of the reorg to use CvCommand, most of the explicit calls to `boot()` were dropped (ae1ed440417b93076aa1e34b7fdc1f4978b33188) in favor of the inherited/automatic boot.

This one fell through the cracks.  The old call to `$this->boot()` probably should've been dropped at the same time (or else FlushCommand should've been flagged as manual-boot).

In any event, this call is duplicative -- and in some configurations, it leads to a chain of other errors (#220).