### PR TITLE
Check if trace is not empty before outputting

### DIFF
--- a/src/Command/ApiCommand.php
+++ b/src/Command/ApiCommand.php
@@ -68,7 +68,7 @@ TIP: To display a full backtrace of any errors, pass "-vv" (very verbose).
 
     $result = \civicrm_api($entity, $action, $params);
 
-    if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE && $result['trace']) {
+    if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE && !empty($result['trace'])) {
       $output->getErrorOutput()->writeln("<error>Error: " . (isset($result['error_message']) ? $result['error_message'] : "") . "</error>");
       $output->getErrorOutput()->writeln("  " . str_replace("\n", "\n  ", $result['trace']), OutputInterface::OUTPUT_RAW);
       $output->getErrorOutput()->write("\n");


### PR DESCRIPTION
e-notice fix @totten 