### PR TITLE
CronCommand - Add support for verbose and force flags (-v and -f)

### DIFF
--- a/lib/src/Log/MultiLogger.php
+++ b/lib/src/Log/MultiLogger.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Civi\Cv\Log;
+
+/**
+ * Forward logs to multiple loggers.
+ */
+class MultiLogger extends InternalLogger {
+
+  /**
+   * @var \Civi\Cv\Log\InternalLogger[]|\Psr\Log\LoggerInterface[]
+   */
+  protected $loggers = [];
+
+  /**
+   * @param string $topic
+   * @param \Civi\Cv\Log\InternalLogger[]|\Psr\Log\LoggerInterface[] $loggers
+   */
+  public function __construct(string $topic, array $loggers = []) {
+    parent::__construct($topic);
+    $this->loggers = $loggers;
+  }
+
+  /**
+   * @param string $id
+   * @return \Civi\Cv\Log\InternalLogger|\Psr\Log\LoggerInterface|null
+   */
+  public function getLogger(string $id) {
+    return $this->loggers[$id] ?? NULL;
+  }
+
+  public function log($level, $message, array $context = []) {
+    $errors = [];
+    foreach ($this->loggers as $logger) {
+      try {
+        $logger->log($level, $message, $context);
+      }
+      catch (\Throwable $t) {
+        $errors[] = $t;
+      }
+    }
+
+    // We'll try to let -some- logger get the message out before we abort.
+    if (!empty($errors)) {
+      throw new MultiLoggerException(implode("\n", $errors), $level);
+    }
+  }
+
+}

--- a/lib/src/Log/MultiLoggerException.php
+++ b/lib/src/Log/MultiLoggerException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Civi\Cv\Log;
+
+class MultiLoggerException extends \RuntimeException {
+
+  /**
+   * @var \Throwable[]
+   */
+  protected $errors;
+
+  /**
+   * @param \Throwable[] $errors
+   */
+  public function __construct($errors = []) {
+    $messages = [];
+    foreach ($errors as $error) {
+      $messages[] = $error->getMessage();
+    }
+    $this->errors = $errors;
+    parent::__construct(implode("\n", $messages));
+  }
+
+}

--- a/src/Command/CronCommand.php
+++ b/src/Command/CronCommand.php
@@ -20,8 +20,26 @@ class CronCommand extends CvCommand {
     $this
       ->setName('core:cron')
       ->setAliases(['cron'])
-      ->setDescription('Run the CiviCRM cron on the default domain (defaults to using the default domain organisation contact, or you can use a --user=USER)')
-      ->addOption('force', 'f', InputOption::VALUE_NONE, 'Ignore pending maintenance tasks. Force cron to run regardless of status.');
+      ->setDescription('Execute scheduled and recurring jobs')
+      ->addOption('force', 'f', InputOption::VALUE_NONE, 'Ignore pending maintenance tasks. Force cron to run regardless of status.')
+      ->setHelp('
+<info>cv cron</info> command is designed for use as a <comment>cron job</comment>. It executes scheduled and recurring tasks, including all enabled jobs from <info>civicrm_job</info> table.
+
+<comment>Identity and Permissions:</comment>
+
+For purposes of logging and permissions, any cron invocation must be linked to a <info>Contact</info> record.
+
+By default, <info>cv cron</info> executes as the <comment>default domain contact</comment> with super-user permissions. You may override this with <info>--user=USER</info>.
+
+<comment>Console Output</comment>
+
+Traditional cron systems send an alert if a cronjob displays output. Therefore, the default output for <info>cv cron</info> is fairly quiet. The exact behavior may be tuned:
+
+* (CiviCRM v6.5+) By default, only display errors.
+* (CiviCRM v6.5+) Use <info>-q</info> (<info>--quiet</info>) to suppress all output (including errors).
+* (CiviCRM v6.5+) Use <info>-vv</info> to enable very verbose output (for monitoring, debugging).
+* (CiviCRM, before v6.5) Strictly quiet, with no options to adjust output.
+');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {


### PR DESCRIPTION
Overview
----------

This builds on #254 and expands the output of `cv cron` to be more useful to Linux/Unix admins.

Before
-------

* `cv cron` never prints any information

After
-----

* `cv cron` does not usually print information, but it will report errors.
* If you want total quiet, then use `cv cron -q`.
* If you want to inspect details about cron, then use `cv cron -vv`.
* Whenever there is output, it uses Symfony color coding (e.g. `<error>` messages typically appear in red). For example, this is verbose output with a mix of success+failure messages:

    <img width="1021" alt="Screenshot 2025-06-11 at 5 12 21 PM" src="https://github.com/user-attachments/assets/51ec3d3f-d75f-4a6f-81a8-29b81c1c6c54" />

Comments
-----------

`cv` can only present logs and errors if the underlying `JobManager` reports them. There are two relevant PRs to improve that on CiviCRM `6.5.alpha` (current `master`):

* https://github.com/civicrm/civicrm-core/pull/32966
* https://github.com/civicrm/civicrm-core/pull/32971

On older versions of CiviCRM, `cv cron` will still work. (But it doesn't provide debug data.)