### PR TITLE
Set $_SERVER['SERVER_SOFTWARE'] to an empty string rather than NULL

### DIFF
--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -196,7 +196,7 @@ class Bootstrap {
 
         $_SERVER['SCRIPT_FILENAME'] = $cmsBasePath . '/index.php';
         $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
-        $_SERVER['SERVER_SOFTWARE'] = '';
+        $_SERVER['SERVER_SOFTWARE'] = ($cmsType === 'drupal') ? NULL : '';
         $_SERVER['REQUEST_METHOD'] = 'GET';
         if (!empty($options['httpHost'])) {
           // Hint for D7 multisite

--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -196,7 +196,7 @@ class Bootstrap {
 
         $_SERVER['SCRIPT_FILENAME'] = $cmsBasePath . '/index.php';
         $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
-        $_SERVER['SERVER_SOFTWARE'] = NULL;
+        $_SERVER['SERVER_SOFTWARE'] = '';
         $_SERVER['REQUEST_METHOD'] = 'GET';
         if (!empty($options['httpHost'])) {
           // Hint for D7 multisite

--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -540,7 +540,7 @@ class CmsBootstrap {
   protected function simulateWebEnv($host, $scriptFile) {
     $_SERVER['SCRIPT_FILENAME'] = $scriptFile;
     $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
-    $_SERVER['SERVER_SOFTWARE'] = NULL;
+    $_SERVER['SERVER_SOFTWARE'] = '';
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $_SERVER['SERVER_NAME'] = $host;
     $_SERVER['HTTP_HOST'] = $host;

--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -161,7 +161,10 @@ class CmsBootstrap {
 
     if (PHP_SAPI === "cli") {
       $this->log->debug("Simulate web environment in CLI");
-      $this->simulateWebEnv($this->options['httpHost'], $cms['path'] . '/index.php');
+      $this->simulateWebEnv($this->options['httpHost'],
+        $cms['path'] . '/index.php',
+        ($cms['type'] === 'Drupal') ? NULL : ''
+      );
     }
 
     $originalErrorReporting = error_reporting();
@@ -534,13 +537,14 @@ class CmsBootstrap {
   }
 
   /**
-   * @param $scriptFile
-   * @param $host
+   * @param string $host
+   * @param string $scriptFile
+   * @param string $serverSoftware
    */
-  protected function simulateWebEnv($host, $scriptFile) {
+  protected function simulateWebEnv($host, $scriptFile, $serverSoftware) {
     $_SERVER['SCRIPT_FILENAME'] = $scriptFile;
     $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
-    $_SERVER['SERVER_SOFTWARE'] = '';
+    $_SERVER['SERVER_SOFTWARE'] = $serverSoftware;
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $_SERVER['SERVER_NAME'] = $host;
     $_SERVER['HTTP_HOST'] = $host;


### PR DESCRIPTION
When using cv in WordPress, we receive deprecation warnings along the lines of

```
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:120
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:120
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:127
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:134
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:134
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:141
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/wp-includes/vars.php:141
```

This is because we have set `$_SERVER['SERVER_SOFTWARE']` to `NULL` and WordPress expects it to be a string.

Given what the PHP manual say about the $_SERVER value here: https://www.php.net/manual/en/reserved.variables.server.php, I think this is a reasonable assumption. 

```
$_SERVER is an array containing information such as headers, paths, and script locations. The entries in this array are created by the web server, therefore there is no guarantee that every web server will provide any of these; servers may omit some, or provide others not listed here [...] When running PHP on the command most of these entries will not be available or have any meaning.

[...]

'SERVER_SOFTWARE'
Server identification string, given in the headers when responding to requests.
```

I'm not sure why we are setting it to NULL specifically but I am guessing it is because some code expects it to be set and that NULL seemed like a reasonable value to set it to. And Drupal does something similar here https://github.com/drupal/drupal/blob/7.x/includes/bootstrap.inc#L643-L651 so maybe that was the inspiration?

This PR is based on the assumption that setting it to an empty string is more 'correct' and that any downstream code is not relying on it being NULL (which I think is a reasonable assumption.

It supercedes https://github.com/civicrm/cv/issues/210
