### PR TITLE
(dev/core#5700) `cv dl` - Split download substeps. Fix upgrades of EFv1=>EFv2.

### DIFF
--- a/bin/cv
+++ b/bin/cv
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+define('CV_BIN', __FILE__);
 ini_set('display_errors', 'stderr');
 if (PHP_SAPI !== 'cli') {
   printf("cv is a command-line tool. It is designed to run with PHP_SAPI \"%s\". The active PHP_SAPI is \"%s\".\n", 'cli', PHP_SAPI);

--- a/bin/cv
+++ b/bin/cv
@@ -1,6 +1,9 @@
 #!/usr/bin/env php
 <?php
 define('CV_BIN', __FILE__);
+putenv('BOX_REQUIREMENT_CHECKER=0');
+// ^^ If we make a recursive call to `cv.phar -vvv`, then do NOT reprint the box requirements-check.
+
 ini_set('display_errors', 'stderr');
 if (PHP_SAPI !== 'cli') {
   printf("cv is a command-line tool. It is designed to run with PHP_SAPI \"%s\". The active PHP_SAPI is \"%s\".\n", 'cli', PHP_SAPI);

--- a/lib/src/Top.php
+++ b/lib/src/Top.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Civi\Cv;
+
+class Top {
+
+  /**
+   * @var string|null
+   */
+  private static $prefixRegex;
+
+  /**
+   * Call a top-level function or method
+   *
+   * @param string|string[] $callable
+   *   Ex: 'drupal_bootstrap'
+   *   Ex: '\drupal_bootstrap'
+   *   Ex: ['Drupal', 'service']
+   *   Note: All symbols are implicitly relative to top-level namespace.
+   * @param mixed[] $args
+   * @return mixed
+   */
+  public static function call($callable, ...$args) {
+    $callable = static::symbol($callable);
+    return call_user_func_array($callable, $args);
+  }
+
+  /**
+   * Instantiate an object (based on the top-level classname).
+   *
+   * @param string $class
+   *   Ex: 'Symfony\Contracts\EventDispatcher\EventDispatcher'
+   *   Ex: '\Symfony\Contracts\EventDispatcher\EventDispatcher'
+   *   Note: All symbols are implicitly relative to top-level namespace.
+   * @param mixed[] $args
+   * @return object
+   */
+  public static function create($class, ...$args) {
+    $class = static::symbol($class);
+    return new $class(...$args);
+  }
+
+  /**
+   * Evaluate a symbol, returning the top-level version of that symbol.
+   *
+   * @param string|string[] $symbol
+   *   Ex: 'Drupal', '\Symfony', ['\Drupal', 'service'], 'Drupal::service'
+   * @return string|string[]
+   *   The same symbol, ut without any php-scoper prefixes.
+   */
+  public static function symbol($symbol) {
+    if (is_string($symbol)) {
+      // Translate function or class
+      if (static::$prefixRegex === NULL) {
+        static::$prefixRegex = static::createPrefixRegex();
+      }
+      $result = preg_replace(static::$prefixRegex, '\\', $symbol);
+      if ($result[0] !== '\\') {
+        $result = '\\' . $result;
+      }
+      return $result;
+    }
+    elseif (is_array($symbol)) {
+      // Translate class
+      $symbol[0] = static::symbol($symbol[0]);
+      return $symbol;
+    }
+    else {
+      return $symbol;
+    }
+  }
+
+  /**
+   * Build a string to match the php-scoper prefix.
+   *
+   * @return string
+   */
+  protected static function createPrefixRegex(): string {
+    $parts = explode('\\', \Path\To\Dummy::class);
+    $topNS = $parts[0];
+
+    // Are we running in a scoped PHAR?
+    if ($topNS[0] === '_' || substr($topNS, -4) === 'Phar' || substr($topNS, -4) === 'phar') {
+      // In `box`+`php-scoper`, default prefix is dynamic value like '_HumbugXYZ'.
+      // Most of my projects use an explicit prefix like 'MyAppPhar'
+      return ';^\\\?' . preg_quote($parts[0], ';') . '\\\;';
+    }
+    else {
+      return ';^\\\;';
+    }
+  }
+
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -87,6 +87,7 @@ class Application extends BaseApplication {
       $commands[] = new \Civi\Cv\Command\CoreCheckReqCommand();
       $commands[] = new \Civi\Cv\Command\CoreInstallCommand();
       $commands[] = new \Civi\Cv\Command\CoreUninstallCommand();
+      $commands[] = new \Civi\Cv\Command\QueueNextCommand();
       $commands[] = new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand();
     }
     return $commands;

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -3,6 +3,7 @@ namespace Civi\Cv\Command;
 
 use Civi\Cv\Cv;
 use Civi\Cv\Exception\QueueTaskException;
+use Civi\Cv\ExtensionPolyfill\PfQueueDownloader;
 use Civi\Cv\Util\ConsoleSubprocessQueueRunner;
 use Civi\Cv\Util\ExtensionTrait;
 use Civi\Cv\Util\Filesystem;
@@ -212,12 +213,14 @@ Note:
     $reloadQueueSpec = array_merge($queueSpec, ['reset' => FALSE]);
     $queue = \CRM_Queue_Service::singleton()->create($newQueueSpec);
 
-    if (class_exists('CRM_Extension_QueueTasks')) {
+    if (class_exists('CRM_Extension_QueueDownloader') && class_exists('CRM_Extension_QueueTasks')) {
+      // Note: 6.1.0 has QueueDownloader but an insufficient signature. Presence of QueueTasks correlates with revised signature (6.1.1-ish).
       $downloader = new \CRM_Extension_QueueDownloader(TRUE, $queue);
       $runner = new ConsoleSubprocessQueueRunner(Cv::io(), $reloadQueueSpec, Cv::input()->getOption('dry-run'), Cv::input()->getOption('step'));
     }
     else {
-      throw new \Exception("TODO: Implement polyfill for CRM_Extension_QueueDownloader");
+      $downloader = new PfQueueDownloader(TRUE, $queue);
+      $runner = new ConsoleSubprocessQueueRunner(Cv::io(), $reloadQueueSpec, Cv::input()->getOption('dry-run'), Cv::input()->getOption('step'));
     }
 
     $batch = NULL;

--- a/src/Command/ExtensionDownloadCommand.php
+++ b/src/Command/ExtensionDownloadCommand.php
@@ -1,6 +1,9 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Cv;
+use Civi\Cv\Exception\QueueTaskException;
+use Civi\Cv\Util\ConsoleSubprocessQueueRunner;
 use Civi\Cv\Util\ExtensionTrait;
 use Civi\Cv\Util\Filesystem;
 use Civi\Cv\Util\HeadlessDownloader;
@@ -33,6 +36,8 @@ class ExtensionDownloadCommand extends CvCommand {
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'If an extension already exists, download it anyway.')
       ->addOption('to', NULL, InputOption::VALUE_OPTIONAL, 'Download to a specific directory (absolute path).')
       ->addOption('keep', 'k', InputOption::VALUE_NONE, 'If an extension already exists, keep it.')
+      ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Preview the list of tasks')
+      ->addOption('step', NULL, InputOption::VALUE_NONE, 'Run the tasks in steps, pausing before each step')
       ->addArgument('key-or-name', InputArgument::IS_ARRAY, 'One or more extensions to enable. Identify the extension by full key ("org.example.foobar") or short name ("foobar"). Optionally append a URL.')
       ->setHelp('Download and enable an extension
 
@@ -67,6 +72,9 @@ Note:
     if ($input->hasOption('bare') && $input->getOption('bare')) {
       $input->setOption('level', 'none');
       $input->setOption('no-install', TRUE);
+      if (empty($input->getOption('to'))) {
+        throw new \LogicException("If --bare is specified, then --to must also be specified.");
+      }
     }
     if ($extRepoUrl = $this->parseRepoUrl($input)) {
       global $civicrm_setting;
@@ -76,6 +84,12 @@ Note:
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
+    if ($input->getOption('step')) {
+      if ($output->getVerbosity() < OutputInterface::VERBOSITY_VERY_VERBOSE) {
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+      }
+    }
+
     $fs = new Filesystem();
 
     if ($input->getOption('to') && !$fs->isAbsolutePath($input->getOption('to'))) {
@@ -100,7 +114,7 @@ Note:
         }
       }
 
-      [$downloads, $errors] = $this->parseDownloads($input);
+      [$requestedDownloads, $errors] = $this->parseDownloads($input);
       if ($refresh == 'auto' && !empty($errors)) {
         $output->writeln("<info>Extension cache does not contain requested item(s)</info>");
         $refresh = 'yes';
@@ -115,59 +129,165 @@ Note:
         $output->getErrorOutput()->writeln("<error>$error</error>");
       }
       $output->getErrorOutput()->writeln("<comment>Tip: To customize the feed, review options in \"cv {$input->getFirstArgument()} --help\"");
-      $output->getErrorOutput()->writeln("<comment>Tip: To browse available downloads, run \"cv ext:list -R\"</comment>");
+      $output->getErrorOutput()->writeln("<comment>Tip: To browse available requestedDownloads, run \"cv ext:list -R\"</comment>");
       return 1;
     }
 
-    if ($input->getOption('to') && count($downloads) > 1) {
+    if ($input->getOption('to') && count($requestedDownloads) > 1) {
       throw new \RuntimeException("When specifying --to, you can only download one extension at a time.");
     }
+    elseif (empty($requestedDownloads)) {
+      Cv::output()->writeln('Nothing to do.');
+      return 0;
+    }
+    elseif ($input->getOption('bare')) {
+      return $this->executeWithBare($requestedDownloads);
+    }
+    else {
+      return $this->executeWithQueue($requestedDownloads);
+    }
+  }
 
-    foreach ($downloads as $key => $url) {
-      $action = $this->pickAction($input, $output, $key);
+  /**
+   * In a bare download, we don't have access to a copy of CiviCRM. This is useful
+   * if you want to grab a specific extension from a feed (before Civi is installed).
+   *
+   * Ex: cv dl -b "@https://civicrm.org/extdir/ver=$DM_VERSION/$SOME_EXT.xml" --to="$SOME_FOLDER"
+   *
+   * @param array $requestedDownloads
+   * @return int
+   */
+  protected function executeWithBare(array $requestedDownloads): int {
+    foreach ($requestedDownloads as $key => $url) {
+      $action = $this->pickAction(Cv::input(), Cv::output(), $key);
       switch ($action) {
         case 'download':
-          if ($to = $input->getOption('to')) {
-            $output->writeln("<info>Downloading extension \"$key\" ($url) to \"$to\"</info>");
+          if ($to = Cv::input()->getOption('to')) {
+            Cv::output()->writeln("<info>Downloading extension \"$key\" ($url) to \"$to\"</info>");
             $dl = new HeadlessDownloader();
-            $dl->run($url, $key, $input->getOption('to'), TRUE);
+            $dl->run($url, $key, Cv::input()->getOption('to'), TRUE);
           }
           else {
-            $output->writeln("<info>Downloading extension \"$key\" ($url)</info>");
-            $this->assertBooted();
-            $result = VerboseApi::callApi3Success('Extension', 'download', array(
-              'key' => $key,
-              'url' => $url,
-              'install' => !$input->getOption('no-install'),
-            ));
+            throw new \LogicException("Missing option --to");
           }
-          break;
-
-        case 'install':
-          $output->writeln("<info>Found extension \"$key\". Enabling.</info>");
-          $result = VerboseApi::callApi3Success('Extension', 'enable', array(
-            'key' => $key,
-          ));
           break;
 
         case 'abort':
-          $output->writeln("<error>Aborted</error>");
+          Cv::output()->writeln("<error>Aborted</error>");
           return 1;
 
+        case 'install':
         case 'skip':
-          $output->writeln("<comment>Skipped extension \"$key\".</comment>");
+          Cv::output()->writeln("<comment>Skipped extension \"$key\".</comment>");
           break;
 
         default:
           throw new \RuntimeException("Unrecognized action: $action");
       }
-
-      if (!empty($result['is_error'])) {
-        return 1;
-      }
     }
 
     return 0;
+  }
+
+  /**
+   * Perform a normal download. This may involve several steps, such as fetching a ZIP,
+   * extracting it, putting it inplace (replacing an old ext), flushing caches,
+   * running upgrades, etc.
+   *
+   * This runs in a queue, and each queue item is launched as a separate subprocess.
+   *
+   * @param array $requestedDownloads
+   * @return int
+   */
+  protected function executeWithQueue(array $requestedDownloads): int {
+    $this->assertBooted();
+
+    if (Cv::input()->getOption('to')) {
+      // FIXME
+      throw new \RuntimeException('Queued downloader does not currently support --to');
+    }
+
+    $queueSpec = $this->createQueueSpec();
+    $newQueueSpec = array_merge($queueSpec, ['reset' => TRUE]);
+    $reloadQueueSpec = array_merge($queueSpec, ['reset' => FALSE]);
+    $queue = \CRM_Queue_Service::singleton()->create($newQueueSpec);
+
+    if (class_exists('CRM_Extension_QueueTasks')) {
+      $downloader = new \CRM_Extension_QueueDownloader(TRUE, $queue);
+      $runner = new ConsoleSubprocessQueueRunner(Cv::io(), $reloadQueueSpec, Cv::input()->getOption('dry-run'), Cv::input()->getOption('step'));
+    }
+    else {
+      throw new \Exception("TODO: Implement polyfill for CRM_Extension_QueueDownloader");
+    }
+
+    $batch = NULL;
+    $updateBatch = function(?string $method, array $data) use (&$batch, $downloader) {
+      if ($batch === NULL) {
+        $batch = ['method' => $method, 'data' => $data];
+      }
+      elseif ($batch['method'] === $method) {
+        $batch['data'] = array_merge($batch['data'], $data);
+      }
+      else {
+        if ($batch['method'] === 'addDownloads') {
+          $downloader->addDownloads($batch['data'], !Cv::input()->getOption('no-install'));
+        }
+        elseif ($batch['method'] === 'addEnable') {
+          $downloader->addEnable($batch['data']);
+        }
+        else {
+          throw new \LogicException("Unrecognized method: $method");
+        }
+        $batch = ['method' => $method, 'data' => $data];
+      }
+    };
+
+    foreach ($requestedDownloads as $key => $url) {
+      $action = $this->pickAction(Cv::input(), Cv::output(), $key);
+      switch ($action) {
+        case 'download':
+          $updateBatch('addDownloads', [$key => $url]);
+          break;
+
+        case 'install':
+          $updateBatch('addEnable', [$key]);
+          break;
+
+        case 'abort':
+          Cv::output()->writeln("<error>Aborted</error>");
+          return 1;
+
+        case 'skip':
+          Cv::output()->writeln("<comment>Skipped extension \"$key\".</comment>");
+          break;
+
+        default:
+          throw new \RuntimeException("Unrecognized action: $action");
+      }
+    }
+
+    $updateBatch(NULL, []);
+    $downloader->fillQueue();
+    try {
+      $runner->runAll();
+      return 0;
+    }
+    catch (QueueTaskException $e) {
+      // The earlier handlers will output details.
+      return 1;
+    }
+  }
+
+  protected function createQueueSpec(): array {
+    return [
+      'name' => 'cli-ext-dl',
+      'type' => 'Sql',
+      'runner' => 'task',
+      'is_autorun' => FALSE,
+      'retry_limit' => 0,
+      'error' => 'abort',
+      'is_persistent' => FALSE,
+    ];
   }
 
   /**
@@ -318,7 +438,7 @@ Note:
       return 'download';
     }
     elseif ($input->getOption('keep')) {
-      return $input->getOptions('no-install') ? 'skip' : 'install';
+      return $input->getOption('no-install') ? 'skip' : 'install';
     }
     elseif ($input->getOption('force')) {
       return 'download';
@@ -339,7 +459,7 @@ Note:
           return 'download';
 
         case 'k':
-          return $input->getOptions('no-install') ? 'skip' : 'install';
+          return $input->getOption('no-install') ? 'skip' : 'install';
 
         case 'a':
         default:

--- a/src/Command/QueueNextCommand.php
+++ b/src/Command/QueueNextCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Civi\Cv\Command;
+
+use Civi;
+use CRM_Queue_Runner;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class QueueNextCommand extends CvCommand {
+
+  protected function configure() {
+    $this
+      ->setName('console-queue:run-next')
+      ->setDescription('(INTERNAL) Run the next task in queue')
+      ->setHidden(TRUE)
+      ->addOption('steal', NULL, InputOption::VALUE_NONE)
+      ->addOption('skip', NULL, InputOption::VALUE_NONE)
+      ->addOption('out', NULL, InputOption::VALUE_REQUIRED, 'Store outcome in a JSON file')
+      ->addOption('queue', NULL, InputOption::VALUE_REQUIRED, 'Queue name')
+      ->addOption('queue-spec', NULL, InputOption::VALUE_REQUIRED, 'Queue specification (Base64-JSON)');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    $outFile = $input->getOption('out');
+    if ($outFile && file_exists($outFile)) {
+      $this->writeFile($outFile, '');
+    }
+
+    $queue = $this->getQueue($input);
+
+    $runner = new CRM_Queue_Runner([
+      'queue' => $queue,
+    ]);
+    if ($input->getOption('skip')) {
+      $result = $runner->skipNext($input->getOption('steal'));
+    }
+    else {
+      $result = $runner->runNext($input->getOption('steal'));
+    }
+
+    if ($outFile) {
+      $this->writeFile($outFile, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    if (!empty($result['exception'])) {
+      throw $result['exception'];
+    }
+    return empty($result['is_error']) ? 0 : 1;
+  }
+
+  private function writeFile(string $outFile, string $data): void {
+    $parent = dirname($outFile);
+    if (!is_dir($parent)) {
+      if (!mkdir($parent, 0777, TRUE)) {
+        throw new \RuntimeException("Failed to create directory $parent");
+      }
+    }
+    $result = file_put_contents($outFile, $data);
+    if ($result === FALSE) {
+      throw new \RuntimeException("Failed to write to $outFile");
+    }
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @return \CRM_Queue_Queue
+   */
+  private function getQueue(InputInterface $input): \CRM_Queue_Queue {
+    // cv is evergreen and may be used on old versions, so we accept either --queue-spec (old style, non-persistent queues)
+    // or --queue (new style, persistent queues).
+    if ($input->getOption('queue-spec')) {
+      // For old-fashioned systems which lack support for persistent queue-definitions.
+      $spec = json_decode(base64_decode($input->getOption('queue-spec')), TRUE);
+      if (empty($spec)) {
+        throw new \InvalidArgumentException('Queue spec is empty or malformed');
+      }
+      $queue = \CRM_Queue_Service::singleton()->create($spec);
+    }
+    elseif ($input->getOption('queue')) {
+      $queue = Civi::queue($input->getOption('queue'));
+    }
+    else {
+      throw new \LogicException("Must specify either --queue or --queue-spec");
+    }
+    return $queue;
+  }
+
+}

--- a/src/Exception/QueueTaskException.php
+++ b/src/Exception/QueueTaskException.php
@@ -1,0 +1,5 @@
+<?php
+namespace Civi\Cv\Exception;
+
+class QueueTaskException extends \Exception {
+}

--- a/src/ExtensionPolyfill/PfHelper.php
+++ b/src/ExtensionPolyfill/PfHelper.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Civi\Cv\ExtensionPolyfill;
+
+use Civi;
+use CRM_Core_Exception;
+use CRM_Core_Session;
+use CRM_Extension_Exception;
+use CRM_Extension_Exception_MissingException;
+use CRM_Extension_Info;
+use CRM_Extension_Manager;
+use CRM_Extension_System;
+use CRM_Utils_File;
+use CRM_Utils_Zip;
+use ZipArchive;
+
+class PfHelper {
+
+  /**
+   * NOTE: Older versions of File::createDir() did not support emitting exceptions. Hence this port.
+   * @param string $path
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @see CRM_Utils_File::createDir()
+   */
+  public static function createDir(string $path) {
+    if (is_dir($path)) {
+      return;
+    }
+    if (@mkdir($path, 0777, TRUE) == FALSE) {
+      throw new CRM_Core_Exception("Failed to create directory: $path");
+    }
+  }
+
+  /**
+   * NOTE: Older versions of extractFiles() did not support $extractTo. Hence this port.
+   *
+   * @param $key
+   * @param $zipFile
+   * @param string|null $extractTo
+   *
+   * @return false|string
+   * @throws \CRM_Core_Exception
+   * @see \CRM_Extension_Downloader::extractFiles()
+   */
+  public static function extractFiles($key, $zipFile, ?string $extractTo = NULL) {
+    $extractTo = $extractTo ?: CRM_Extension_System::singleton()->getDownloader()->tmpDir;
+
+    $zip = new ZipArchive();
+    $res = $zip->open($zipFile);
+    if ($res === TRUE) {
+      $zipSubDir = CRM_Utils_Zip::guessBasedir($zip, $key);
+      if ($zipSubDir === FALSE) {
+        Civi::log()->error('Unable to extract the extension: bad directory structure');
+        CRM_Core_Session::setStatus(ts('Unable to extract the extension: bad directory structure'), '', 'error');
+        return FALSE;
+      }
+      $extractedZipPath = $extractTo . DIRECTORY_SEPARATOR . $zipSubDir;
+      if (is_dir($extractedZipPath)) {
+        if (!CRM_Utils_File::cleanDir($extractedZipPath, TRUE, FALSE)) {
+          Civi::log()->error('Unable to extract the extension {extension}: {path} cannot be cleared', [
+            'extension' => $key,
+            'path' => $extractedZipPath,
+          ]);
+          CRM_Core_Session::setStatus(ts('Unable to extract the extension: %1 cannot be cleared', [1 => $extractedZipPath]), ts('Installation Error'), 'error');
+          return FALSE;
+        }
+      }
+      if (!$zip->extractTo($extractTo)) {
+        Civi::log()->error('Unable to extract the extension to {path}.', ['path' => $extractTo]);
+        CRM_Core_Session::setStatus(ts('Unable to extract the extension to %1.', [1 => $extractTo]), ts('Installation Error'), 'error');
+        return FALSE;
+      }
+      $zip->close();
+    }
+    else {
+      Civi::log()->error('Unable to extract the extension');
+      CRM_Core_Session::setStatus(ts('Unable to extract the extension'), '', 'error');
+      return FALSE;
+    }
+
+    return $extractedZipPath;
+  }
+
+  /**
+   * NOTE: Older versions of CRM_Extension_Manager did not have this method.
+   *
+   * @see \CRM_Extension_Manager::checkInstallRequirements()
+   */
+  public static function checkInstallRequirements(array $installKeys, $newInfos = NULL): array {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    $errors = [];
+    $requiredExtensions = static::findInstallRequirements($installKeys, $newInfos);
+    $installKeysSummary = implode(',', $requiredExtensions);
+    foreach ($requiredExtensions as $extension) {
+      if ($manager->getStatus($extension) !== CRM_Extension_Manager::STATUS_INSTALLED && !in_array($extension, $installKeys)) {
+        $requiredExtensionInfo = CRM_Extension_System::singleton()->getBrowser()->getExtension($extension);
+        $requiredExtensionInfoName = empty($requiredExtensionInfo->name) ? $extension : $requiredExtensionInfo->name;
+        $errors[] = [
+          'title' => ts('Missing Requirement: %1', [1 => $extension]),
+          'message' => ts('You will not be able to install/upgrade %1 until you have installed the %2 extension.', [1 => $installKeysSummary, 2 => $requiredExtensionInfoName]),
+        ];
+      }
+    }
+    return $errors;
+  }
+
+  /**
+   * NOTE: Older versions of Manager::findInstallRequirements() were less accepting of $newInfos.
+   * @see \CRM_Extension_Manager::findInstallRequirements()
+   */
+  public static function findInstallRequirements($keys, $newInfos = NULL) {
+    $mapper = CRM_Extension_System::singleton()->getMapper();
+    if (is_object($newInfos)) {
+      $infos[$newInfos->key] = $newInfos;
+    }
+    elseif (is_array($newInfos)) {
+      $infos = $newInfos;
+    }
+    else {
+      $infos = $mapper->getAllInfos();
+    }
+    // array(string $key).
+    $todoKeys = array_unique($keys);
+    // array(string $key => 1);
+    $doneKeys = [];
+    $sorter = Civi\Cv\Top::create('MJS\TopSort\Implementations\FixedArraySort');
+
+    while (!empty($todoKeys)) {
+      $key = array_shift($todoKeys);
+      if (isset($doneKeys[$key])) {
+        continue;
+      }
+      $doneKeys[$key] = 1;
+
+      /** @var \CRM_Extension_Info $info */
+      $info = @$infos[$key];
+
+      if ($info && $info->requires) {
+        $sorter->add($key, $info->requires);
+        $todoKeys = array_merge($todoKeys, $info->requires);
+      }
+      else {
+        $sorter->add($key, []);
+      }
+    }
+    return $sorter->sort();
+  }
+
+  /**
+   * NOTE: Older versions of Manager::replace() did not support $backupCodeDir or $refresh. Hence this port.
+   *
+   * Install or upgrade the code for an extension -- and perform any
+   * necessary database changes (eg replacing extension metadata).
+   *
+   * This only works if the extension is stored in the default container.
+   *
+   * @param string $tmpCodeDir
+   *   Path to a local directory containing a copy of the new (inert) code.
+   * @param string|null $backupCodeDir
+   *   Optionally move the old code to $backupCodeDir
+   * @return string
+   *   The final path where the extension has been loaded.
+   * @throws CRM_Extension_Exception
+   * @see CRM_Extension_Manager::replace()
+   */
+  public static function basicReplace(string $tmpCodeDir, ?string $backupCodeDir = NULL): string {
+    $defaultContainer = CRM_Extension_System::singleton()->getDefaultContainer();
+    $fullContainer = CRM_Extension_System::singleton()->getFullContainer();
+    $manager = CRM_Extension_System::singleton()->getManager();
+
+    if (!$defaultContainer) {
+      throw new CRM_Extension_Exception("Default extension container is not configured");
+    }
+
+    $newInfo = CRM_Extension_Info::loadFromFile($tmpCodeDir . DIRECTORY_SEPARATOR . CRM_Extension_Info::FILENAME);
+    if ($newInfo->type !== 'module') {
+      throw new \CRM_Extension_Exception("PfHelper::replace() only supports module extensions");
+    }
+
+    $oldStatus = $manager->getStatus($newInfo->key);
+
+    // find $tgtPath
+    try {
+      // We prefer to put the extension in the same place (where it already exists).
+      $tgtPath = $fullContainer->getPath($newInfo->key);
+    }
+    catch (CRM_Extension_Exception_MissingException $e) {
+      // the extension does not exist in any container; we're free to put it anywhere
+      $tgtPath = $defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;
+    }
+    if (!CRM_Utils_File::isChildPath($defaultContainer->getBaseDir(), $tgtPath, FALSE)) {
+      // But if we don't control the folder, then force installation in the default-container
+      $oldPath = $tgtPath;
+      $tgtPath = $defaultContainer->getBaseDir() . DIRECTORY_SEPARATOR . $newInfo->key;
+      CRM_Core_Session::setStatus(ts('A copy of the extension (%1) is in a system folder (%2). The system copy will be preserved, but the new copy will be used.', [
+        1 => $newInfo->key,
+        2 => $oldPath,
+      ]), '', 'alert', ['expires' => 0]);
+    }
+
+    if ($backupCodeDir && is_dir($tgtPath)) {
+      if (!rename($tgtPath, $backupCodeDir)) {
+        throw new CRM_Extension_Exception("Failed to move $tgtPath to backup $backupCodeDir");
+      }
+    }
+
+    // move the code!
+    if (!CRM_Utils_File::replaceDir($tmpCodeDir, $tgtPath)) {
+      throw new CRM_Extension_Exception("Failed to move $tmpCodeDir to $tgtPath");
+    }
+    switch ($oldStatus) {
+      case CRM_Extension_Manager::STATUS_INSTALLED:
+      case CRM_Extension_Manager::STATUS_INSTALLED_MISSING:
+      case CRM_Extension_Manager::STATUS_DISABLED:
+      case CRM_Extension_Manager::STATUS_DISABLED_MISSING:
+        $reflection = new \ReflectionMethod($manager, '_updateExtensionEntry');
+        $reflection->setAccessible(TRUE);
+        $reflection->invokeArgs($manager, [$newInfo]);
+
+        if (class_exists('Civi\Core\ClassScanner')) {
+          \Civi\Core\ClassScanner::cache('structure')->flush();
+          \Civi\Core\ClassScanner::cache('index')->flush();
+        }
+        break;
+    }
+
+    return $tgtPath;
+  }
+
+}

--- a/src/ExtensionPolyfill/PfQueueDownloader.php
+++ b/src/ExtensionPolyfill/PfQueueDownloader.php
@@ -1,0 +1,267 @@
+<?php
+namespace Civi\Cv\ExtensionPolyfill;
+
+use Civi;
+use CRM_Extension_System;
+use CRM_Extension_Manager;
+use CRM_Queue_Queue;
+use CRM_Queue_Task;
+use CRM_Utils_File;
+use CRM_Utils_String;
+use CRM_Utils_Time;
+
+/**
+ * Prepare a set of steps for downloading extension upgrades.
+ *
+ * The general idea is:
+ *
+ *   $dl = new CRM_Extension_QueueDownloader();
+ *   $dl->addDownloads(
+ *     ['ext-1' => 'https://example.com/ext-1/releases/1.2.3./zip']
+ *   );
+ *   $runner = new CRM_Queue_Runner([
+ *     'queue' => $dl->fillQueue(), ...
+ *   ]);
+ *   $runner->runAllViaWeb();
+ *
+ * == NOTE: Using subprocesses
+ *
+ * When upgrading extensions, you MUST provide a chance to reset the PHP process (loading new PHP files).
+ *
+ * We will assume that every task runs in a new PHP process. This is compatible with runAllViaWeb() not but runAll().
+ *
+ * Headless clients (like `cv`) will need to use a suitable runner that spawns new subprocesses.
+ *
+ * == NOTE: Sequencing
+ *
+ * When you have multiple extensions to download/enable (and each may come with different start-state
+ * and version; and each may have differing versioned-dependencies)... then there is an interesting
+ * question about how to sequence/group the operations.
+ *
+ * Some operations target multiple ext's concurrently (like "rebuild" or "hook_upgrade" or "enable(keys=>A,B,C)").
+ * It's nice to lean into this style ("fetch A+B+C" then "rebuild system" then "upgrade A+B+C")
+ * because it's a good facsimile of the behavior in SCM (git/gzr/svn)-based workflows.
+ *
+ * However, it's not perfect, and there may still be edge-cases where that doesn't work. I'm pessimistic
+ * that this class will be able to automatically form perfect+universal plans based only on a declared
+ * list of downloads.
+ *
+ * So if a problematic edge-case comes up, how could you resolve it? The caller can decide sequencing/batching.
+ * Compare:
+ *
+ * ## Ex 1: Download 'a' and 'b' in the same batch. They will be fetched, swapped, and rebuilt in tandem.
+ *   $dl->addDownloads(['a' => ..., 'b' => ...]);
+ *
+ * ## Ex 2: Download 'a' and 'b' as separate batches. 'a' will be fully handled before 'b'.
+ *   $dl->addDownloads(['a' => ...]);
+ *   $dl->addDownloads(['b' => ...]);
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class PfQueueDownloader {
+
+  const QUEUE_PREFIX = 'pf_ext_upgrade_';
+
+  /**
+   * Unique ID for this batch of downloads.
+   *
+   * @var string
+   *   Ex: 20250607_abcd1234abcd1234
+   */
+  protected $upId;
+
+  protected $queue;
+
+  protected $cleanup;
+
+  /**
+   * @var array
+   *   Ex: [0 => ['type' => 'download', 'urls' => ['my.extension' => 'https://example/my.extension-1.0.zip']]]
+   *   Ex: [0 => ['type' => 'enable', 'keys' => ['my.extension']]]
+   */
+  protected $batches = [];
+
+  /**
+   * @param bool $cleanup
+   *    Whether to delete temporary files and backup files at the end.
+   * @param \CRM_Queue_Queue|null $queue
+   */
+  public function __construct(bool $cleanup = TRUE, ?CRM_Queue_Queue $queue = NULL) {
+    $this->upId = (CRM_Utils_Time::date('Y-m-d') . '-' . CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC));
+    $this->cleanup = $cleanup;
+    $this->queue = $queue ?: $this->createQueue();
+  }
+
+  public function createQueue(): CRM_Queue_Queue {
+    return Civi::queue(static::QUEUE_PREFIX . $this->upId, [
+      'type' => 'Sql',
+      'runner' => 'task',
+      'is_autorun' => FALSE,
+      'retry_limit' => 0,
+      'error' => 'abort',
+      'reset' => TRUE,
+    ]);
+  }
+
+  protected function getStagingPath(...$moreParts): string {
+    // The staging path is basically "{extensionsDir}/.civicrm-staging/{upId}". Note that:
+    // - This puts the staging files in the right filesystem (close to their final location).
+    //   Thus, `rename()` can be used to rearrange folders.
+    // - `uploadDir` might be viable, but it's also at greater risk of getting auto-cleaned
+    //   and being on separate filesystem.
+
+    $baseDir = CRM_Extension_System::singleton()->getDefaultContainer()->baseDir;
+    $prefix = [
+      rtrim($baseDir, DIRECTORY_SEPARATOR . '/'),
+      '.civicrm-staging',
+      $this->upId,
+    ];
+    return implode('/', array_merge($prefix, $moreParts));
+  }
+
+  public function getTitle(): string {
+    return ts('Download and Install (<em><small>ID: %1</small></em>)', [1 => $this->upId]);
+  }
+
+  /**
+   * Add a set of extensions to download and enable.
+   *
+   * @param array $downloads
+   *   Ex: ['ext1' => 'https://example.com/ext1/releases/1.0.zip']
+   * @param bool $autoApply
+   *   TRUE if the downloader should execute the installation/upgrade routines
+   *   FALSE if the downloader should only get the files and put them in place
+   *
+   * @return $this
+   */
+  public function addDownloads(array $downloads, bool $autoApply = TRUE) {
+    $this->batches[] = ['type' => 'download', 'urls' => $downloads, 'autoApply' => $autoApply];
+    return $this;
+  }
+
+  /**
+   * Add a set of keys which should be enabled. (Use this if you -only- want to enable. If you are actually downloading,
+   * then use addDownloads().)
+   *
+   * @param array $keys
+   *   Ex: ['my.ext1', 'my.ext2']
+   *
+   * @return $this
+   */
+  public function addEnable(array $keys) {
+    $this->batches[] = ['type' => 'enable', 'keys' => $keys];
+    return $this;
+  }
+
+  /**
+   * Take the list of pending updates (from addDownload, addEnable)
+   */
+  public function fillQueue(): CRM_Queue_Queue {
+    $queue = $this->queue;
+
+    // Store some metadata about what's going on. This may help with debugging.
+    CRM_Utils_File::createDir($this->getStagingPath(), 'exception');
+    file_put_contents($this->getStagingPath('details.json'), json_encode([
+      'startTime' => CRM_Utils_Time::date('c'),
+      'upId' => $this->upId,
+      'queue' => $queue->getName(),
+      'batches' => $this->batches,
+      'statuses' => CRM_Extension_System::singleton()->getManager()->getStatuses(),
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    foreach ($this->batches as $batch) {
+      switch ($batch['type']) {
+        case 'enable':
+          $queue->createItem(static::task(ts('Enable %1', [1 => $this->quotedList($batch['keys'])]), 'enable', [$batch['keys']]));
+          break;
+
+        case 'download':
+          $downloads = $batch['urls'];
+
+          // Download and extract zip files. This is I/O dependent (error-prone), so we do each as a separate (retriable) step.
+          foreach ($downloads as $ext => $url) {
+            $queue->createItem(static::task(ts('Fetch "%1" from "%2"', [1 => $ext, 2 => $url]), 'fetch', [$ext, $url]));
+          }
+
+          // Verify all requirements with a single operation -- _before_ loading the new code.
+          // We won't be sensitive to (re)ordering of fetch-tasks, because we only care if the final set is coherent.
+          $queue->createItem(static::task(ts('Verify requirements'), 'preverify', [array_keys($downloads)]));
+
+          // Swap-in new folders with a single operation. This should be similar to more sophisticated site-builder
+          // workflows. (f you manage a site in git, then "git pull" swaps all code at the same time.) This
+          // can't guarantee that all combinations of $downloads work, but at least they'll behave consistently.
+          $queue->createItem(static::task(ts('Swap folders'), 'swap', [array_keys($downloads)]));
+
+          // The "swap" and "rebuild" must happen in separate steps.
+          if ($batch['autoApply']) {
+            $queue->createItem(static::task(ts('Rebuild system'), 'rebuild'));
+          }
+
+          $statuses = CRM_Extension_System::singleton()->getManager()->getStatuses();
+          $findByStatus = function(array $matchStatuses) use ($downloads, $statuses) {
+            return array_filter(
+              array_keys($downloads),
+              function($key) use ($statuses, $matchStatuses) {
+                return in_array($statuses[$key] ?? CRM_Extension_Manager::STATUS_UNINSTALLED, $matchStatuses, TRUE);
+              }
+            );
+          };
+          $needEnable = $findByStatus([
+            CRM_Extension_Manager::STATUS_UNINSTALLED,
+            CRM_Extension_Manager::STATUS_DISABLED,
+            CRM_Extension_Manager::STATUS_DISABLED_MISSING,
+          ]);
+          $needUpgrade = $findByStatus([
+            CRM_Extension_Manager::STATUS_INSTALLED,
+            CRM_Extension_Manager::STATUS_DISABLED,
+            CRM_Extension_Manager::STATUS_DISABLED_MISSING,
+          ]);
+          if ($batch['autoApply'] && $needEnable) {
+            $queue->createItem(static::task(ts('Enable %1', [1 => $this->quotedList($needEnable)]), 'enable', [$needEnable]));
+          }
+          if ($batch['autoApply'] && $needUpgrade) {
+            $queue->createItem(static::task(ts('Upgrade database'), 'upgradeDb'));
+          }
+
+          break;
+
+      }
+    }
+
+    if ($this->cleanup) {
+      $queue->createItem(
+        static::task(ts('Cleanup workspace'), 'cleanup'),
+        ['weight' => 2000]
+      );
+    }
+
+    return $queue;
+  }
+
+  private function quotedList(array $items) {
+    // This can at least adapt to quotes and guillemets... we should probably have some more general helpers for lists and conjunctions...
+    $template = ts('"%1"');
+    return implode(', ', array_map(function($item) use ($template) {
+      return str_replace('%1', $item, $template);
+    }, $items));
+  }
+
+  /**
+   * Create a CRM_Queue_Task that executes on this class.
+   *
+   * @param string $title
+   * @param string $method
+   * @param array $args
+   *
+   * @return \CRM_Queue_Task
+   */
+  protected function task(string $title, string $method, array $args = []): CRM_Queue_Task {
+    return new CRM_Queue_Task(
+      [PfQueueTasks::class, $method],
+      array_merge([$this->getStagingPath()], $args),
+      $title
+    );
+  }
+
+}

--- a/src/ExtensionPolyfill/PfQueueTasks.php
+++ b/src/ExtensionPolyfill/PfQueueTasks.php
@@ -1,0 +1,155 @@
+<?php
+namespace Civi\Cv\ExtensionPolyfill;
+
+use Civi;
+use CRM_Core_Config;
+use CRM_Core_Invoke;
+use CRM_Extension_Exception;
+use CRM_Extension_Info;
+use CRM_Extension_System;
+use CRM_Extension_Upgrades;
+use CRM_Queue_TaskContext;
+use CRM_Utils_File;
+
+/**
+ * Library of queue-tasks which are useful for extension-management.
+ */
+class PfQueueTasks {
+
+  /**
+   * Download extension ($key) from $url and store it in {$stagingPath}/new/{$key}.
+   * @throws \CRM_Core_Exception
+   */
+  public static function fetch(CRM_Queue_TaskContext $ctx, string $stagingPath, string $key, string $url): bool {
+    $tmpDir = "$stagingPath/tmp";
+    $zipFile = "$stagingPath/fetch/$key.zip";
+    $stageDir = "$stagingPath/new/$key";
+
+    PfHelper::createDir($tmpDir);
+    PfHelper::createDir(dirname($zipFile));
+    PfHelper::createDir(dirname($stageDir));
+
+    if (file_exists($stageDir)) {
+      // In case we're retrying from a prior failure.
+      CRM_Utils_File::cleanDir($stageDir, TRUE, FALSE);
+    }
+
+    $downloader = CRM_Extension_System::singleton()->getDownloader();
+    if (!$downloader->fetch($url, $zipFile)) {
+      throw new CRM_Extension_Exception("Failed to download: $url");
+    }
+
+    $extractedZipPath = PfHelper::extractFiles($key, $zipFile, $tmpDir);
+    if (!$extractedZipPath) {
+      throw new CRM_Extension_Exception("Failed to extract: $zipFile");
+    }
+
+    if (!$downloader->validateFiles($key, $extractedZipPath)) {
+      throw new CRM_Extension_Exception("Failed to validate $extractedZipPath. Consult CiviCRM log for details.");
+      // FIXME: Might be nice to show errors immediately, but we've got bigger fish to fry right now.
+    }
+
+    if (!rename($extractedZipPath, $stageDir)) {
+      throw new CRM_Extension_Exception("Failed to rename $extractedZipPath to $stageDir");
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   * This checks requirements as declared in the staging area.
+   * @throws \CRM_Core_Exception
+   */
+  public static function preverify(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    $infos = CRM_Extension_System::singleton()->getMapper()->getAllInfos();
+    foreach ($keys as $key) {
+      $infos[$key] = CRM_Extension_Info::loadFromFile("$stagingPath/new/$key/" . CRM_Extension_Info::FILENAME);
+    }
+
+    $errors = PfHelper::checkInstallRequirements($keys, $infos);
+    if (!empty($errors)) {
+      Civi::log()->error('Failed to verify requirements for new downloads in {path}', [
+        'path' => $stagingPath,
+        'installKeys' => $keys,
+        'errors' => $errors,
+      ]);
+      throw new CRM_Extension_Exception(implode("\n", array_merge(
+        ["Failed to verify requirements for new downloads in $stagingPath."],
+        array_column($errors, 'title'),
+        ["Consult CiviCRM log for details."],
+      )));
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Take the extracted code (`stagingDir/new/{key}`) and put it into its final place.
+   * Move any old code to the backup (`stagingDir/old/{key}`).
+   * Delete the container-cache
+   * @throws \CRM_Core_Exception
+   */
+  public static function swap(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    PfHelper::createDir("$stagingPath/old");
+    try {
+      foreach ($keys as $key) {
+        $tmpCodeDir = "$stagingPath/new/$key";
+        $backupCodeDir = "$stagingPath/old/$key";
+
+        PfHelper::basicReplace($tmpCodeDir, $backupCodeDir);
+        // What happens when you call replace(.., refresh: false)? Varies by type:
+        // - For report/search/payment-extensions, it runs the uninstallation/reinstallation routines.
+        // - For module-extensions, it swaps the folders and clears the class-index.
+
+        // Arguably, for DownloadQueue, we should only clear class-index after all code is swapped,
+        // but it's messier to write that patch, and it's not clear if it's needed.
+      }
+    } finally {
+      // Delete `CachedCiviContainer.*.php`, `CachedExtLoader.*.php`, and similar.
+      $config = CRM_Core_Config::singleton();
+      $config->cleanup(1);
+      CRM_Core_Config::clearDBCache();
+      // $config->cleanupCaches(FALSE);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * @param \CRM_Queue_TaskContext $ctx
+   * @return bool
+   * @throws \Exception
+   */
+  public static function rebuild(CRM_Queue_TaskContext $ctx): bool {
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
+    return TRUE;
+  }
+
+  /**
+   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   */
+  public static function enable(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+    CRM_Extension_System::singleton()->getManager()->enable($keys);
+    return TRUE;
+  }
+
+  public static function upgradeDb(CRM_Queue_TaskContext $ctx): bool {
+    if (CRM_Extension_Upgrades::hasPending()) {
+      CRM_Extension_Upgrades::fillQueue($ctx->queue);
+    }
+    return TRUE;
+  }
+
+  /**
+   * @param \CRM_Queue_TaskContext $ctx
+   * @param string $stagingPath
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public static function cleanup(CRM_Queue_TaskContext $ctx, string $stagingPath): bool {
+    CRM_Utils_File::cleanDir($stagingPath, TRUE, FALSE);
+    return TRUE;
+  }
+
+}

--- a/src/ExtensionPolyfill/PfQueueTasks.php
+++ b/src/ExtensionPolyfill/PfQueueTasks.php
@@ -149,6 +149,11 @@ class PfQueueTasks {
    */
   public static function cleanup(CRM_Queue_TaskContext $ctx, string $stagingPath): bool {
     CRM_Utils_File::cleanDir($stagingPath, TRUE, FALSE);
+    $parent = dirname($stagingPath);
+    $siblings = preg_grep('/^\.\.?$/', scandir($parent), PREG_GREP_INVERT);
+    if (empty($siblings)) {
+      rmdir($parent);
+    }
     return TRUE;
   }
 

--- a/src/Util/ConsoleQueueRunner.php
+++ b/src/Util/ConsoleQueueRunner.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Util;
 
+use Civi\Cv\Exception\QueueTaskException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -88,10 +89,10 @@ class ConsoleQueueRunner {
         try {
           $isOK = $task->run($taskCtx);
           if (!$isOK) {
-            throw new \Exception('Task returned false');
+            throw new QueueTaskException('Task returned false');
           }
         }
-        catch (\Exception $e) {
+        catch (\Throwable $e) {
           // WISHLIST: For interactive mode, perhaps allow retry/skip?
           $io->writeln(sprintf("<error>Error executing task: %s</error>", $task->title));
           throw $e;

--- a/src/Util/ConsoleQueueRunner.php
+++ b/src/Util/ConsoleQueueRunner.php
@@ -93,7 +93,7 @@ class ConsoleQueueRunner {
         }
         catch (\Exception $e) {
           // WISHLIST: For interactive mode, perhaps allow retry/skip?
-          $io->writeln(sprintf("<error>Error executing task \"%s\"</error>", $task->title));
+          $io->writeln(sprintf("<error>Error executing task: %s</error>", $task->title));
           throw $e;
         }
       }

--- a/src/Util/ConsoleSubprocessQueueRunner.php
+++ b/src/Util/ConsoleSubprocessQueueRunner.php
@@ -1,0 +1,153 @@
+<?php
+namespace Civi\Cv\Util;
+
+use Civi\Cv\Exception\QueueTaskException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class ConsoleSubprocessQueueRunner
+ * @package Civi\Cv\Util
+ *
+ * Execute tasks in a CRM_Queue_Queue, with output directed to the console.
+ *
+ * Similar to ConsoleQueueRunner, but this executes each task in a new PHP subprocess.
+ *
+ * @see \Civi\Cv\Util\ConsoleQueueRunner
+ */
+class ConsoleSubprocessQueueRunner {
+
+  /**
+   * @var bool
+   */
+  private $dryRun;
+
+  /**
+   * @var \Symfony\Component\Console\Style\SymfonyStyle
+   */
+  private $io;
+
+  /**
+   * @var array
+   */
+  private $queueSpec;
+
+  /**
+   * @var bool
+   */
+  private $step;
+
+  /**
+   * Temporary file where we can ask the subprocess to store detailed information about its outcome.
+   *
+   * @var string
+   */
+  private $stateFile;
+
+  /**
+   * ConsoleQueueRunner constructor.
+   *
+   * @param \Symfony\Component\Console\Style\StyleInterface $io
+   * @param array $queueSpec
+   * @param bool $dryRun
+   * @param bool $step
+   */
+  public function __construct(\Symfony\Component\Console\Style\StyleInterface $io, array $queueSpec, $dryRun = FALSE, $step = FALSE) {
+    $this->io = $io;
+    $this->queueSpec = $queueSpec;
+    $this->dryRun = $dryRun;
+    $this->step = (bool) $step;
+    $this->stateFile = $this->pickStateFile();
+  }
+
+  public function __destruct() {
+    if ($this->stateFile && file_exists($this->stateFile)) {
+      @unlink($this->stateFile);
+    }
+  }
+
+  private function pickStateFile(): string {
+    $id = \uniqid();
+    if (getenv('XDG_STATE_HOME')) {
+      return implode(DIRECTORY_SEPARATOR, [getenv('XDG_STATE_HOME'), 'cv', "dl-{$id}.json"]);
+    }
+    $home = getenv('HOME') ? getenv('HOME') : getenv('USERPROFILE');
+    if (!empty($home) && file_exists($home)) {
+      return implode(DIRECTORY_SEPARATOR, [getenv('HOME'), '.cv', 'state', "dl-{$id}.json"]);
+    }
+    throw new \RuntimeException("Failed to pick state-file. Please set one of: HOME, USERPROFILE, XDG_STATE_HOME");
+  }
+
+  private function getState(): ?array {
+    if (!file_exists($this->stateFile)) {
+      return NULL;
+    }
+    return json_decode(file_get_contents($this->stateFile), TRUE);
+  }
+
+  /**
+   * @throws \Exception
+   */
+  public function runAll() {
+    /** @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+    $io = $this->io;
+    $queue = \CRM_Queue_Service::singleton()->create($this->queueSpec);
+
+    while ($queue->numberOfItems()) {
+      // In case we're retrying a failed job.
+      $item = $queue->stealItem();
+      $task = $item->data;
+
+      if ($io->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
+        // Symfony progress bar would be prettier, but (when last checked) they didn't allow
+        // resetting when the queue-length expands dynamically.
+        $io->write(".");
+      }
+      elseif ($io->getVerbosity() === OutputInterface::VERBOSITY_VERBOSE) {
+        $io->writeln(sprintf("<info>%s</info>", $task->title));
+      }
+      elseif ($io->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
+        $io->writeln(sprintf("<info>%s</info> (<comment>%s</comment>)", $task->title, self::formatTaskCallback($task)));
+      }
+
+      $action = 'y';
+      if ($this->step) {
+        $action = $io->choice('Execute this step?', ['y' => 'yes', 's' => 'skip', 'a' => 'abort'], 'y');
+      }
+      if ($action === 'a') {
+        throw new \Exception('Aborted');
+      }
+
+      $specArg = escapeshellarg(base64_encode(json_encode($this->queueSpec, JSON_UNESCAPED_SLASHES)));
+      $fileArg = escapeshellarg($this->stateFile);
+      $runCmd = "console-queue:run-next --queue-spec=$specArg --steal --out=$fileArg " . ($action === 's' ? '--skip' : '');
+      if ($this->dryRun) {
+        $io->writeln(sprintf("<info>DRY-RUN</info> cv %s", $runCmd));
+        $queue->deleteItem($item);
+      }
+      else {
+        $exitCode = Cv::passthru($runCmd);
+        $state = $this->getState();
+        if ($exitCode || !empty($state['is_error'])) {
+          // WISHLIST: For interactive mode, perhaps allow retry/skip?
+          $io->writeln('');
+          $io->writeln(sprintf("<error>Error executing task: %s</error>", $task->title));
+          if ($io->isDebug()) {
+            $io->writeln('Subprocess results: ' . json_encode($state, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT), OutputInterface::OUTPUT_PLAIN);
+          }
+          throw new QueueTaskException('Task returned error');
+        }
+      }
+    }
+
+    if ($io->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
+      $io->newLine();
+    }
+  }
+
+  protected static function formatTaskCallback(\CRM_Queue_Task $task) {
+    $cb = implode('::', (array) $task->callback);
+    $args = json_encode($task->arguments, JSON_UNESCAPED_SLASHES);
+    return sprintf("%s(%s)", $cb, substr($args, 1, -1));
+  }
+
+}

--- a/src/Util/Process.php
+++ b/src/Util/Process.php
@@ -17,7 +17,7 @@ class Process {
     $newArgs = array();
     $newArgs[] = array_shift($args);
     foreach ($args as $arg) {
-      $newArgs[] = preg_match(';^[a-zA-Z0-9\.\/]+$;', $arg) ? $arg : escapeshellarg($arg);
+      $newArgs[] = static::lazyEscape($arg);
     }
     return call_user_func_array('sprintf', $newArgs);
   }
@@ -123,6 +123,24 @@ class Process {
       'Output' => $process->getOutput(),
       'Error Output' => $process->getErrorOutput(),
     ));
+  }
+
+  /**
+   * Escape a value for use as a shell argument.
+   *
+   * This is basically the same as `escapeshellarg()`, but quotation marks can be skipped for
+   * some simple strings.
+   *
+   * @param string $value
+   * @return string
+   */
+  public static function lazyEscape(string $value): string {
+    if (preg_match('/^[a-zA-Z0-9_\.\-\/=]*$/', $value)) {
+      return $value;
+    }
+    else {
+      return escapeshellarg($value);
+    }
   }
 
 }

--- a/tests/CvTestTrait.php
+++ b/tests/CvTestTrait.php
@@ -13,7 +13,7 @@ trait CvTestTrait {
    * @return \Symfony\Component\Process\Process
    */
   protected function cv($command) {
-    $cvPath = getenv('CV_TEST_BINARY') ?: dirname(__DIR__) . '/bin/cv';
+    $cvPath = $this->getCvPath();
     $process = \Symfony\Component\Process\Process::fromShellCommandline("{$cvPath} $command");
     return $process;
   }
@@ -49,6 +49,14 @@ trait CvTestTrait {
   protected function cvJsonOk($cmd) {
     $p = Process::runOk($this->cv($cmd));
     return json_decode($p->getOutput(), 1);
+  }
+
+  private function getCvPath(): string {
+    return getenv('CV_TEST_BINARY') ?: dirname(__DIR__) . '/bin/cv';
+  }
+
+  protected function isCvPharTest(): bool {
+    return (bool) preg_match(';\.phar$;', $this->getCvPath());
   }
 
 }

--- a/tests/TopHelperTest.php
+++ b/tests/TopHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Civi\Cv;
+
+use Civi\Cv\Util\Process;
+
+/**
+ * The "Top" helper provides access to top-level class-names, even if you have namespace prefixing.
+ * To ensure that it works, we need distinct tests for PHAR and SRC runtimes.
+ *
+ * @group std
+ * @group php
+ */
+class TopHelperTest extends \Civi\Cv\CivilTestCase {
+
+  public function testTop() {
+    if ($this->isCvPharTest()) {
+      $exprs = [
+        'Cvphar\Fruit\Apple' => '\Fruit\Apple',
+        '\Cvphar\Fruit\Banana' => '\Fruit\Banana',
+        'Fruit\Cherry' => '\Fruit\Cherry',
+        '\Fruit\Date' => '\Fruit\Date',
+      ];
+    }
+    else {
+      $exprs = [
+        'Fruit\Apple' => '\Fruit\Apple',
+        '\Fruit\Banana' => '\Fruit\Banana',
+      ];
+    }
+
+    foreach ($exprs as $input => $expected) {
+      $p = Process::runOk($this->cv("ev 'return \Civi\Cv\Top::symbol(getenv(\"SYMBOL\"));'")
+        ->setEnv(['SYMBOL' => $input]));
+      $actual = json_decode($p->getOutput());
+      $this->assertEquals($expected, $actual, "Input ($input) should yield value ($expected).");
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
--------------

`cv dl` (`cv ext:download`) allows you to download extension-upgrades. As presented in [dev/core#5700](https://lab.civicrm.org/dev/core/-/issues/5700), some upgrades are prone to sporadic failures. One reproducible version of this occurs when an extension transitions from  "Entity Framework v1" (EFv1) to "Entity Framework v2" (EFv2).

In general, the technique to fix this is to split the download-workflow into multiple subprocesses. The basic issue has been addressed in the web-based downloader for 6.1+ (https://github.com/civicrm/civicrm-core/pull/32285); and there is also a [hotfix for the web-based downloader in older versions](https://lab.civicrm.org/extensions/hotfix_extup/). This PR applies the same technique to CLI downloads

Before
-------

Upgrading example extension (`bottlecap`) from v0.1 (EFv1) to v0.2 (EFv2) via `cv dl` leads to an error:

```bash
$ cv dl bottlecap
Using extension feed "https://think.hm/tmp/bottlecap/feed-0.2"
Downloading extension "bottlecap" (https://think.hm/tmp/bottlecap/bottlecap-0.2.zip)

In Bottlecap.php line 14:

  [Error]
  Class "CRM_Bottlecap_DAO_Base" not found
```

After
-----

Similar commands pass. With verbose output, we see:

```
$ cv dl bottlecap -vf
Using extension feed "https://think.hm/tmp/bottlecap/feed-0.2"
Fetch "bottlecap" from "https://think.hm/tmp/bottlecap/bottlecap-0.2.zip"
Verify requirements
Swap folders
Rebuild system
Upgrade database
Cleanup workspace
```

Internally, this required a fair amount of work. For each of those lines ("Verify requirements", "Swap folders", etc), `cv` needs to open a subprocess to do the work -- and then report-back on its outcome. When there are errors, the errors should propagate back in a sensible way (e.g. being printed to the screen in conformance with usual verbose/non-verbose behavior -- and yielding a decent exit-code).

Comments
-----------

* For testing, I focused on [the `bottlecap` extension](https://gist.github.com/totten/273b22ba7c033982982bc4267fe2b83d) which can be used to [reproduce upgrade problems](https://lab.civicrm.org/dev/core/-/issues/5700).
    * My testing got sidetracked for a bit because I wasn't following the test procedure closely enough -- in particular, [after any failed download, you need to reset everything](https://lab.civicrm.org/dev/core/-/issues/5700#note_176127). If you don't, then your next download may pass for the wrong reasons.
* The update is loosely coupled to https://github.com/civicrm/civicrm-core/pull/32591:
    * Once 32591 is merged into core, `cv` will start using the core implementation of `CRM_Extension_QueueDownloader`.
    * However, on older versions of Civi, `cv` will use a backport that's included here (`./src/ExtensionPolyfill/PfQueueDownloader`). This copy should slowly become obsolete as older versions of Civi fade-out.
* Locally, I've used both the raw cv src (`bin/cv`) and a compiled (`bin/cv.phar`). It seems to work with both. I've also spot-checked with builds of `drupal-clean` on `6.2` (with and with 32591), `6.1.0`, `5.81`, `5.75`, `5.63`, `5.57`, and `5.45`.
