### PR TITLE
Show the config file location of cv.json with the command vars:show 

### DIFF
--- a/lib/src/SiteConfigReader.php
+++ b/lib/src/SiteConfigReader.php
@@ -66,6 +66,7 @@ class SiteConfigReader {
       $config = Config::read();
       $this->cache['home'] = isset($config['sites'][$this->settingsFile])
         ? $config['sites'][$this->settingsFile] : array();
+      $this->cache['home']['CONFIG_FILE'] = Config::getFileName();
     }
     return $this->cache['home'];
   }


### PR DESCRIPTION
This PR is a follow up on https://github.com/civicrm/cv/pull/243#issuecomment-2782715117

It will show the location of `cv.json` file when running `cv vars:show`

See screenshot below

![2025-04-10_16-25](https://github.com/user-attachments/assets/5e2d82fc-75ba-46b5-a30f-94fec14ad8f7)
