### PR TITLE
php:boot - When using --level=classloader, propagate the $civicrm_root

### DIFF
--- a/src/Command/BootCommand.php
+++ b/src/Command/BootCommand.php
@@ -15,8 +15,11 @@ class BootCommand extends CvCommand {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     switch ($input->getOption('level')) {
       case 'classloader':
-        $code = sprintf('require_once  %s . "/CRM/Core/ClassLoader.php";', var_export(rtrim($GLOBALS["civicrm_root"], '/'), 1))
-          . '\CRM_Core_ClassLoader::singleton()->register();';
+        $code = implode("\n", [
+          sprintf('$GLOBALS["civicrm_root"] = %s;', var_export(rtrim($GLOBALS["civicrm_root"], '/'), 1)),
+          'require_once $GLOBALS["civicrm_root"] . "/CRM/Core/ClassLoader.php";',
+          '\CRM_Core_ClassLoader::singleton()->register();',
+        ]);
         break;
 
       case 'settings':


### PR DESCRIPTION
## Overview

Provide more hints to `CRM_Core_ClassLoader::register()` about how to setup classloader.

## Before

```
cv php:boot --level=classloader
```
```
/*BEGINPHP*/
require_once  '/home/totten/bknix/build/tmpd10/vendor/civicrm/civicrm-core' . "/CRM/Core/ClassLoader.php";
\CRM_Core_ClassLoader::singleton()->register();
/*ENDPHP*/
```

## After

```
cv php:boot --level=classloader
```
```
/*BEGINPHP*/
$GLOBALS["civicrm_root"] = '/home/totten/bknix/build/tmpd10/vendor/civicrm/civicrm-core';
require_once $GLOBALS["civicrm_root"] . "/CRM/Core/ClassLoader.php";
\CRM_Core_ClassLoader::singleton()->register();
/*ENDPHP*/
```

## Comments

This complements civicrm-core#31512. The general idea is this:

* When booting, you need to find the `vendor/autoload.php`.
* If the site-build has symlinks, then you'd like to search for `vendor/autoload.php` based on the *nominal* path (pre-symlink) rather than the *real* path (post-symlink).
* We find the nominal path based on the declared `$civicrm_root`.
* However, when using `eval(cv php:boot --level=classloader)`, the receiver doesn't load `civicrm.settings.php`. So the receiver doesn't get `$civicrm_root`. So we cannot use it as a reference-point to search for `vendor/autoload.php`.
* But if if we send a copy of `$civicrm_root`, then the receiver *can* use it to search for `vendor/autoload.php`.