### PR TITLE
cv dl - Work-around lab.c.o guard

### DIFF
--- a/src/Util/HeadlessDownloader.php
+++ b/src/Util/HeadlessDownloader.php
@@ -118,8 +118,13 @@ class HeadlessDownloader {
       \Civi\Cv\Application::version()
     ));
     curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
     fclose($fp);
+
+    if ($httpCode >= 400) {
+      throw new \Exception("Download failed: HTTP $httpCode");
+    }
   }
 
 }


### PR DESCRIPTION
## Overview

When using the `--bare` (or "headless") download option (as currently required for `--to`), the `lab.civicrm.org` response is not a well-formed zip file. Changing the `User-Agent` fixes it.

Also, when we receiving an HTTP error, we should try to report the error a bit better.

## Example

I run this:

```bash
cv dl -b "@https://civicrm.org/extdir/ver=6.3|cms=Drupal/firewall.xml" --to=/tmp/foo
```

and it fails with an exception:

```
Unable to extract the extension
```

## Analysis

The ZIP file was not actually sent. If you dig into the HTTP response, it said:

```
<html>
<head><title>429 Too Many Requests</title></head>
<body>
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

During the past year, `lab.c.o` has developed a bunch of heuristics to allow some bots but exclude other bots. So we're more likely to get errors.

The new `User-Agent` puts `cv dl --bare` back on the good side.

And this updates the error-display so that it's a little faster to recognize (i.e. the console will indicate the HTTP 429).