### PR TITLE
Debugging - Print details about SQL errors (more compat)

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -21,6 +21,7 @@ return [
   ],
   'exclude-classes' => [
     '/^(CRM_|HTML_|DB_|Log_)/',
+    '/^PEAR_(Error|Exception)/',
     'DB',
     'Log',
     'JFactory',


### PR DESCRIPTION
Overview
-------------

Follow-up to #230, which improves support for:

* Handling exceptions when the command is executed as `cv.phar` (instead of `cv` source)
* Handling chained exceptions (`getPrevious()`)

Before
---------

If you invoke `cv` as a PHAR file, or if you have chained exceptions, then the DB errors are reductive:

![Screenshot from 2025-02-04 23-52-54](https://github.com/user-attachments/assets/aa3567aa-40c6-45fc-b5e1-bede40cee6ad)


After
------

Displayed with more debug info:

![Screenshot from 2025-02-04 23-53-08](https://github.com/user-attachments/assets/136dc0c4-9960-4b4a-9c6b-790b0c956f10)


Comments
--------------

* `getCause()` and `getPrevious()` sound similar, but actually differ:
    * `getPrevious()` is a PHP stdlib thing (v7+). It points to the earlier `Exception` which provoked the current exception.
    * `getCause()` is a PEAR thing. It unwraps the `PEAR_Error` that provoked the `Exception`
