### PR TITLE
ang:html:list - Prevent failures from incomplete/non-renderable HTML files

### DIFF
--- a/src/Command/AngularHtmlListCommand.php
+++ b/src/Command/AngularHtmlListCommand.php
@@ -55,7 +55,7 @@ Examples:
     $rows = array();
 
     foreach ($ang->getModules() as $name => $module) {
-      $partials = $ang->getPartials($name);
+      $partials = $ang->getRawPartials($name);
       foreach ($partials as $file => $html) {
         $rows[] = array(
           'file' => preg_replace(';^~/;', '', $file),


### PR DESCRIPTION
## Scenario

* The extension `civicrm_admin_ui` includes replacements for random screens. For example, in CiviCRM 6.13, it has `afsearchTabPledge.aff.html`.
* `afsearchTabPledge.aff.html` relies on metadata from CiviPledge, but `civicrm_admin_ui` doesn't broadly depend on `civi_pledge`.
* If you try to inspect the effective markup for `afsearchTabPledge.aff.html`, it will crash (unless you manually enable `civi_pledge`)

The scenario is pretty useful from the perspective of `civicrm_admin_ui`.

## Before

In CiviCRM 6.13,  `cv ang:html:list` will try to enumerate files with `getPartials()`. This crashes because `afsearchTabPledge.aff.html` cannot be loaded if `Civi\Api4\Pledge::get` is unknown. 

## After

We don't actually need the final/effective markup.  We just want to know if markup exists.  So we switch from `getPartials()` to `getRawPartials()`.

In CiviCRM 6.13,  `cv ang:html:list` works better.