### PR TITLE
Implement Joomla CMS boot routine

### DIFF
--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -410,10 +410,12 @@ class CmsBootstrap {
       ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
     $app = $container->get(\Joomla\CMS\Application\ConsoleApplication::class);
     \Joomla\CMS\Factory::$application = $app;
-    $userFactory = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class);
-    $user = $userFactory->loadUserByUserName($cmsUser);
-    if (empty($user->id)) {
-      throw new \Exception(sprintf("Fail to find Joomla user (%s)", $cmsUser));
+    if ($cmsUser) {
+      $userFactory = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class);
+      $user = $userFactory->loadUserByUserName($cmsUser);
+      if (empty($user->id)) {
+        throw new \Exception(sprintf("Fail to find Joomla user (%s)", $cmsUser));
+      }
     }
     return $this;
   }
@@ -605,7 +607,7 @@ class CmsBootstrap {
         break;
 
       case 'Joomla':
-        $user = \JFactory::getUser();
+        $user = (!class_exists('JFactory') ? \Joomla\CMS\Factory::getUser() : \JFactory::getUser());
         \CRM_Core_BAO_UFMatch::synchronize($user, TRUE, CIVICRM_UF, 'Individual');
         break;
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -18,6 +18,7 @@ return [
 
     // Joomla bootstrap
     'TYPO3\\PharStreamWrapper',
+    'Joomla\\',
   ],
   'exclude-classes' => [
     '/^(CRM_|HTML_|DB_|Log_)/',
@@ -27,6 +28,7 @@ return [
     'JFactory',
     'Civi',
     'Drupal',
+    'Joomla',
   ],
   'exclude-functions' => [
     '/^civicrm_/',


### PR DESCRIPTION
This implements cmsBoot function for Joomla and associated matters. 

I have tested this on a J4 site and it seems to work. It doesn't work for a J3 site but that is EOL so maybe ok?, I haven't tested what it does on a J5 site yet.

one element I wasn't sure about is if in L230 I should use $this->bootedCms['path'] or JPATH_BASE. The way it is coded up now it loads the administrator civicrm.settings.php whereas using $this->bootedCms['path'] would load up the front end (site) civicrm.settings.php