### PR TITLE
cv api4 - Add options to provide result-metadata (e.g. "count" and "countFetched")

### DIFF
--- a/tests/Command/Api4CommandTest.php
+++ b/tests/Command/Api4CommandTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Civi\Cv\Command;
+
+use Civi\Cv\Util\Process;
+
+/**
+ * @group std
+ */
+class Api4CommandTest extends \Civi\Cv\CivilTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  public function testDefaultData() {
+    $p = Process::runOk($this->cv("api4 Contact.get +s id,display_name +l 3@6"));
+    $rows = json_decode($p->getOutput(), 1);
+    $this->assertEquals(3, count($rows), 'Result should have the right number of records');
+    foreach ($rows as $row) {
+      $this->assertNotEmpty($row['id'], 'Each record should have id');
+      $this->assertNotEmpty($row['display_name'], 'Each record should have display_name');
+      $this->assertEquals(['id', 'display_name'], array_keys($row), 'No other properties should be returned');
+    }
+  }
+
+  public function testMetaProps() {
+    $p = Process::runOk($this->cv("api4 Contact.get +s id,display_name +l 3@6 -M"));
+    $result = json_decode($p->getOutput(), 1);
+    $this->assertEquals('Contact', $result['entity'], 'Result should have meta property: entity');
+    $this->assertEquals('get', $result['action'], 'Result should have meta property: action');
+    $this->assertEquals(3, $result['count'], 'Result should have meta property: count');
+    $this->assertEquals(3, count($result['values']), 'Result should have the right number of records');
+    foreach ($result['values'] as $row) {
+      $this->assertNotEmpty($row['id'], 'Each record should have id');
+      $this->assertNotEmpty($row['display_name'], 'Each record should have display_name');
+      $this->assertEquals(['id', 'display_name'], array_keys($row), 'No other properties should be returned');
+    }
+  }
+
+  public function testMetaPropsLimited() {
+    $p = Process::runOk($this->cv("api4 Contact.get +s id,display_name +l 3@6 -m entity,countFetched"));
+    $result = json_decode($p->getOutput(), 1);
+    $this->assertEquals('Contact', $result['entity'], 'Result should have meta property: entity');
+    $this->assertFalse(isset($result['action']));
+    $this->assertEquals(3, $result['countFetched'], 'Result should have meta property: countFetched');
+    $this->assertFalse(isset($result['values']));
+  }
+
+}


### PR DESCRIPTION
## Overview

`cv api4` generally presents the _result-data_ -- that is, the specific records and fields requested. However, APIv4's `$result` object also defines some _result-metadata_ -- such as the `count`, `countFetched`, `countMatched`.  The metadata is available to PHP and HTTP callers. This provides similar metadata for CLI callers.

## Before

By default, calls to `cv api4` present the _result-data_:

```bash
cv api4 Contact.get +s id,display_name +l 25@200
```
```javascript
[
    {
        "id": 201,
        "display_name": "Dr. Kandace Deforest"
    },
    {
        "id": 202,
        "display_name": "Jenny Lee"
    },
    {
        "id": 203,
        "display_name": "Standalone Admin"
    },
    {
        "id": 204,
        "display_name": "Demo User"
    }
]
```

## After

That call works the same, but (*optionally*) you can pass other options to expose metadata.

__Pass the big `-M`__ (`--enable-meta`) to return a deeper array with more _result-metadata_.

```bash
cv api4 Contact.get +s id,display_name +l 25@200 -M
```
```javascript
{
    "entity": "Contact",
    "action": "get",
    "version": 4,
    "values": [
        {
            "id": 201,
            "display_name": "Dr. Kandace Deforest"
        },
        {
            "id": 202,
            "display_name": "Jenny Lee"
        },
        {
            "id": 203,
            "display_name": "Standalone Admin"
        },
        {
            "id": 204,
            "display_name": "Demo User"
        }
    ],
    "count": 204,
    "countFetched": 4
}
```

__Pass the little `-m`__ (`--select-meta`) to select a specific piece of results-metadata.

```bash
cv api4 Contact.get +s id +l 25@200 -m count,countFetched 
```
```javascript
{
    "count": 204,
    "countFetched": 4
}
```

__Additionally__, APIv4 defines a magic field `row_count`. Practically speaking, this acts as an optimization flag -- when enabled, you fetch metadata (`count`, `countFetched`, etc) without fetching raw data (`values`). You can combine it with `-M` or `-m`.

```bash
cv api4 Contact.get +s row_count -M
```
```javascript
{
    "entity": "Contact",
    "action": "get",
    "version": 4,
    "values": [],
    "count": 204,
    "countFetched": 0
}
```



## Comments

Replaces #97

The interplay between `['select'=>'row_count']`, `count()`, `countFetched()`, and `countMatched()` feels... a bit rough to me. But it's a settled contract -- this PR is just trying to pass around that (meta)data.