### PR TITLE
Improve handling of active URLs (esp HTTPS construction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,14 +228,14 @@ Bootstrap
 > ___NOTE___: In absence of a configuration variable, the __Automatic__ mode will behave like `CIVICRM_SETTINGS="Auto"` (in v0.3.x).
   This is tentatively planned to change in v0.4.x, where it will behave like `CIVICRM_BOOT="Auto://."`
 
-Additionally, some deployments handle multiple sites ("multisite"/"multidomain"). You should target a specific site using `--hostname` or `HTTP_HOST`.
+Additionally, some deployments handle multiple sites ("multisite"/"multidomain"). You should target a specific site using `--url` or `HTTP_HOST`.
 
 Here are a few examples of putting these together:
 
 ```bash
-## Use --hostname for a domain
+## Use --url for a domain
 export CIVICRM_BOOT="WordPress:/$HOME/public_html/"
-cv --hostname='www.example.org' ext:list -L
+cv --url='https://www.example.org' ext:list -L
 ```
 
 ```bash
@@ -246,9 +246,9 @@ cv ext:list -L
 ```
 
 ```bash
-## Use --hostname for a subfolder
+## Use --url for a subfolder
 export CIVICRM_BOOT="WordPress:/$HOME/public_html/"
-cv --hostname='www.example.org/nyc' ext:list -L
+cv --url='www.example.org/nyc' ext:list -L
 ```
 
 Autocomplete

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -113,7 +113,7 @@ The `\Civi\Cv\Cv` facade provides some helpers for implementing functionality:
 You can register new subcommands within `cv`. `cv` includes the base-class from Symfony Console, and its adds another base-class. Compare:
 
 * `CvDeps\Symfony\Component\Console\Command\Command` is the original building-block from Symfony Console. It can define and parse CLI arguments, but it does *not* bootstrap CiviCRM or CMS. It may be suitable for some basic commands. Documentation is provided by upstream.
-* `Civi\Cv\Command\CvCommand` (v0.3.56+) is an extended version. It automatically boots CiviCRM and CMS. It handles common options like `--user`, `--hostname`, and `--level`, and it respect environment-variables like `CIVICRM_BOOT`.
+* `Civi\Cv\Command\CvCommand` (v0.3.56+) is an extended version. It automatically boots CiviCRM and CMS. It handles common options like `--user`, `--url`, and `--level`, and it respect environment-variables like `CIVICRM_BOOT`.
 
 For this document, we focus on `CvCommand`.
 

--- a/lib/src/BaseApplication.php
+++ b/lib/src/BaseApplication.php
@@ -145,12 +145,12 @@ class BaseApplication extends \Symfony\Component\Console\Application {
 
   protected static function filterDeprecatedOptions(array $argv): array {
     foreach ($argv as &$arg) {
-      if (preg_match('/^--(cms-base-url|hostname)$/', $arg, $m)) {
-        Cv::io()->note(sprintf("Option --%s renamed to --url", $m[1]));
+      if (preg_match('/^--(cms-base-url|hostname|uri)$/', $arg, $m)) {
+        Cv::io()->note(sprintf("Option --%s is a deprecated alias for --url (-l)", $m[1]));
         $arg = '--url';
       }
-      elseif (preg_match('/^--(cms-base-url|hostname)=(.*)/', $arg, $m)) {
-        Cv::io()->note(sprintf("Option --%s renamed to --url", $m[1]));
+      elseif (preg_match('/^--(cms-base-url|hostname|uri)=(.*)/', $arg, $m)) {
+        Cv::io()->note(sprintf("Option --%s is a deprecated alias for --url (-l)", $m[1]));
         $arg = '--url=' . $m[2];
       }
     }

--- a/lib/src/BaseApplication.php
+++ b/lib/src/BaseApplication.php
@@ -28,6 +28,7 @@ class BaseApplication extends \Symfony\Component\Console\Application {
       Cv::ioStack()->replace('app', $application);
       $application->configure();
       $argv = AliasFilter::filter($argv);
+      $argv = static::filterDeprecatedOptions($argv);
       $result = $application->run(new CvArgvInput($argv), Cv::ioStack()->current('output'));
     }
     finally {
@@ -140,6 +141,20 @@ class BaseApplication extends \Symfony\Component\Console\Application {
     ShellVerbosityIsEvil::doWithoutEvil(function() use ($input, $output) {
       parent::configureIO($input, $output);
     });
+  }
+
+  protected static function filterDeprecatedOptions(array $argv): array {
+    foreach ($argv as &$arg) {
+      if (preg_match('/^--(cms-base-url|hostname)$/', $arg, $m)) {
+        Cv::io()->note(sprintf("Option --%s renamed to --url", $m[1]));
+        $arg = '--url';
+      }
+      elseif (preg_match('/^--(cms-base-url|hostname)=(.*)/', $arg, $m)) {
+        Cv::io()->note(sprintf("Option --%s renamed to --url", $m[1]));
+        $arg = '--url=' . $m[2];
+      }
+    }
+    return $argv;
   }
 
 }

--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -214,7 +214,7 @@ class Bootstrap {
         throw new \Exception("Could not load the CiviCRM settings file: {$settings}");
       }
 
-      if (empty($_SERVER['HTTP_HOST']) && $cmsType === 'backdrop') {
+      if (empty($_SERVER['HTTP_HOST']) && in_array($cmsType, ['backdrop', 'wp'])) {
         // backdrop_settings_initialize() tries to configure cookie policy - and complains if HTTP_HOST is missing
         $webHostVars = $this->convertUrlToCgiVars(defined('CIVICRM_UF_BASEURL') ? CIVICRM_UF_BASEURL : 'http://localhost');
         foreach ($webHostVars as $key => $value) {
@@ -254,6 +254,9 @@ class Bootstrap {
       $result['HTTP_HOST'] = $parts['host'];
       $result['SERVER_PORT'] = $parts['scheme'] === 'http' ? 80 : 443;
     }
+    if ($parts['scheme'] === 'https') {
+      $result['HTTPS'] = 'on';
+    }
     return $result;
   }
 
@@ -276,7 +279,7 @@ class Bootstrap {
       'REQUEST_METHOD',
       'SCRIPT_NAME',
     );
-    if (CIVICRM_UF === 'Backdrop') {
+    if (in_array(CIVICRM_UF, ['Backdrop', 'WordPress'])) {
       $webHostVars = $this->convertUrlToCgiVars(defined('CIVICRM_UF_BASEURL') ? CIVICRM_UF_BASEURL : 'http://localhost');
       $srvVars = array_merge($srvVars, array_keys($webHostVars));
       // ^^ This might make sense for all UF's, but it would require more testing to QA.

--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -211,8 +211,10 @@ class Bootstrap {
         throw new \Exception("Could not load the CiviCRM settings file: {$settings}");
       }
 
-      if (empty($_SERVER['HTTP_HOST']) && in_array($cmsType, ['backdrop', 'wp'])) {
-        // backdrop_settings_initialize() tries to configure cookie policy - and complains if HTTP_HOST is missing
+      if (empty($_SERVER['HTTP_HOST'])) {
+        // 1. backdrop_settings_initialize() tries to configure cookie policy - and complains if HTTP_HOST is missing
+        // 2. WP functions like plugin_url() and is_ssl() may choose HTTP even if the site supports SSL -- unless you have env setup
+        // 3. Generally, if there's no indication of what host/scheme to use, then best-guess is UF_BASEURL.
         $webHostVars = SimulateWeb::convertUrlToCgiVars(defined('CIVICRM_UF_BASEURL') ? CIVICRM_UF_BASEURL : SimulateWeb::localhost());
         foreach ($webHostVars as $key => $value) {
           $_SERVER[$key] = $value;

--- a/lib/src/Bootstrap.php
+++ b/lib/src/Bootstrap.php
@@ -63,7 +63,8 @@ use Civi\Cv\Util\SimulateWeb;
  *   - env: string|NULL. The environment variable which may contain the path to
  *     civicrm.settings.php (or the token "Auto"). Set NULL to disable environment-checking.
  *     (Default: CIVICRM_SETTINGS)
- *   - httpHost: string|NULL. For multisite, the HTTP hostname.
+ *   - url: string|NULL. Specify the logical URL being used to process this request
+ *   - httpHost: string|NULL. For multisite, the HTTP hostname. (DEPRECATED; prefer "url")
  *   - log: \Psr\Log\LoggerInterface|\Civi\Cv\Log\InternalLogger (If given, send log messages here)
  *   - output: Symfony OutputInterface. (Fallback for handling logs - in absence of 'log')
  *   - prefetch: bool. Whether to load various caches.
@@ -113,7 +114,7 @@ class Bootstrap {
         'settingsFile' => NULL,
         'search' => TRUE,
         'cmsType' => NULL,
-        'httpHost' => array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : '',
+        'url' => SimulateWeb::detectEnvUrl(),
       ));
     }
     return self::$singleton;
@@ -124,7 +125,7 @@ class Bootstrap {
    *   See options in class doc.
    */
   public function __construct($options = array()) {
-    $this->options = $options;
+    $this->setOptions($options);
   }
 
   /**
@@ -135,6 +136,7 @@ class Bootstrap {
    * @throws \Exception
    */
   public function boot($options = array()) {
+    $options = $this->filterOptions($options);
     $this->log = Log\Logger::resolve($options, 'Bootstrap');
 
     $isBooting = TRUE;
@@ -195,10 +197,10 @@ class Bootstrap {
 
       if (PHP_SAPI === "cli") {
         $this->log->notice("Simulate web environment in CLI");
-        $effectiveUrl = !empty($options['httpHost']) ? SimulateWeb::prependDefaultScheme($options['httpHost']) : NULL;
-        SimulateWeb::apply($effectiveUrl,
+        SimulateWeb::apply($options['url'] ?? NULL,
           $cmsBasePath . '/index.php',
           ($cmsType === 'drupal') ? NULL : '');
+        // NOTE: If we don't get explicit URL (env-var or cli-arg), then we leave HTTP_HOST blank -- and try to guess later.
       }
 
       $this->log->debug("Load settings file \"" . $settings . "\"");
@@ -300,7 +302,18 @@ class Bootstrap {
    *   See options in class doc.
    */
   public function setOptions($options) {
-    $this->options = $options;
+    $this->options = $this->filterOptions($options);
+  }
+
+  private function filterOptions($options) {
+    if (isset($options['httpHost'])) {
+      $options['url'] = $options['url'] ?? $options['httpHost'];
+      unset($options['httpHost']);
+    }
+    if (isset($options['url'])) {
+      $options['url'] = SimulateWeb::prependDefaultScheme($options['url']);
+    }
+    return $options;
   }
 
   /**
@@ -406,10 +419,12 @@ class Bootstrap {
    * @return array
    */
   protected function findDrupalDirs($cmsRoot, $searchDir) {
+    $httpHost = empty($this->options['url']) ? '' : parse_url($this->options['url'], PHP_URL_HOST);
+
     // If there's no explicit host and we start the search from "web/sites/FOO/...", then infer subsite path.
     $sitesRoot = "$cmsRoot/sites";
     $sitesRootQt = preg_quote($sitesRoot, ';');
-    if (empty($this->options['httpHost']) && preg_match(";^($sitesRootQt/[^/]+);", $searchDir, $m)) {
+    if (empty($httpHost) && preg_match(";^($sitesRootQt/[^/]+);", $searchDir, $m)) {
       if (basename($m[1]) !== 'all') {
         return [$m[1]];
       }
@@ -420,7 +435,7 @@ class Bootstrap {
       include "$cmsRoot/sites/sites.php";
     }
     $dirs = array();
-    $server = explode('.', implode('.', array_reverse(explode(':', rtrim($this->options['httpHost'], '.')))));
+    $server = explode('.', implode('.', array_reverse(explode(':', rtrim($httpHost, '.')))));
     for ($j = count($server); $j > 0; $j--) {
       $s = implode('.', array_slice($server, -$j));
       if (isset($sites[$s]) && file_exists("$cmsRoot/sites/" . $sites[$s])) {

--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -85,7 +85,7 @@ class CmsBootstrap {
       self::$singleton = new CmsBootstrap(array(
         'env' => 'CIVICRM_BOOT',
         'search' => TRUE,
-        'url' => NULL,
+        'url' => SimulateWeb::detectEnvUrl(),
         'user' => NULL,
       ));
     }
@@ -164,8 +164,7 @@ class CmsBootstrap {
 
     if (PHP_SAPI === "cli") {
       $this->log->debug("Simulate web environment in CLI");
-      $effectiveUrl = SimulateWeb::prependDefaultScheme($this->options['url'] ?? (SimulateWeb::detectEnvHost() ?: 'localhost'));
-      SimulateWeb::apply($effectiveUrl,
+      SimulateWeb::apply($this->options['url'] ?? SimulateWeb::localhost(),
         $cms['path'] . '/index.php',
         ($cms['type'] === 'Drupal') ? NULL : ''
       );
@@ -451,6 +450,10 @@ class CmsBootstrap {
       $options['url'] = $options['url'] ?? $options['httpHost'];
       unset($options['httpHost']);
     }
+    if (isset($options['url'])) {
+      $options['url'] = SimulateWeb::prependDefaultScheme($options['url']);
+    }
+
     $this->options = array_merge($this->options, $options);
     $this->log = Log\Logger::resolve($options, 'CmsBootstrap');
     return $this;

--- a/lib/src/Command/CvCommand.php
+++ b/lib/src/Command/CvCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * `CvCommand` is a Symfony `Command` with support for bootstrapping CiviCRM/CMS.
  *
- * - From end-user POV, the command accepts options like --user, --level, --hostname.
+ * - From end-user POV, the command accepts options like --user, --level, --url.
  * - From dev POV, the command allows you to implement `execute()` method without needing to
  *   explicitly boot Civi.
  * - From dev POV, you may fine-tune command by changing the $bootOptions / getBootOptions().

--- a/lib/src/Util/BootTrait.php
+++ b/lib/src/Util/BootTrait.php
@@ -45,7 +45,7 @@ trait BootTrait {
     // However, we also have extension-based commands. The system will boot before we have a chance to discover them.
     // By putting these options at the application level, we ensure they will be defined+used.
     $definition->addOption(new InputOption('level', NULL, InputOption::VALUE_REQUIRED, 'Bootstrap level (none,classloader,settings,full,cms-only,cms-full)', $defaultLevel));
-    $definition->addOption(new InputOption('hostname', NULL, InputOption::VALUE_REQUIRED, 'Hostname (for a multisite system)'));
+    $definition->addOption(new InputOption('url', 'l', InputOption::VALUE_REQUIRED, 'URL or hostname of the current site (for a multisite system)'));
     $definition->addOption(new InputOption('test', 't', InputOption::VALUE_NONE, 'Bootstrap the test database (CIVICRM_UF=UnitTests)'));
     $definition->addOption(new InputOption('user', 'U', InputOption::VALUE_REQUIRED, 'CMS user'));
   }
@@ -267,8 +267,8 @@ trait BootTrait {
     if ($input->getOption('user')) {
       $boot_params['user'] = $input->getOption('user');
     }
-    if ($input->getOption('hostname')) {
-      $boot_params['httpHost'] = $input->getOption('hostname');
+    if ($input->getOption('url')) {
+      $boot_params['url'] = $input->getOption('url');
     }
 
     return \Civi\Cv\CmsBootstrap::singleton()->addOptions($boot_params);
@@ -345,8 +345,8 @@ trait BootTrait {
     if ($output->isDebug()) {
       $boot_params['output'] = $output;
     }
-    if ($input->getOption('hostname')) {
-      $boot_params['httpHost'] = $input->getOption('hostname');
+    if ($input->getOption('url')) {
+      $boot_params['url'] = $input->getOption('url');
     }
     return $boot_params;
   }

--- a/lib/src/Util/SimulateWeb.php
+++ b/lib/src/Util/SimulateWeb.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Civi\Cv\Util;
+
+class SimulateWeb {
+
+  /**
+   * @param string $effectiveUrl
+   * @param string $scriptFile
+   * @param string $serverSoftware
+   */
+  public static function apply($effectiveUrl, $scriptFile, $serverSoftware) {
+    $_SERVER['SCRIPT_FILENAME'] = $scriptFile;
+    $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+    $_SERVER['SERVER_SOFTWARE'] = $serverSoftware;
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+
+    if ($effectiveUrl) {
+      foreach (SimulateWeb::convertUrlToCgiVars($effectiveUrl) as $key => $value) {
+        $_SERVER[$key] = $value;
+      }
+    }
+
+    if (ord($_SERVER['SCRIPT_NAME']) != 47) {
+      $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
+    }
+  }
+
+  public static function convertUrlToCgiVars(?string $url): array {
+    if (strpos($url, '://') === FALSE) {
+      throw new \LogicException("convertUrlToCgiVars() expects a URL");
+    }
+
+    $parts = parse_url($url);
+    $result = [];
+    $result['SERVER_NAME'] = $parts['host'];
+    if (!empty($parts['port'])) {
+      $result['HTTP_HOST'] = $parts['host'] . ':' . $parts['port'];
+      $result['SERVER_PORT'] = $parts['port'];
+    }
+    else {
+      $result['HTTP_HOST'] = $parts['host'];
+      $result['SERVER_PORT'] = $parts['scheme'] === 'http' ? 80 : 443;
+    }
+    if ($parts['scheme'] === 'https') {
+      $result['HTTPS'] = 'on';
+    }
+    return $result;
+  }
+
+  public static function detectEnvUrl(): ?string {
+    if ($host = static::detectEnvHost()) {
+      return static::detectEnvScheme() . '://' . $host;
+    }
+    return NULL;
+  }
+
+  /**
+   * If the user has environment-variables like HTTP_HOST, take that as a sign of
+   * the intended host.
+   *
+   * @return string|null
+   */
+  public static function detectEnvHost(): ?string {
+    if (array_key_exists('HTTP_HOST', $_SERVER) && strpos($_SERVER['HTTP_HOST'], '//') === FALSE) {
+      $url = $_SERVER['HTTP_HOST'];
+      if (array_key_exists('HTTP_PORT', $_SERVER)) {
+        $url .= $_SERVER['HTTP_PORT'];
+      }
+      return $url;
+    }
+    return NULL;
+  }
+
+  public static function detectEnvScheme(): ?string {
+    return (($_SERVER['SERVER_PORT'] ?? NULL) === 443 || ($_SERVER['HTTPS'] ?? NULL) === 'on') ? 'https' : 'http';
+  }
+
+  public static function prependDefaultScheme(?string $url): string {
+    if ($url === NULL || $url === '') {
+      return $url;
+    }
+    elseif (strpos($url, '://') !== FALSE) {
+      return $url;
+    }
+    else {
+      return static::detectEnvScheme() . '://' . $url;
+    }
+  }
+
+  public static function localhost(): string {
+    return static::prependDefaultScheme('localhost');
+  }
+
+}

--- a/src/Command/CoreInstallCommand.php
+++ b/src/Command/CoreInstallCommand.php
@@ -33,7 +33,7 @@ $ cv core:install
 $ wp plugin activate civicrm
 
 Example: Install on a basic Drupal 7 build.
-$ cv core:install --cms-base-url=http://example.com/
+$ cv core:install --url=https://example.com/
 $ drush -y en civicrm
 
 Example: Install on WordPress with a custom language and database.

--- a/src/Util/SetupCommandTrait.php
+++ b/src/Util/SetupCommandTrait.php
@@ -28,7 +28,6 @@ trait SetupCommandTrait {
       ->addOption('setup-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM-Setup source tree. (If omitted, read CV_SETUP_PATH or scan common defaults.)')
       ->addOption('src-path', NULL, InputOption::VALUE_OPTIONAL, 'The path to CivCRM-Core source tree. (If omitted, read CV_SETUP_SRC_PATH or scan common defaults.)')
       ->addOption('plugin-path', NULL, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'A directory with extra installer plugins')
-      ->addOption('cms-base-url', NULL, InputOption::VALUE_OPTIONAL, 'The URL of the CMS (If omitted, attempt to autodetect.)')
       ->addOption('lang', NULL, InputOption::VALUE_OPTIONAL, 'Specify the installation language')
       ->addOption('comp', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM components to enable. (Ex: CiviEvent,CiviContribute,CiviMember,CiviMail,CiviReport)')
       ->addOption('ext', NULL, InputOption::VALUE_OPTIONAL, 'Comma-separated list of CiviCRM extensions to enable. (Ex: org.civicrm.shoreditch,org.civicrm.flexmailer)')
@@ -101,12 +100,12 @@ trait SetupCommandTrait {
       throw new \Exception("Failed to locate civicrm-setup");
     }
 
-    // Note: We set 'cms-base-url' both before and after init. The "before"
+    // Note: We set 'cmsBaseUrl' both before and after init. The "before"
     // lets us give hints to init code which reads cmsBaseUrl. The "after"
     // lets us override any changes made by init code (i.e. this user-input
     // is mandatory).
-    if ($input->getOption('cms-base-url')) {
-      $setupOptions['cmsBaseUrl'] = $input->getOption('cms-base-url');
+    if ($input->getOption('url')) {
+      $setupOptions['cmsBaseUrl'] = $input->getOption('url');
     }
 
     $pluginPaths = $this->buildPluginPaths($b, $input->getOption('plugin-path'));
@@ -150,7 +149,7 @@ trait SetupCommandTrait {
       $setup->getModel()->settingsPath,
     ]);
     $setup->getModel()->cmsBaseUrl = ArrayUtil::pickFirst([
-      $input->getOption('cms-base-url'),
+      $input->getOption('url'),
       $setup->getModel()->cmsBaseUrl,
     ]);
     if ($input->getOption('db')) {

--- a/tests/Command/CoreLifecycleTest.php
+++ b/tests/Command/CoreLifecycleTest.php
@@ -25,13 +25,13 @@ class CoreLifecycleTest extends \PHPUnit\Framework\TestCase {
     $cases[] = [
       'backdrop-empty',
       ['modules' => 'https://download.civicrm.org/latest/civicrm-RC-backdrop.tar.gz'],
-      'core:install -f --cms-base-url=http://localhost',
+      'core:install -f --url=http://localhost',
       '',
     ];
     $cases[] = [
       'drupal-empty',
       ['sites/all/modules' => 'https://download.civicrm.org/latest/civicrm-RC-drupal.tar.gz'],
-      'core:install -f --cms-base-url=http://localhost',
+      'core:install -f --url=http://localhost',
     // 'drush -y en civicrm', // No longer needed -- FlushDrupal plugin autoenables.
       '',
     ];


### PR DESCRIPTION
Overview
----------

Improve the integration between `cv`, its URL inputs, and the common `$_SERVER` variables. Specifically, if you give the `--url` option, then it will set variables like `HTTP_HOST`, `HTTPS`, and `SERVER_PORT`

```
$ cv ev --url=https://example.com:4444 'echo $_SERVER["HTTP_HOST"];'
example.com:4444

$ cv ev --url=https://example.com:4444 'echo $_SERVER["SERVER_NAME"];'
example.com

$ cv ev --url=https://example.com:4444 'echo $_SERVER["SERVER_PORT"];'
4444

$ cv ev --url=https://example.com:4444 'echo $_SERVER["HTTPS"];'
on
```

By setting these server-variables, we should give better hints to any URL-generating functions in CMS or Civi.

The older options `--cms-base-url` and `--hostname` are retained as unpublicized aliases. The new `--url` option is the combined+expanded replacement.

Example Problem
------------------

In https://github.com/civicrm/civicrm-core/pull/31271, @seamuslee001 mentions the use-case where one installs a WordPress site with an HTTPS address:

```bash
cv core:install --cms-base-url='https://example.com/'
```

This URL is properly recorded in `CIVICRM_UF_BASEURL`. However, when calling APIs to generate URLs (such as WP's `plugin_dir_url()`), those functions may sometimes compose `http://` URLs _even though_ the user indicated that `https://` is valid. (And if `https://` is valid, then it really should be used.)

For `plugin_dir_url()`, the reason is that WP is inspecting the active request (`$_SERVER` and its properties, `HTTP_HOST`, `HTTPS`, `SERVER_PORT`, etc); these don't include any HTTPS flags, so we get basic HTTP.

It seems that we should provide stronger direction on how these server-vars behave in CLI context.

Before
-------

* All `cv` commands accept input from `--hostname example.com` and env-var `HTTP_HOST=example.com`. 
    * These do feed into `$_SERVER`, but they don't indicate whether HTTPS is supported.
* In `cv core:install`, there is also an option `--cms-base-url` which accepts a fully formed URL. 
    * This conveys more information (including HTTPS), but it doesn't feed into `$_SERVER`.
* If you do not specify a URL via `--hostname` or `HTTP_HOST`, then `$_SERVER` is devoid of information about HTTP/SSL. Consequently, you are liable to emit `http://` URLs and `localhost` URLs.

After
-----

* The old options `--hostname` and `--cms-base-url` are deprecated. They function as aliases for `--url`.
* All `cv` commands accept input from  `--url` (`-l`) and env-vars `HTTP_HOST`, `HTTPS`, `SERVER_PORT`.
    * This feeds into `$_SERVER`, and it also indicates HTTPS support.
    * As before, you can give a bare hostname -- but you can also give a fully formed URL.

        ```bash
        cv ev 'echo $_SERVER["HTTP_HOST"];' --url=example.com
        cv ev 'echo $_SERVER["HTTP_HOST"];' --url=https://example.com
        cv ev 'echo $_SERVER["HTTP_HOST"];' --url=http://example.com
        ```

        If the given URL is `https://`, then you can expect most URL-composition to enable HTTPS.

        This works for `core:install` (CMS-first boot) and all regular commands (Civi-first or CMS-first boot).

    * The new option is shorter and easier to type. It also gives a nod to folks who use wp-cli or drush:
        | Cv Options | Similar To | Comments |
        | -- |-- |-- |
        | `cv --url=XXX` | `wp --url=XXX` | In vernacular speech, "URL" is common. |
        | `cv --uri=XXX` | `drush --uri=XXX`| Unpublicized alias. "URI" is less vernacular. |
        | `cv -l XXX`  | `drush -l XXX` | |

* If you do not specify `--url` (or similar env-vars), then the behavior varies:
    * If Civi boots first, then it populates `$_SERVER` using `CIVICRM_UF_BASEURL`. (*You will get HTTPS if the BASEURL has HTTPS.*)
    * If CMS boots first, then it populates `$_SERVER` using `http://localhost`. (This doesn't seem ideal -- it will still tend toward HTTP. But it is the status-quo, and it's trickier to find a fix.)