### PR TITLE
SqlCommand - Add more --target options

### DIFF
--- a/src/Command/SqlCliCommand.php
+++ b/src/Command/SqlCliCommand.php
@@ -144,6 +144,18 @@ The ENV expressions are prefixed to indicate their escaping rule:
       case 'cms':
         $dsn = \CRM_Core_Config::singleton()->userFrameworkDSN;
         break;
+
+      case 'rw':
+      case 'master':
+        global $civirpow;
+        $dsn = $civirpow['masters'][0];
+        break;
+
+      case 'ro':
+      case 'slave':
+        global $civirpow;
+        $dsn = $civirpow['masters'][0];
+        break;
     }
 
     if (empty($dsn)) {


### PR DESCRIPTION
This should improve support for using `cv sql` on  `rpow` systems, e.g.

```php
## Open read only DB
cv sql -T ro

## Open read-write DB
cv sql -T rw
```

Untested patch. For @eileenmcnaughton 
