### PR TITLE
Add in a require once to the deprecated notice function used in jooml…

### DIFF
--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -418,6 +418,7 @@ class CmsBootstrap {
       if (empty($user->id)) {
         throw new \Exception(sprintf("Fail to find Joomla user (%s)", $cmsUser));
       }
+      \Joomla\CMS\Factory::getApplication()->loadIdentity($user);
     }
     return $this;
   }
@@ -609,7 +610,7 @@ class CmsBootstrap {
         break;
 
       case 'Joomla':
-        $user = (!class_exists('JFactory') ? \Joomla\CMS\Factory::getUser() : \JFactory::getUser());
+        $user = (!class_exists('JFactory') ? \Joomla\CMS\Factory::getApplication()->getIdentity() : \JFactory::getUser());
         \CRM_Core_BAO_UFMatch::synchronize($user, TRUE, CIVICRM_UF, 'Individual');
         break;
 

--- a/lib/src/CmsBootstrap.php
+++ b/lib/src/CmsBootstrap.php
@@ -402,6 +402,7 @@ class CmsBootstrap {
     define('JPATH_BASE', $cmsRootPath . DS . 'administrator');
     require_once JPATH_BASE . '/includes/defines.php';
     require_once JPATH_BASE . '/includes/framework.php';
+    require_once JPATH_LIBRARIES . '/vendor/symfony/deprecation-contracts/function.php';
     $container = \Joomla\CMS\Factory::getContainer();
     $container->alias('session', 'session.cli')
       ->alias('JSession', 'session.cli')
@@ -409,6 +410,7 @@ class CmsBootstrap {
       ->alias(\Joomla\Session\Session::class, 'session.cli')
       ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
     $app = $container->get(\Joomla\CMS\Application\ConsoleApplication::class);
+    $app->createExtensionNamespaceMap();
     \Joomla\CMS\Factory::$application = $app;
     if ($cmsUser) {
       $userFactory = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class);

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -39,7 +39,13 @@ return [
   'exclude-files' => [
     'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php'
   ],
-
+  'exclude-constants' => [
+    'JPATH_BASE',
+    'JPATH_LIBRARIES',
+    'CIVICRM_SETTINGS_PATH',
+    'DS',
+    '_JEXEC',
+  ],
   // Do not generate wrappers/aliases for `civicrm_api()` etc or various CMS-booting functions.
   'expose-global-functions' => FALSE,
 ];


### PR DESCRIPTION
…a and ensure that joomla related constants are not namespaced in building the phar

@totten I found that I was hitting issues with an undefined function that is created in the deprecation contracts symfony package when running in joomla 5 and also found that some Defines were being namespaced by box

cc @webmaster-cses-org-uk 