### PR TITLE
Login - Prefer `authx_login()` over `$userSystem->loadUser()`

### DIFF
--- a/lib/src/Util/BootTrait.php
+++ b/lib/src/Util/BootTrait.php
@@ -190,7 +190,18 @@ trait BootTrait {
     if ($input->getOption('user')) {
       $logger->debug('Set system user');
 
-      if (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
+      if (is_callable('authx_login')) {
+        authx_login([
+          'flow' => 'script',
+          'useSession' => FALSE,
+          'principal' => ['user' => $input->getOption('user')],
+        ]);
+        if (!$this->ensureUserContact($output)) {
+          throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
+        }
+      }
+      elseif (is_callable(array(\CRM_Core_Config::singleton()->userSystem, 'loadUser'))) {
+        $output->getErrorOutput()->writeln("<error>System does not support authx. Falling back to legacy implementation of loadUser().</error>");
         if (!\CRM_Core_Config::singleton()->userSystem->loadUser($input->getOption('user')) || !$this->ensureUserContact($output)) {
           throw new \Exception("Failed to determine contactID for user=" . $input->getOption('user'));
         }

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -31,6 +31,7 @@ return [
     'Joomla',
   ],
   'exclude-functions' => [
+    '/^authx_/',
     '/^civicrm_/',
     '/^wp_.*/',
     '/^(drupal|backdrop|user|module)_/',


### PR DESCRIPTION
Overview
--------------

This aims to fix a new warning that appears on Standalone after 6.12.1 introduced session-rotation (https://github.com/civicrm/civicrm-core/commit/0af9c03bd0e1153c40b96aaddb7d2f40c664f49d). The underlying fallacy is that `cv` does not really support sessions (so it doesn't make sense to do session-rotation). The login should be treated as stateless.

Before
----------

```
$ ~/src/cv/bin/cv scr -U admin tmp/hello.php  

[PHP Warning] session_regenerate_id(): Session ID cannot be regenerated when there is no active session at /home/totten/bknix/build/dev/web/core/ext/standaloneusers/Civi/Authx/Standalone.php:29
Hello 203!
```

After
----------

```
$ ~/src/cv/bin/cv scr -U admin tmp/hello.php  

Hello 203!
```

Technical Details
------------------------

1. In `authx_login()`, you can be explicit about whether you want sessions.

2. In `CRM_Utils_System_*::loadUser()`, the session handling is unclear and details vary by UF.