### PR TITLE
ConsoleQueueRunner - Fix some warnings

### DIFF
--- a/src/Util/ConsoleQueueRunner.php
+++ b/src/Util/ConsoleQueueRunner.php
@@ -107,10 +107,9 @@ class ConsoleQueueRunner {
   }
 
   protected static function formatTaskCallback(\CRM_Queue_Task $task) {
-    return sprintf("%s(%s)",
-      implode('::', (array) $task->callback),
-      implode(',', $task->arguments)
-    );
+    $cb = implode('::', (array) $task->callback);
+    $args = json_encode($task->arguments, JSON_UNESCAPED_SLASHES);
+    return sprintf("%s(%s)", $cb, substr($args, 1, -1));
   }
 
 }


### PR DESCRIPTION
Depending on the mix of upgrade-tasks and verbosity-flag, the console may sometimes print warnings when it tries to describe a pending queue task. (esp when the task arguments include nested arrays)