### PR TITLE
CmsBootstrap - Fix excessively modest error-reporting

### DIFF
--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -163,6 +163,8 @@ class CmsBootstrap {
       $this->log->debug("Simulate web environment in CLI");
       $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
     }
+
+    $originalErrorReporting = error_reporting();
     $func = 'boot' . $cms['type'];
     if (!is_callable([$this, $func])) {
       throw new \Exception("Failed to locate boot function ($func)");
@@ -172,7 +174,7 @@ class CmsBootstrap {
       $cms['path'], $this->options['user'], $this->options['httpHost']);
 
     if (PHP_SAPI === "cli") {
-      error_reporting(1);
+      error_reporting($originalErrorReporting);
     }
 
     $this->log->debug("Finished");


### PR DESCRIPTION
Overview
--------

When you call the CMS to bootstrap the environment (CMS-first protocol), then it may sometimes adjust the PHP `error_reporting()` policy (eg to hide warnings from anonymous users). It's well and good for CMS to dictate that policy on web UI. But for CLI, we often prefer to communicate more to the console user.

With this revision, the effective value of `error_reporting()` should be more consistent between traditional `Bootstrap.php` (Civi-first) and `CmsBootstrap.php` (CMS-first).

Before
------

Once `CmsBootstrap` has started the CMS, it tries to reset the value. But the specific value used here is a poor choice. (I suspect there was an inversion error in the original draft -- `E_ALL` vs `1`. Either static value is suboptimal... but `1` is particularly bad...)

After
-----

Once `CmsBootstrap` has started the CMS, it restores the prior value. This means that we preserve whatever value was defined by `php.ini` or `bin/cv` or `php -d error_reporting=` or similar.