### PR TITLE
cv flush - Add more targetting options (--all, --include)

### DIFF
--- a/src/Command/FlushCommand.php
+++ b/src/Command/FlushCommand.php
@@ -13,11 +13,29 @@ class FlushCommand extends CvCommand {
     $this
       ->setName('flush')
       ->setAliases(array())
+      ->addOption('all', NULL, InputOption::VALUE_NONE, 'Flush all (v6.1+)')
+      ->addOption('include', 'I', InputOption::VALUE_OPTIONAL, 'Only flush specific targets (comma-separated) (v6.1+), e.g. --exclude=entities,userjobs (only available in CiviCRM 6.1 or newer)')
       ->addOption('triggers', 'T', InputOption::VALUE_NONE, 'Rebuild triggers')
-      ->addOption('exclude', 'E', InputOption::VALUE_OPTIONAL, 'Exclude specific components (comma-separated), e.g. --exclude=entities,userjobs (only available in CiviCRM 6.1 or newer)')
+      ->addOption('exclude', 'E', InputOption::VALUE_OPTIONAL, 'Exclude specific targets (comma-separated) (v6.1+), e.g. --exclude=entities,userjobs (only available in CiviCRM 6.1 or newer)')
       ->setDescription('Flush system caches')
       ->setHelp('
 Flush system caches
+
+Example: Flush most subsystems
+$ cv flush
+
+Example: Flush all subsystems (regardless of how slow/disruptive it might be) [v6.1+]
+$ cv flush --all
+
+Example: Flush ONLY the router and nav-menu [v6.9+]
+$ cv flush --include router,navigation
+
+Example: Flush everything EXCEPT managed-entities and form-states [v6.1+]
+$ cv flush --all --exclude entities,sessions
+
+If you need to precisely target with --include or --exclude, then you
+should lookup available targets by consulting documentation for Civi::rebuild()
+in your CiviCRM version.
 ');
   }
 
@@ -35,17 +53,34 @@ Flush system caches
 
     // the modern way (from core 6.1 on)
     if (is_callable(['Civi', 'rebuild'])) {
-      $default_params = ['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE];
+      if ($input->getOption('all')) {
+        $default_params = ['*' => TRUE];
+      }
+      elseif ($input->getOption('include')) {
+        $default_params = ['*' => FALSE];
+      }
+      else {
+        $default_params = ['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE];
+      }
+
+      // Interpret other CLI args to fine-tune $default_params.
       if ($input->getOption('triggers')) {
         $default_params['triggers'] = TRUE;
       }
+      if ($input->getOption('include')) {
+        $includes = explode(',', $input->getOption('include'));
+        foreach ($includes as $include) {
+          $default_params[$include] = TRUE;
+        }
+      }
       if ($input->getOption('exclude')) {
-        $exclude_param = $input->getOption('exclude');
-        $excludes = explode(',', $exclude_param);
+        $excludes = explode(',', $input->getOption('exclude'));
         foreach ($excludes as $exclude) {
           $default_params[$exclude] = FALSE;
         }
       }
+
+      // We know what must be done!
       if ($output->isVerbose()) {
         \Civi\Cv\Cv::io()->table(
           ['target', 'enabled'],


### PR DESCRIPTION
A description of the new options is included in the help screen. It lists these examples:

```bash
# Example: Flush most subsystems
$ cv flush

# Example: Flush all subsystems (regardless of how slow/disruptive it might be) [v6.1+]
$ cv flush --all

# Example: Flush ONLY the router and nav-menu [v6.9+]
$ cv flush --include router,navigation

# Example: Flush everything EXCEPT managed-entities and form-states [v6.1+]
$ cv flush --all --exclude entities,sessions
```
