### PR TITLE
[DRAFT] don't try to run extension upgrades when none exist

### DIFF
--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -275,6 +275,11 @@ Examples:
     $input = $this->input;
     $output = $this->output;
 
+    if (!\CRM_Extension_Upgrades::hasPending()) {
+      $output->writeln("<info>No pending extension upgrades.</info>", $this->niceVerbosity);
+      return 0;
+    }
+
     if ($isFirstTry) {
       $output->writeln("<info>Preparing extension upgrade...</info>", $this->niceVerbosity);
       \CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);


### PR DESCRIPTION
`cv` extension upgrades always clear cache first without first checking if there are pending upgrades to run.

Marking as draft because I wrote this a long time ago and only found it uncommitted just now, so I haven't tested it to see if the cache clear is actually necessary.  I'm guessing someone reviewing this will know that off the top of their head, in which case just close this.

Sorry for the drive-by PR, I just thought better submitted than deleted!