### PR TITLE
Add subcommand "status" to report key facts

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -71,6 +71,7 @@ class Application extends BaseApplication {
     $commands[] = new \Civi\Cv\Command\SettingRevertCommand();
     $commands[] = new \Civi\Cv\Command\SqlCliCommand();
     $commands[] = new \Civi\Cv\Command\ShowCommand();
+    $commands[] = new \Civi\Cv\Command\StatusCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeCommand();
     $commands[] = new \Civi\Cv\Command\UpgradeDbCommand();
     // $commands[] = new \Civi\Cv\Command\UpgradeDlCommand();

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Application;
+use Civi\Cv\Util\StructuredOutputTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StatusCommand extends CvCommand {
+
+  use StructuredOutputTrait;
+
+  protected function configure() {
+    $this
+      ->setName('status')
+      ->setDescription('Provide an overview of current site/environment')
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table']);
+
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    $isPhar = preg_match(';^phar://;', __FILE__);
+    $civiCodeVer = \CRM_Utils_System::version();
+    $civiDbVer = \CRM_Core_BAO_Domain::version();
+    $mysqlVersion = \CRM_Utils_SQL::getDatabaseVersion();
+    $ufType = strtolower((CIVICRM_UF === 'Drupal8') ? 'Drupal' : CIVICRM_UF);
+    $ufVer = \CRM_Core_Config::singleton()->userSystem->getVersion();
+    if (method_exists(\CRM_Core_Smarty::singleton(), 'getVersion')) {
+      $smartyVer = \CRM_Core_Smarty::singleton()->getVersion();
+    }
+    else {
+      $smartyVer = 'Unknown';
+    }
+
+    $summaryCode = sprintf('%s%s %s%s %s %s',
+      $civiCodeVer,
+      ($civiCodeVer === $civiDbVer) ? '' : '**',
+      $this->shortPhp(PHP_VERSION),
+      $this->shortDbms($mysqlVersion),
+      $this->shortCms(CIVICRM_UF, $ufVer),
+      strtolower(php_uname('s'))
+    );
+
+    $data = [];
+    $data['summary'] = $summaryCode;
+    $data['civicrm'] = ($civiDbVer === $civiCodeVer) ? "$civiCodeVer" : "$civiCodeVer (DB $civiDbVer)";
+    $data['cv'] = Application::version() . ($isPhar ? ' (phar)' : ' (src)');
+    $data['php'] = sprintf('%s (%s)', PHP_VERSION, PHP_SAPI);
+    $data['mysql'] = $mysqlVersion;
+    $data[$ufType] = $ufVer;
+    $data['os'] = php_uname('s') . ' ' . php_uname('r') . ' ' . php_uname('m');
+    // Would be nice to get lsb_release, but that requires more conditionality
+    $data['smarty'] = $smartyVer;
+    $data['path: cms.root'] = \Civi::paths()->getPath('[cms.root]/.');
+    $data['path: civicrm.root'] = \Civi::paths()->getPath('[civicrm.root]/.');
+    $data['path: civicrm.log'] = \Civi::paths()->getPath('[civicrm.log]/.');
+    $data['path: civicrm.l10n'] = \Civi::paths()->getPath('[civicrm.l10n]/.');
+    $data['path: extensionsDir'] = \CRM_Core_Config::singleton()->extensionsDir;
+
+    $rows = [];
+    foreach ($data as $name => $value) {
+      $rows[$name] = ['name' => $name, 'value' => $value];
+    }
+
+    $this->sendTable($input, $output, $rows);
+    return 0;
+  }
+
+  private function shortPhp($version): string {
+    return 'php' . preg_replace('/([0-9]+)\.([0-9]+).*$/', '$1$2', $version);
+  }
+
+  private function shortDbms($version): string {
+    if (str_contains($version, 'Maria')) {
+      // FIXME: ex: 10.5 ==> r105
+      return 'r???';
+    }
+    else {
+      return 'm' . preg_replace('/([0-9]+)\.([0-9]+).*$/', '$1$2', $version);
+    }
+  }
+
+  private function shortCms($ufName, $ufVersion): string {
+    switch ($ufName) {
+      case 'Drupal':
+      case 'Drupal8':
+        return 'drupal' . explode('.', $ufVersion)[0];
+
+      case 'WordPress':
+        return 'wp';
+
+      case 'Joomla':
+        return 'joomla' . explode('.', $ufVersion)[0];
+
+      case 'Backdrop':
+        return 'backdrop';
+
+      case 'Standalone':
+        return 'standalone';
+
+      default:
+        return $ufName;
+    }
+  }
+
+}

--- a/tests/Command/StatusCommandTest.php
+++ b/tests/Command/StatusCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Civi\Cv\Command;
+
+/**
+ * @group std
+ */
+class StatusCommandTest extends \Civi\Cv\CivilTestCase {
+
+  public function setUp(): void {
+    parent::setup();
+  }
+
+  public function testStatus() {
+    $p = $this->cv("status");
+    $p->run();
+    $data = $p->getOutput();
+    $this->assertTrue((bool) preg_match('/| php .* | \d+\.\d+\./', $data));
+  }
+
+  public function testStatusJson() {
+    $p = $this->cv("status --out=json");
+    $p->run();
+    $data = json_decode($p->getOutput(), 1);
+    $this->assertTrue((bool) preg_match('/^\d+\.\d+\./', $data['civicrm']['value']));
+    $this->assertTrue((bool) preg_match('/^\d+\.\d+\./', $data['php']['value']));
+  }
+
+}


### PR DESCRIPTION
Add a new subcommand, `cv status`, which reports key facts about this current system.

After
-------

Example 1:

![Screenshot from 2025-02-06 00-47-38](https://github.com/user-attachments/assets/e33211eb-abf4-41a7-ad9a-a8edfcaf7634)

Example 2:

![Screenshot from 2025-02-06 00-31-15](https://github.com/user-attachments/assets/a73648fc-c826-4db5-a881-e704729884d3)

Comments
---------------

* This differs from `cv --version` in that it bootstraps and probes the full environment.
* This is similar to `drush status` and `bee status`.
