### PR TITLE
PHP 8.4 - Fix warning about E_STRICT

### DIFF
--- a/lib/src/ErrorHandler.php
+++ b/lib/src/ErrorHandler.php
@@ -72,23 +72,27 @@ class ErrorHandler {
   }
 
   protected static function getErrorTypes(): array {
-    return [
-      E_ERROR => 'PHP Error',
-      E_WARNING => 'PHP Warning',
-      E_PARSE => 'PHP Parse Error',
-      E_NOTICE => 'PHP Notice',
-      E_CORE_ERROR => 'PHP Core Error',
-      E_CORE_WARNING => 'PHP Core Warning',
-      E_COMPILE_ERROR => 'PHP Compile Error',
-      E_COMPILE_WARNING => 'PHP Compile Warning',
-      E_USER_ERROR => 'PHP User Error',
-      E_USER_WARNING => 'PHP User Warning',
-      E_USER_NOTICE => 'PHP User Notice',
-      E_STRICT => 'PHP Strict Warning',
-      E_RECOVERABLE_ERROR => 'PHP Recoverable Fatal Error',
-      E_DEPRECATED => 'PHP Deprecation',
-      E_USER_DEPRECATED => 'PHP User Deprecation',
-    ];
+    return array_merge(
+      [
+        E_ERROR => 'PHP Error',
+        E_WARNING => 'PHP Warning',
+        E_PARSE => 'PHP Parse Error',
+        E_NOTICE => 'PHP Notice',
+        E_CORE_ERROR => 'PHP Core Error',
+        E_CORE_WARNING => 'PHP Core Warning',
+        E_COMPILE_ERROR => 'PHP Compile Error',
+        E_COMPILE_WARNING => 'PHP Compile Warning',
+        E_USER_ERROR => 'PHP User Error',
+        E_USER_WARNING => 'PHP User Warning',
+        E_USER_NOTICE => 'PHP User Notice',
+        E_RECOVERABLE_ERROR => 'PHP Recoverable Fatal Error',
+        E_DEPRECATED => 'PHP Deprecation',
+        E_USER_DEPRECATED => 'PHP User Deprecation',
+      ],
+      version_compare(phpversion(), '8.4', '<') ? [constant('E_STRICT') => 'PHP Strict Warning'] : []
+      // https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant
+      // In theory, once cv shifts to 8.x only, we can simplify this.
+    );
   }
 
 }

--- a/lib/src/Util/BootTrait.php
+++ b/lib/src/Util/BootTrait.php
@@ -330,7 +330,9 @@ trait BootTrait {
     $this->bootLogger($output)->debug('Attempting to set verbose error reporting');
 
     // standard php debug chat settings
-    error_reporting(E_ALL | E_STRICT);
+    error_reporting(E_ALL | (version_compare(phpversion(), '8.4', '<') ? E_STRICT : 0));
+    // https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant
+    // In theory, once cv shifts to 8.x only, we can simplify this.
     ini_set('display_errors', 'stderr');
     ini_set('display_startup_errors', TRUE);
   }


### PR DESCRIPTION
Fix warning:

```
  Deprecated: Constant E_STRICT is deprecated in ...lib/src/ErrorHandler.php
```

Reportedly, E_STRICT:
* Is meaningful (from php-src.git POV) in 7.x
* Stopped being meaningful (from php-src.git POV) in 8.x
* Started throwing deprecation warnings in 8.4

It's unclear if there might be significance for contrib in the 8.x era.