### PR TITLE
upgrade:db - Better reporting of pre-upgrade blockers

### DIFF
--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Cv\Command;
 
+use Civi\Cv\Cv;
 use Civi\Cv\Util\StructuredOutputTrait;
 use Civi\Cv\Util\ConsoleQueueRunner;
 use Symfony\Component\Console\Input\InputInterface;
@@ -179,11 +180,11 @@ Examples:
     if (is_callable([$upgrade, 'getUpgradeBlockers'])) {
       $htmlErrors = $upgrade->getUpgradeBlockers($dbVer, $codeVer);
       if ($htmlErrors) {
-        \Civi\Cv\Cv::io()->error("Upgrade is currently blocked!");
+        Cv::io()->error("Upgrade is currently blocked!");
         foreach ($htmlErrors as $error) {
-          \Civi\Cv\Cv::io()->write('<error>Blocker:</error> ');
-          \Civi\Cv\Cv::io()->writeln(html_entity_decode(strip_tags($error)), OutputInterface::OUTPUT_RAW);
-          \Civi\Cv\Cv::io()->writeln('');
+          Cv::io()->write('<error>Blocker:</error> ');
+          Cv::io()->writeln(html_entity_decode(strip_tags($error)), OutputInterface::OUTPUT_RAW);
+          Cv::io()->writeln('');
         }
         return 2;
       }
@@ -201,7 +202,7 @@ Examples:
       $upgrade->setPreUpgradeMessage($preUpgradeMessage, $dbVer, $codeVer);
       if ($preUpgradeMessage) {
         $output->writeln(\CRM_Utils_String::htmlToText($preUpgradeMessage), $this->niceVerbosity);
-        if (!\Civi\Cv\Cv::io()->confirm('Continue?')) {
+        if (!Cv::io()->confirm('Continue?')) {
           $output->writeln("<error>Abort</error>");
           return 2;
         }
@@ -239,7 +240,7 @@ Examples:
     }
 
     $output->writeln("<info>Executing upgrade...</info>", $this->niceVerbosity);
-    $runner = new ConsoleQueueRunner(\Civi\Cv\Cv::io(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
+    $runner = new ConsoleQueueRunner(Cv::io(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
     $runner->runAll();
 
     $output->writeln("<info>Finishing upgrade...</info>", $this->niceVerbosity);
@@ -317,7 +318,7 @@ Examples:
       }
     }
 
-    $runner = new ConsoleQueueRunner(\Civi\Cv\Cv::io(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
+    $runner = new ConsoleQueueRunner(Cv::io(), $queue, $input->getOption('dry-run'), $input->getOption('step'));
     $runner->runAll();
     return 0;
   }

--- a/src/Command/UpgradeDbCommand.php
+++ b/src/Command/UpgradeDbCommand.php
@@ -86,21 +86,27 @@ Examples:
       throw new \Exception("Cannot resume upgrade: The log file ($postUpgradeMessageFile) is missing. Consider a regular upgrade (without --retry or --skip).");
     }
 
-    $result = 0;
     $mode = $input->getOption('mode');
     if ($mode === 'auto') {
       $mode = (version_compare($dbVer, $codeVer, '<') ? 'full' : 'ext');
     }
 
     if ($mode === 'full') {
-      $result += $this->runCoreUpgrade($isFirstTry, $dbVer, $postUpgradeMessageFile, $codeVer);
-      $this->sendMessages($postUpgradeMessageFile, $codeVer);
+      $result = $this->runCoreUpgrade($isFirstTry, $dbVer, $postUpgradeMessageFile, $codeVer);
+      if ($result !== 2) {
+        $this->sendMessages($postUpgradeMessageFile, $codeVer);
+      }
     }
     elseif ($mode === 'ext') {
-      $result += $this->runExtensionUpgrade($isFirstTry);
+      $result = $this->runExtensionUpgrade($isFirstTry);
+    }
+    else {
+      $result = 0;
     }
 
-    $output->writeln("<info>Have a nice day.</info>");
+    if ($result === 0) {
+      $output->writeln("<info>Have a nice day.</info>");
+    }
     return $result;
   }
 
@@ -159,7 +165,7 @@ Examples:
    * @return int|null
    * @throws \CRM_Core_Exception
    */
-  protected function runCoreUpgrade(bool $isFirstTry, string $dbVer, string $postUpgradeMessageFile, string $codeVer): ?int {
+  protected function runCoreUpgrade(bool $isFirstTry, string $dbVer, string $postUpgradeMessageFile, string $codeVer): int {
     $input = $this->input;
     $output = $this->output;
 
@@ -169,8 +175,24 @@ Examples:
 
     $upgrade = new \CRM_Upgrade_Form();
 
-    if ($error = $upgrade->checkUpgradeableVersion($dbVer, $codeVer)) {
-      throw new \Exception($error);
+    // Check for blockers. (For v6.10+, use getUpgradeBlockers(). Older versions require `checkUpgradeableVersion()`.)
+    if (is_callable([$upgrade, 'getUpgradeBlockers'])) {
+      $htmlErrors = $upgrade->getUpgradeBlockers($dbVer, $codeVer);
+      if ($htmlErrors) {
+        \Civi\Cv\Cv::io()->error("Upgrade is currently blocked!");
+        foreach ($htmlErrors as $error) {
+          \Civi\Cv\Cv::io()->write('<error>Blocker:</error> ');
+          \Civi\Cv\Cv::io()->writeln(html_entity_decode(strip_tags($error)), OutputInterface::OUTPUT_RAW);
+          \Civi\Cv\Cv::io()->writeln('');
+        }
+        return 2;
+      }
+    }
+    else {
+      if ($error = $upgrade->checkUpgradeableVersion($dbVer, $codeVer)) {
+        // Weird output format -- only one error; with HTML entities but no HTML tags
+        throw new \Exception(html_entity_decode(strip_tags($error)));
+      }
     }
 
     if ($isFirstTry) {
@@ -181,7 +203,7 @@ Examples:
         $output->writeln(\CRM_Utils_String::htmlToText($preUpgradeMessage), $this->niceVerbosity);
         if (!\Civi\Cv\Cv::io()->confirm('Continue?')) {
           $output->writeln("<error>Abort</error>");
-          return 1;
+          return 2;
         }
       }
       else {


### PR DESCRIPTION
# Overview

When running an upgrade, there are a few pre-upgrade checks (such as PHP version, MySQL version, and various settings in PHP/MySQL). If any of these fail, the upgrade is not allowed to run.

This improves reporting of those errors.

# Before

<img width="1140" height="405" alt="Screenshot 2026-08-21 at 11 55 35 AM" src="https://github.com/user-attachments/assets/24ce9be2-3484-458d-bf0e-5dd6d95789ff" />

1. Only one error can be displayed. The choice is arbitrary.
2. The error may bleed-through some HTML entities.

# After

<img width="1020" height="200" alt="Screenshot 2026-08-21 at 12 18 06 PM" src="https://github.com/user-attachments/assets/9f137286-c334-4e6e-a8a1-e7795fa0b223" />

1. Multiple errors are presented.
2. The error appears as text (no HTML entities).