### PR TITLE
Plugins - Add 'basic-alias' and 'alias-cmd' to cv.phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -2,6 +2,7 @@
     "chmod": "0755",
     "directories": [
         "lib/src",
+        "lib/plugin",
         "src"
     ],
     "finder": [

--- a/lib/plugin/alias-cmd.php
+++ b/lib/plugin/alias-cmd.php
@@ -11,6 +11,7 @@ use Civi\Cv\BasicAliasPlugin\AliasFinder;
 
 use Civi\Cv\Command\CvCommand;
 use Civi\Cv\Cv;
+use Civi\Cv\Util\Filesystem;
 use Civi\Cv\Util\StructuredOutputTrait;
 use CvDeps\Symfony\Component\Console\Input\InputArgument;
 use CvDeps\Symfony\Component\Console\Output\OutputInterface;
@@ -157,14 +158,7 @@ class AliasAddCommand extends CvCommand {
       return is_dir($d) && is_writable($d);
     });
     $collections['viable'] = array_values(array_filter($collections['all'], function($d) {
-      $iter = $d;
-      while (dirname($iter) && dirname($iter) !== $iter) {
-        if (is_dir($iter) && is_writable($iter)) {
-          return TRUE;
-        }
-        $iter = dirname($iter);
-      }
-      return FALSE;
+      return Filesystem::isCreatable($d);
     }));
 
     foreach (['extant', 'viable'] as $type) {

--- a/lib/plugin/alias-cmd.php
+++ b/lib/plugin/alias-cmd.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * This plugin is a supplement for basic-alias. It adds CLI commands for managing the alias-files.
+ */
+
+// Plugin lives in a unique namespace
+namespace Civi\Cv\AliasCmdPlugin;
+
+use Civi\Cv\BasicAliasPlugin\AliasFinder;
+
+use Civi\Cv\Command\CvCommand;
+use Civi\Cv\Cv;
+use Civi\Cv\Util\StructuredOutputTrait;
+use CvDeps\Symfony\Component\Console\Input\InputArgument;
+
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
+  die("Expect CV_PLUGIN API v1");
+}
+
+Cv::dispatcher()->addListener('cv.app.commands', function($e) {
+  $e['commands'][] = new AliasListCommand();
+  $e['commands'][] = new AliasAddCommand();
+});
+
+class AliasListCommand extends CvCommand {
+  use StructuredOutputTrait;
+
+  protected function configure() {
+    $this
+      ->setName('alias:list')
+      ->setDescription('List any @aliases')
+      ->configureOutputOptions(['tabular' => TRUE, 'fallback' => 'table', 'defaultColumns' => 'name,type,config', 'shortcuts' => TRUE])
+      ->setBootOptions(['auto' => FALSE]);
+  }
+
+  protected function execute($input, $output): int {
+    $aliasEvent = Cv::filter(Cv::app()->getName() . ".app.site-alias.list", [
+      'aliases' => [],
+    ]);
+    $aliases = array_map(function($alias) {
+      return [
+        'name' => $alias['name'],
+        'type' => $alias['type'],
+        'config' => $alias['config'],
+      ];
+    }, $aliasEvent['aliases']);
+    $this->sendStandardTable($aliases);
+    return 0;
+  }
+
+}
+
+class AliasAddCommand extends CvCommand {
+
+  protected function configure() {
+    $this
+      ->setName('alias:add')
+      ->addArgument('name', InputArgument::OPTIONAL, 'Alias name')
+      ->addArgument('path', InputArgument::OPTIONAL, 'Local path to the instance (web-root)')
+      ->setDescription('Interactively create a new @alias')
+      ->setBootOptions(['auto' => FALSE]);
+  }
+
+  protected function execute($input, $output): int {
+    if (!class_exists(AliasFinder::class)) {
+      throw new \Exception("Cannot add new aliases without the \"basic-alias\" plugin.");
+    }
+
+    $answers['name'] = $this->askName();
+    $answers['path'] = $this->askPath();
+    $answers['mode'] = $this->askBootstrap($answers['path']);
+    $answers['settings'] = ($answers['mode'] === 'settings') ? $this->askSettings($answers['path']) : NULL;
+    if ($answers['mode'] !== 'settings' && $this->askMultisite($answers['path'])) {
+      $answers['url'] = $this->askUrl($answers['name'], $answers['path']);
+    }
+    $answers['user'] = $this->askUser($answers['name']);
+
+    $this->writeInfo($this->askAliasFile($answers['name'] . '.json'), $this->createInfo($answers));
+    return 0;
+  }
+
+  protected function writeInfo(string $outputFile, array $info): void {
+    $infoJson = json_encode($info, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";
+
+    $parent = dirname($outputFile);
+    if (!is_dir($parent)) {
+      mkdir($parent, 0777, TRUE);
+    }
+    file_put_contents($outputFile, $infoJson);
+  }
+
+  protected function createInfo(array $answers) {
+    extract($answers);
+
+    $info = [];
+    $modeMap = [
+      'auto' => 'Auto://',
+      'standalone' => 'Standalone://',
+      'backdrop' => 'Backdrop://',
+      'drupal' => 'Drupal8://',
+      'drupal7' => 'Drupal://',
+      'joomla' => 'Joomla://',
+      'wordpress' => 'WordPress://',
+    ];
+    if (isset($modeMap[$answers['mode']])) {
+      $info['env']['CIVICRM_BOOT'] = $modeMap[$answers['mode']] . ltrim($answers['path'], '/' . DIRECTORY_SEPARATOR);
+    }
+    elseif ($answers['mode'] === 'settings') {
+      $info['env']['CIVICRM_SETTINGS'] = $answers['settings'];
+      $info['options']['cwd'] = $answers['path'];
+    }
+
+    if (!empty($answers['url'])) {
+      $info['options']['url'] = $answers['url'];
+    }
+    if (!empty($answers['user'])) {
+      $info['options']['user'] = $answers['user'];
+    }
+    return $info;
+  }
+
+  protected function askAliasFile(string $entry): string {
+    Cv::io()->section('Save alias info');
+
+    $collections['all'] = AliasFinder::getFolders();
+    $collections['extant'] = array_filter($collections['all'], function($d) {
+      return is_dir($d) && is_writable($d);
+    });
+    $collections['viable'] = array_values(array_filter($collections['all'], function($d) {
+      $iter = $d;
+      while (dirname($iter) && dirname($iter) !== $iter) {
+        if (is_dir($iter) && is_writable($iter)) {
+          return TRUE;
+        }
+        $iter = dirname($iter);
+      }
+      return FALSE;
+    }));
+
+    foreach (['extant', 'viable'] as $type) {
+      $options = array_values($collections[$type]);
+      foreach ($options as $option) {
+        if (file_exists("$option/$entry")) {
+          Cv::io()->info("Found existing alias entry: $option/$entry");
+          if (!Cv::io()->confirm('Overwrite existing file?')) {
+            throw new \Exception("Aborted. File already exists.");
+          }
+          return "$option/$entry";
+        }
+      }
+      if (count($options) === 1) {
+        Cv::io()->note("Found existing alias folder ({$options[0]})");
+        return $options[0] . "/$entry";
+      }
+      if (count($options) > 1) {
+        return Cv::io()->choice('Where should we store the alias entry?', $options) . "/$entry";
+      }
+    }
+    throw new \RuntimeException(sprintf("Failed to identify a viable folder for aliases. All candidates (%s) are unwritable.", implode(' ', $collections['all'])));
+  }
+
+  protected function askName(): string {
+    $validateName = function ($name): ?string {
+      $name = trim($name);
+      if (empty($name)) {
+        throw new \Exception("The alias name is required");
+      }
+      if (!preg_match('/^[a-zA-Z0-9\-]+$/', $name)) {
+        throw new \Exception("Malformed alias ($name). Use only alphanumerics and dashes.");
+      }
+      return $name;
+    };
+
+    Cv::io()->title('Site Aliases: Add new');
+    if ($name = Cv::input()->getArgument('name')) {
+      $name = $validateName($name);
+      Cv::io()->writeln("<info>Alias-name</info>: $name");
+    }
+    else {
+      Cv::io()->section('Configure alias-name');
+      Cv::io()->info([
+        'The alias is a short nickname to identify your CiviCRM instance. It allows you to construct shorter commands.',
+        'For example, if you choose the alias "wombatcrm", then you can construct commands like:',
+        '$ cv @wombatcrm status',
+      ]);
+      $name = Cv::io()->ask('Alias-name (required)', NULL, $validateName);
+    }
+    return $name;
+  }
+
+  protected function askPath(): string {
+    $validatePath = function ($path): ?string {
+      $path = trim($path);
+      $path = rtrim($path, '/' . DIRECTORY_SEPARATOR);
+      if (!is_dir($path)) {
+        throw new \Exception("The path ($path) is not valid.");
+      }
+      return $path;
+    };
+
+    if ($path = Cv::input()->getArgument('path')) {
+      $path = $validatePath($path);
+      Cv::io()->writeln("<info>Root-path</info>: $path");
+    }
+    else {
+      Cv::io()->section('Configure root-path');
+      Cv::io()->info('The root-path identifies the source-tree (web-root) that includes CiviCRM.');
+      $path = Cv::io()->ask('Root-path (required)', getcwd(), $validatePath);
+    }
+    return $path;
+  }
+
+  protected function askBootstrap(string $path): string {
+    Cv::io()->section('Configure bootstrap mode');
+    Cv::io()->info([
+      "CiviCRM may run as a standalone application or as an add-on with another application (such as Drupal or WordPress).",
+      "cv needs to determine which kind of application lives in $path.",
+      "This can often be done automatically. However, some systems work better with manual options. For example, if you have created symlinks, or if you have rearranged the folders in WordPress, then use manual.",
+    ]);
+    $choice = Cv::io()->choice('Bootstrap mode', [
+      'auto' => 'Identify the system automatically (using file-layout)',
+      'manual' => 'Manually specify the system type.',
+      'settings' => 'Identify the system by reading "civicrm.settings.php" (legacy)',
+      // The 'auto' and 'manual' options are more representative of HTTP lifecycle, and they can preserve current CWD.
+      // However, 'settings' is closer to the actual default behavior.
+    ], 'auto');
+
+    if ($choice !== 'manual') {
+      return $choice;
+    }
+    else {
+      return Cv::io()->choice('Application type', [
+        'standalone' => 'CiviCRM-Standalone',
+        'backdrop' => 'Backdrop with CiviCRM',
+        'drupal' => 'Drupal (8/9/10/11) with CiviCRM',
+        'drupal7' => 'Drupal (7) with CiviCRM',
+        'joomla' => 'Joomla with CiviCRM',
+        'wordpress' => 'WordPress with CiviCRM',
+      ]);
+    }
+  }
+
+  protected function askMultisite(string $path): bool {
+    Cv::io()->section('Configure multi-site options?');
+    Cv::io()->info([
+      'In single-site installations, CiviCRM has one codebase, one database, and one URL.',
+      'In multi-site installations, the codebase may be re-used with multiple databases and/or multiple URLs. This may require extra options.',
+    ]);
+    return Cv::io()->confirm("Does <comment>$path</comment> require multi-site options?", FALSE);
+  }
+
+  protected function askSettings(string $path): string {
+    $validateSettings = function ($settings): ?string {
+      $settings = trim($settings);
+      if (empty($settings)) {
+        throw new \Exception("The settings path is required");
+      }
+      if (!file_exists($settings) || !is_readable($settings)) {
+        throw new \Exception("The settings path ($settings) is not valid.");
+      }
+      return $settings;
+    };
+
+    Cv::io()->section("Configure settings path");
+
+    Cv::io()->info("To use this bootstrap option, we must choose a settings file. Let's search for some candidates.");
+    Cv::io()->writeln('Searching...');
+
+    $settingsFiles = [];
+    $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path));
+    foreach ($iterator as $file) {
+      if ($file->getFilename() === 'civicrm.settings.php') {
+        $settingsFiles[] = $file->getPathname();
+      }
+    }
+    switch (count($settingsFiles)) {
+      case 0:
+        throw new \Exception(sprintf('In "%s", we could not find any files named "%s". This may indicate an incorrect path or other misconfiguration.', $path, 'civicrm.settings.php'));
+
+      case 1:
+        Cv::io()->info('We found 1 file which appears to be suitable:');
+        Cv::io()->listing($settingsFiles);
+        return $settingsFiles[0];
+
+      default:
+        sort($settingsFiles);
+        Cv::io()->info('We found ' . count($settingsFiles) . ' files which appear to be suitable:');
+        Cv::io()->listing($settingsFiles);
+        return Cv::io()->ask('Settings file', NULL, $validateSettings);
+    }
+  }
+
+  protected function askUrl(string $name, string $path): string {
+    $validateUrl = function($url): ?string {
+      $url = trim($url);
+      if (empty($url)) {
+        throw new \Exception("The URL is required for multi-site mode.");
+      }
+
+      $parsed = parse_url($url);
+      if (empty($parsed['scheme']) || empty($parsed['host'])) {
+        throw new \Exception("The URL must specify a scheme and hostname, such as \"https://example.com\"");
+      }
+      if (!in_array($parsed['scheme'], ['http', 'https'])) {
+        throw new \Exception("The only supported URL schemes are \"http\" and \"https\"");
+      }
+      return $url;
+    };
+    Cv::io()->section('Configure multi-site options: Web URL');
+    Cv::io()->info([
+      "Each CiviCRM instance can be identified by its web URL. Which URL should be associated with \"@{$name}\"?",
+      "Example: https://sub-site-123.example.com/",
+    ]);
+    return Cv::io()->ask('Web URL', NULL, $validateUrl);
+  }
+
+  protected function askUser(string $name): ?string {
+    Cv::io()->section('Configure default user (OPTIONAL)');
+    Cv::io()->info([
+      "In the CiviCRM CLI, -most- commands execute as the system (with super-privileges).",
+      "However, -some- CLI commands may involve a CiviCRM user.",
+      "To handle these commands automatically, specify the default user for \"@{$name}\".",
+    ]);
+    return trim(Cv::io()->ask('Default user (optional)'));
+  }
+
+}

