### PR TITLE
CronCommand - Determine domain-contact based on active-domain

### DIFF
--- a/src/Command/CronCommand.php
+++ b/src/Command/CronCommand.php
@@ -55,7 +55,13 @@ Traditional cron systems send an alert if a cronjob displays output. Therefore, 
 
       };
 
-      $cid = \CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_domain ORDER BY id LIMIT 1');
+      $cid = NULL;
+      if ($domain = \CRM_Core_BAO_Domain::getDomain()) {
+        $cid = $domain->contact_id;
+      }
+      if (!$cid) {
+        $cid = \CRM_Core_DAO::singleValueQuery('SELECT contact_id FROM civicrm_domain ORDER BY id LIMIT 1');
+      }
       authx_login(['principal' => ['contactId' => $cid]]);
     }
 


### PR DESCRIPTION
In theory, this should work for multisite. The general idea is to say:

```bash
cv cron --url=https://subsite-3.example.com
cv cron --url=https://subsite-4.example.com
cv cron --url=https://subsite-5.example.com
```

(In turn, the `--url` mechanism works with site-aliases, e.g. if you've defined an alias for `subsite-3` then can say  `cv @subsite-3 cron`.)

I hedged my intro (_"In theory..."_) because there are many kinds of multisite, and each takes a bit of work to test, and I haven't tested any of them. However, in principle, this approach should work for each:

* __Multiple Hostnames, Multiple Databases, Multiple Settings Files__
    * Ex: This is the style used  in Drupal-multsite. (I believe @mlutfy is also experimentally using it with Standalone.)
    * For this, setting the `--url` should lead it to loading the appropriate settings file. (That's existing functionality for  all applicable `cv` commands.)
* __Multiple Hostnames, Single Databases, Single Settings File__
    * Ex: This is the style described in https://lab.civicrm.org/extensions/multisite.  (I haven't really used this.)
    * For this, the key thing is that the `civicrm.settings.php` should be customized to inspect the active URL and set `CIVICRM_DOMAIN_ID`, which then feeds into `CRM_Core_BAO_Domain::getDomain()`, which then feeds into here (`$domain->contact_id`).

There's some more discussion with @seamuslee001 and me in https://chat.civicrm.org/civicrm/pl/hpnht8o1nff6up5rzypohufs1c).

In any case, I'm optimistic, so I wanted to get the patch posted case someone else has a suitable environment for testing.