### PR TITLE
Don't assume the existence of CIVICRM_UF_DSN

### DIFF
--- a/lib/src/SiteConfigReader.php
+++ b/lib/src/SiteConfigReader.php
@@ -82,7 +82,7 @@ class SiteConfigReader {
     $paths = is_callable(array('Civi', 'paths')) ? \Civi::paths() : NULL;
     $log = \CRM_Core_Error::createDebugLogger();
     $data = array(
-      'CMS_DB_DSN' => CIVICRM_UF_DSN,
+      'CMS_DB_DSN' => defined('CIVICRM_UF_DSN') ? CIVICRM_UF_DSN : NULL,
       'CMS_VERSION' => \CRM_Core_Config::singleton()->userSystem->getVersion(),
       'CIVI_DB_DSN' => CIVICRM_DSN,
       'CIVI_SITE_KEY' => CIVICRM_SITE_KEY,


### PR DESCRIPTION
If your `civicrm.settings.php` doesn't have a `CIVICRM_UF_DSN`, `cv vars:show` returns a fatal error.

Since ideally a standalone Civi doesn't have a `CIVICRM_UF_DSN`, `cv` should support the non-existence of it.