--- a/lib/plugin/basic-alias.php
+++ b/lib/plugin/basic-alias.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * This plugin adds support for site-aliases in CiviCRM's `cv` tool.
+ *
+ * == INSTALLATION ==
+ *
+ * Put this file in ~/.cv/plugin/ or /etc/cv/plugin
+ *
+ * == USAGE ==
+ *
+ * In ~/.cv/alias/, create a file MYSITE.yaml. If your system doesn't support php-yaml, use JSON.
+ *
+ * == EXAMPLE FILE ==
+ *
+ * ```yaml
+ * ## Connect to a remote server
+ * remote_command: ssh webuser@server.com
+ *
+ * ## Use a specific copy of cv
+ * cv_command: /usr/local/bin/cv
+ *
+ * ## Set some environment variables
+ * env:
+ *   CIVICRM_BOOT: "WordPress://srv/www/wpmaster/web"
+ *   HTTP_HOST: "example.com"
+ *
+ * ## Pass some extra options like `--user=admin`
+ * options:
+ *   user: "admin"
+ * ```
+ */
+
+// Plugin lives in a unique namespace
+namespace Civi\Cv\BasicAliasPlugin;
+
+use Civi\Cv\Cv;
+use Civi\Cv\CvEvent;
+use CvDeps\Symfony\Component\Console\Output\OutputInterface;
+
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) die("Expect CV_PLUGIN API v1");
+
+Cv::dispatcher()->addListener('*.app.site-alias', function(CvEvent $event) {
+  foreach (AliasFinder::find($event['alias']) as $file) {
+    $config = AliasFinder::read($file);
+    ShellAliasHandler::setup($event, $config);
+  }
+});
+
+/**
+ * Find and read alias configurations.
+ */
+class AliasFinder {
+  public static function find(string $nameOrWildcard): iterable {
+    yield from [];
+    $dirs = array_map('dirname', Cv::plugins()->getPaths());
+    foreach ($dirs as $dir) {
+      foreach (['yaml', 'json'] as $type) {
+        $pat = "$dir/alias/$nameOrWildcard.$type";
+        $files = (array) glob($pat);
+        foreach ($files as $file) {
+          yield $file;
+        }
+      }
+    }
+  }
+  public static function read(string $file): array {
+    if (preg_match(';\.ya?ml$;', $file)) {
+      if (!is_callable('yaml_parse')) {
+        throw new \RuntimeException("Cannot load $file. Missing yaml_parse().");
+      }
+      $parsed = yaml_parse(file_get_contents($file));
+    }
+    elseif (preg_match(';\.json$;', $file)) {
+      $parsed = json_decode(file_get_contents($file), 1);
+    }
+    else {
+      throw new \RuntimeException("Unrecognized alias file type: $file");
+    }
+
+    if (empty($parsed) || !is_array($parsed)) {
+      throw new \RuntimeException("Alias file ($file) appears invalid");
+    }
+    return $parsed;
+  }
+}
+
+class ShellAliasHandler {
+
+  /**
+   * Read the configuration options from JSON/YAML. Update the $event['transport'].
+   */
+  public static function setup(CvEvent $event, array $config): void {
+    /** @var \Civi\Cv\Util\CvArgvInput $input */
+    $input = $event['input'];
+    /** @var \CvDeps\Symfony\Component\Console\Output\OutputInterface $output */
+    $output = $event['output'];
+    $isRemote = !empty($config['remote_command']);
+    $localCvBin = $input->getOriginalArgv()[0];
+
+    $defaultConfig = [
+      'env' => [],
+      'options' => [],
+      'cv_command' => $isRemote ? 'cv' : $localCvBin,
+    ];
+    $config = array_merge($defaultConfig, $config);
+
+    $cvCommand = array_merge(static::cvCommand($config), static::passthruArgs($input->getOriginalArgv()));
+    if ($isRemote) {
+      $fullCommand = $config['remote_command'] . ' bash -c ' . escapeshellarg(implode(' ', $cvCommand));
+    }
+    else {
+      $fullCommand = '( ' . implode(' ', $cvCommand) . ' )';
+    }
+
+    $event['transport'] = function() use ($input, $output, $fullCommand) {
+      if ($output->isVeryVerbose()) {
+        $output->write('<info>Found alias. Run subcommand:</info> ');
+        $output->writeln($fullCommand, OutputInterface::OUTPUT_RAW);
+      }
+      // echo "TODO call passthru\n";
+      static::passthru($fullCommand);
+    };
+  }
+
+  public static function cvCommand(array $config): array {
+    $result = [];
+    if (!empty($config['env'])) {
+      foreach ($config['env'] as $key => $value) {
+        $result[] = "$key=" . escapeString($value);
+      }
+      // This technique allows things like "
+      $result[] = sprintf('; export %s;', implode(' ', array_keys($config['env'])));
+    }
+
+    $result[] = $config['cv_command'];
+    foreach ($config['options'] ?? [] as $key => $value) {
+      if ($value === NULL) {
+        $result[] = escapeString("--$key");
+      }
+      else {
+        $result[] = escapeString("--$key=$value");
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * Figure out which arguments to pass-thru to subcommand.
+   *
+   * @param array $rawArgs
+   * @return array
+   */
+  public static function passthruArgs(array $rawArgs): array {
+    array_shift($rawArgs); /* ignore program name */
+
+    $result = [];
+    while (count($rawArgs)) {
+      $rawArg = array_shift($rawArgs);
+      if ($rawArg === '--site-alias') {
+        // Ignore next part
+        array_shift($rawArgs);
+      }
+      elseif (strpos($rawArg, '--site-alias=') === 0) {
+        // ignore
+      }
+      else {
+        $result[] = escapeString($rawArg);
+      }
+    }
+    return $result;
+  }
+
+  public static function passthru(string $command): int {
+    $process = proc_open(
+      $command,
+      [0 => STDIN, 1 => STDOUT, 2 => STDERR],
+      $pipes
+    );
+    return proc_close($process);
+  }
+}
+
+
+
+function escapeString(string $expr): string {
+  return preg_match('{^[\w=-]+$}', $expr) ? $expr : escapeshellarg($expr);
+}

--- a/lib/plugin/basic-alias.php
+++ b/lib/plugin/basic-alias.php
@@ -82,9 +82,9 @@ class AliasFinder {
   }
 
   public static function getFolders(): array {
-    $dirs = [];
-    foreach (Cv::plugins()->getPaths() as $pluginDir) {
-      $dirs[] = dirname($pluginDir) . '/alias';
+    $dirs = ['/etc/cv/alias', '/usr/local/share/cv/alias', '/usr/share/cv/alias'];
+    if (getenv('HOME')) {
+      array_unshift($dirs, getenv('HOME') . '/.cv/alias');
     }
     return $dirs;
   }

--- a/lib/plugin/basic-alias.php
+++ b/lib/plugin/basic-alias.php
@@ -38,7 +38,9 @@ use Civi\Cv\Cv;
 use Civi\Cv\CvEvent;
 use CvDeps\Symfony\Component\Console\Output\OutputInterface;
 
-if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) die("Expect CV_PLUGIN API v1");
+if (empty($CV_PLUGIN['protocol']) || $CV_PLUGIN['protocol'] > 1) {
+  die("Expect CV_PLUGIN API v1");
+}
 
 Cv::dispatcher()->addListener('*.app.site-alias', function(CvEvent $event) {
   foreach (AliasFinder::find($event['alias']) as $file) {
@@ -51,6 +53,7 @@ Cv::dispatcher()->addListener('*.app.site-alias', function(CvEvent $event) {
  * Find and read alias configurations.
  */
 class AliasFinder {
+
   public static function find(string $nameOrWildcard): iterable {
     yield from [];
     $dirs = array_map('dirname', Cv::plugins()->getPaths());
@@ -64,6 +67,7 @@ class AliasFinder {
       }
     }
   }
+
   public static function read(string $file): array {
     if (preg_match(';\.ya?ml$;', $file)) {
       if (!is_callable('yaml_parse')) {
@@ -83,6 +87,7 @@ class AliasFinder {
     }
     return $parsed;
   }
+
 }
 
 class ShellAliasHandler {
@@ -180,9 +185,8 @@ class ShellAliasHandler {
     );
     return proc_close($process);
   }
+
 }
-
-
 
 function escapeString(string $expr): string {
   return preg_match('{^[\w=-]+$}', $expr) ? $expr : escapeshellarg($expr);

--- a/lib/plugin/basic-alias.php
+++ b/lib/plugin/basic-alias.php
@@ -86,6 +86,9 @@ class AliasFinder {
     if (getenv('HOME')) {
       array_unshift($dirs, getenv('HOME') . '/.cv/alias');
     }
+    elseif (getenv('USERPROFILE')) {
+      array_unshift($dirs, getenv('USERPROFILE') . '/.cv/alias');
+    }
     return $dirs;
   }
 

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -33,7 +33,7 @@ class CvPlugins {
     }
 
     // Always load internal plugins
-    $this->paths[] = dirname(__DIR__) . '/plugin';
+    $this->paths['builtin'] = dirname(__DIR__) . '/plugin';
 
     $this->plugins = [];
     foreach ($this->paths as $path) {

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -38,7 +38,7 @@ class CvPlugins {
     $this->plugins = [];
     foreach ($this->paths as $path) {
       if (file_exists($path) && is_dir($path)) {
-        foreach ((array) glob("$path/*.php") as $file) {
+        foreach ($this->findFiles($path, '/\.php$/') as $file) {
           $pluginName = preg_replace(';(\d+-)?(.*)(@\w+)?\.php;', '\\2', basename($file));
           if ($pluginName === basename($file)) {
             throw new \RuntimeException("Malformed plugin name: $file");
@@ -89,6 +89,14 @@ class CvPlugins {
    */
   public function getPlugins(): array {
     return $this->plugins;
+  }
+
+  private function findFiles(string $path, string $regex): array {
+    // NOTE: scandir() works better than glob() in PHAR context.
+    $files = preg_grep($regex, scandir($path));
+    return array_map(function ($f) use ($path) {
+      return "$path/$f";
+    }, $files);
   }
 
 }

--- a/lib/src/CvPlugins.php
+++ b/lib/src/CvPlugins.php
@@ -30,6 +30,9 @@ class CvPlugins {
       if (getenv('HOME')) {
         array_unshift($this->paths, getenv('HOME') . '/.cv/plugin');
       }
+      elseif (getenv('USERPROFILE')) {
+        array_unshift($this->paths, getenv('USERPROFILE') . '/.cv/plugin');
+      }
     }
 
     // Always load internal plugins

--- a/lib/src/Util/Filesystem.php
+++ b/lib/src/Util/Filesystem.php
@@ -10,6 +10,32 @@ class Filesystem {
   }
 
   /**
+   * Determine whether the given $path can be created.
+   *
+   * It does not matter if the parent exists already (if the parent is creatable).
+   *
+   * It only matters if we have sufficient write access to some ancestor.
+   *
+   * @param string $path
+   *   The file that you would like to create.
+   * @return bool
+   */
+  public static function isCreatable(string $path): bool {
+    if (file_exists($path)) {
+      return is_writable($path);
+    }
+
+    $iter = $path;
+    while (!empty($iter) && dirname($iter) !== $iter) {
+      if (file_exists($iter)) {
+        return is_dir($iter) && is_writable($iter);
+      }
+      $iter = dirname($iter);
+    }
+    return FALSE;
+  }
+
+  /**
    * @return false|string
    */
   public function pwd() {

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -3,6 +3,7 @@
 namespace Civi\Cv\Command;
 
 use Civi\Cv\Application;
+use Civi\Cv\Cv;
 use Civi\Cv\Util\StructuredOutputTrait;
 use Civi\Test\Invasive;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,6 +49,9 @@ class StatusCommand extends CvCommand {
     $data['summary'] = $summaryCode;
     $data['civicrm'] = $this->longCivi($civiCodeVer, $civiDbVer);
     $data['cv'] = Application::version() . ($isPhar ? ' (phar)' : ' (src)');
+    if ($plugins = Cv::plugins()->getPlugins()) {
+      $data['cv plugins'] = sprintf("%dx (%s)", count($plugins), implode(', ', array_keys($plugins)));
+    }
     $data['php'] = $this->longPhp();
     $data['mysql'] = $mysqlVersion;
     $data[$ufType] = $ufVer;
@@ -222,6 +226,13 @@ class StatusCommand extends CvCommand {
     // Oddballs
     $urlList['url: CIVICRM_UF_BASEURL'] = \CRM_Utils_Constant::value('CIVICRM_UF_BASEURL');
     $pathList['path: extensionsDir'] = \CRM_Core_Config::singleton()->extensionsDir;
+    if ($output->isVerbose() && $pluginPaths = Cv::plugins()->getPaths()) {
+      $parts = [];
+      foreach ($pluginPaths as $key => $pluginPath) {
+        $parts[] = "[$key] $pluginPath";
+      }
+      $pathList['path: CV_PLUGIN_PATH'] = implode("\n", $parts);
+    }
 
     asort($pathList);
     asort($urlList);

--- a/src/Util/StructuredOutputTrait.php
+++ b/src/Util/StructuredOutputTrait.php
@@ -182,7 +182,7 @@ trait StructuredOutputTrait {
                 return '';
               }
               elseif (is_array($value)) {
-                return json_encode($value);
+                return json_encode($value, JSON_UNESCAPED_SLASHES);
               }
               elseif (is_object($value)) {
                 return '(' . get_class($value) . ')';


### PR DESCRIPTION
Overview
----------

Site aliases allow you run a `cv` subcommand on a particular site without manually navigating through the filesystem. Compare:

```bash
## Explicitly navigate the filesystem
cd /home/myuser/projects/wombat.org/web && cv api4 Contact.get

## Explicitly use SSH, navigate the filesystem and set various boot options
ssh server.wombat.org
cd /home/myuser/projects/wombat.org/web
cv api4 Contact.get \
  --url='https://www.wombat.org/' \
  --level=cms-first \
  --user=admin

## Use an alias
cv @wombat api4 Contact.get
```

In the last example, it uses an alias (`@wombat`). The alias can define all these options (path, URL, etc) so that you don't need to type them into every command.

This functionality was previously demonstrated by implementing  the [`basic-alias` plugin](https://gist.github.com/totten/8241b80440221555c0051d4f3447fa40) that was published via gist, but this is fairly obscure. This PR adds `basic-alias` plugin as a built-in feature, and it also introduces a complementary plugin (`alias-cmd`) for managing aliases via CLI.

Before
-------

* You can manually define bootstrap options like `cd`, `--cwd`, `--user`, `--url`.

* You can download the alias plugin and create alias-files by hand.

After
-----

There is a built-in alias-plugin and helper commands.

To define a new alias, run the `alias:add` command:

```bash
## Start an interactive questionnaire
$ cv alias:add

## As above, but pre-fill some of the answers
$ cv alias:add wpmaster /var/www/wpmaster/web
```

This will ask questions about remote (SSH), multisite (base URL), default user-name, etc. It will ultimately create a file (such as `$HOME/.cv/alias/wpmaster.json`).

Similarly, you can browse available aliases:

```bash
cv alias:list
```
```
+----------+-------+---------------------------------------+
| name     | type  | config                                |
+----------+-------+---------------------------------------+
| dmaster  | basic | /Users/totten/.cv/alias/dmaster.json  |
| wpmaster | basic | /Users/totten/.cv/alias/wpmaster.json |
+----------+-------+---------------------------------------+
```

Finally, you can run commands with the alias, as in:

```bash
cv @wpmaster status
cv @wpmaster ext:list -Li
```

Comments
-----------

There's a sample build at https://think.hm/tmp/cv-aliases-2025-02-26-0.phar.

The general reason why `basic-alias` is a plugin is that it would be handy to make new variations on the functionality. There's a lot of subjectivity in what features should be provided for aliases. For example:

* If you use `civibuild`, then you might want to automatically recognize aliases for all `BUILDKIT/build/*.sh` files.
* If you want contextual aliases within a build (`@staging`, `@prod`), then you need to seek-out a context-sensitive config-file.

In any case, the absence of a reference-implementation makes the whole thing seem esoteric.

With this approach, we can kind of have it both ways:

* There is a default/out-of-the-box/concrete option for site-aliases.
* The default option is structured as a plugin -- so the wiring is plugin-friendly, and it can be adapted to other techniques.